### PR TITLE
chore: remove redundant @testing-library/dom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.4",
     "@tailwindcss/postcss": "4.2.1",
-    "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.2",
     "@types/node": "25.3.3",
     "@types/react": "19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@tailwindcss/postcss':
         specifier: 4.2.1
         version: 4.2.1
-      '@testing-library/dom':
-        specifier: 10.4.1
-        version: 10.4.1
       '@testing-library/react':
         specifier: 16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary

- Remove `@testing-library/dom` from direct devDependencies — it's already a transitive dependency of `@testing-library/react`

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (17/17 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)