### PR TITLE
chore: add TODO.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ next-env.d.ts
 
 # claude code generated artifacts
 .claude/audit-*
+
+TODO.txt


### PR DESCRIPTION
## Summary

- Add `TODO.txt` to `.gitignore` to exclude local task notes from version control

## Test plan

- Verify `TODO.txt` is ignored by git after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)