### PR TITLE
chore: update CI workflow and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,18 +23,29 @@ updates:
         update-types:
           - minor
           - patch
-      mantine:
+      next:
         patterns:
-          - '@mantine/*'
+          - 'next'
+          - '@next/*'
       react:
         patterns:
           - '@types/react'
           - '@types/react-dom'
           - 'react'
           - 'react-dom'
-      react-router:
+      tailwind:
         patterns:
-          - '@react-router/*'
+          - 'tailwindcss'
+          - '@tailwindcss/*'
+          - 'tw-animate-css'
+      shadcn:
+        patterns:
+          - 'shadcn'
+          - 'radix-ui'
+      biome:
+        patterns:
+          - '@biomejs/*'
+          - 'ultracite'
       vitest:
         patterns:
           - '@vitest/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,25 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: "25"
+          node-version: "24"
           cache: pnpm
+
+      - name: Cache Next.js build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -41,7 +50,7 @@ jobs:
         run: pnpm exec tsc --noEmit
 
       - name: Run tests
-        run: pnpm test -- --run
+        run: pnpm test -- --run --reporter=default --reporter=github-actions
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
## Summary

- Pin GitHub Actions (`checkout`, `action-setup`, `setup-node`, `cache`) to commit SHAs for supply-chain security
- Fix Node.js version from 25 to 24 to match project engine requirement
- Add Next.js build cache step to speed up CI builds
- Add `github-actions` test reporter for inline annotations on failures
- Align dependabot dependency groups with actual stack (next, tailwind, shadcn, biome) replacing outdated mantine/react-router groups

## Test plan

- [ ] CI workflow runs successfully with pinned actions
- [ ] Next.js build cache is populated and restored on subsequent runs
- [ ] Dependabot creates PRs with the correct dependency grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)