### PR TITLE
chore: add security headers, sitemap, and cleanup unused code

### DIFF
--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import nextConfig from "./next.config";
+
+describe("next.config headers", () => {
+  const getGlobalHeaders = async () => {
+    const headerGroups = await nextConfig.headers?.();
+    const global = headerGroups?.find((g) => g.source === "/(.*)");
+    if (!global) {
+      throw new Error("Global headers group not found");
+    }
+    return global.headers;
+  };
+
+  const getHeaderValue = async (key: string) => {
+    const headers = await getGlobalHeaders();
+    return headers.find((h) => h.key === key)?.value;
+  };
+
+  it("sets X-Content-Type-Options to nosniff", async () => {
+    expect(await getHeaderValue("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("sets X-Frame-Options to DENY", async () => {
+    expect(await getHeaderValue("X-Frame-Options")).toBe("DENY");
+  });
+
+  it("sets Referrer-Policy", async () => {
+    expect(await getHeaderValue("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin"
+    );
+  });
+
+  it("sets Permissions-Policy to restrict sensitive APIs", async () => {
+    const value = await getHeaderValue("Permissions-Policy");
+    expect(value).toContain("camera=()");
+    expect(value).toContain("microphone=()");
+    expect(value).toContain("geolocation=()");
+  });
+
+  it("sets HSTS with includeSubDomains and preload", async () => {
+    const value = await getHeaderValue("Strict-Transport-Security");
+    expect(value).toContain("max-age=63072000");
+    expect(value).toContain("includeSubDomains");
+    expect(value).toContain("preload");
+  });
+
+  it("sets Content-Security-Policy with required directives", async () => {
+    const csp = await getHeaderValue("Content-Security-Policy");
+    expect(csp).toBeDefined();
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("worker-src 'self'");
+  });
+
+  it("does not include deprecated X-XSS-Protection header", async () => {
+    expect(await getHeaderValue("X-XSS-Protection")).toBeUndefined();
+  });
+
+  it("disables poweredByHeader", () => {
+    expect(nextConfig.poweredByHeader).toBe(false);
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,11 +9,24 @@ const nextConfig: NextConfig = {
       headers: [
         { key: "X-Content-Type-Options", value: "nosniff" },
         { key: "X-Frame-Options", value: "DENY" },
-        { key: "X-XSS-Protection", value: "1; mode=block" },
         { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
         {
           key: "Permissions-Policy",
           value: "camera=(), microphone=(), geolocation=()",
+        },
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload",
+        },
+        {
+          key: "Content-Security-Policy",
+          // 'unsafe-inline' is required in script-src and style-src because
+          // next-themes injects an inline script to prevent flash of incorrect
+          // theme on page load. Replacing it with a nonce-based CSP requires
+          // architectural changes (custom Document, middleware) and should be
+          // tackled as a separate task.
+          value:
+            "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com; worker-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
         },
       ],
     },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-Agent: *
 Allow: /
 
-Sitemap: https://themagiclab.com/sitemap.xml
+Sitemap: https://themagiclab.app/sitemap.xml

--- a/public/sw.js
+++ b/public/sw.js
@@ -27,5 +27,5 @@ self.addEventListener("push", (event) => {
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  event.waitUntil(clients.openWindow("https://themagiclab.app"));
+  event.waitUntil(clients.openWindow(self.location.origin));
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,7 +8,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,12 @@
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
   subsets: ["latin"],
 });
 
@@ -49,9 +44,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${geistSans.variable} antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <a
             className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:text-foreground focus:shadow-md"

--- a/src/app/manifest.test.ts
+++ b/src/app/manifest.test.ts
@@ -19,11 +19,12 @@ describe("manifest", () => {
   it("includes required icon sizes", () => {
     const icons = manifest().icons;
     expect(icons).toBeDefined();
-    expect(icons).toHaveLength(2);
+    expect(icons).toHaveLength(3);
     expect(icons).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ sizes: "192x192" }),
         expect.objectContaining({ sizes: "512x512" }),
+        expect.objectContaining({ sizes: "512x512", purpose: "maskable" }),
       ])
     );
   });

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -21,6 +21,12 @@ export default function manifest(): MetadataRoute.Manifest {
         sizes: "512x512",
         type: "image/png",
       },
+      {
+        src: "/icon-512x512.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "maskable",
+      },
     ],
   };
 }

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Home from "./page";
+
+vi.mock("next/image", () => ({
+  default: ({ alt, ...props }: { alt: string } & Record<string, unknown>) => (
+    <div aria-label={alt} role="presentation" {...props} />
+  ),
+}));
+
+vi.mock("@/components/theme-toggle", () => ({
+  ThemeToggle: () => <button type="button">Theme Toggle</button>,
+}));
+
+vi.mock("@/components/push-notifications-lazy", () => ({
+  PushNotificationsLazy: () => (
+    <div data-testid="push-notifications">Push Notifications</div>
+  ),
+}));
+
+const UNDER_DEVELOPMENT_RE = /under active development/;
+const VIEW_ON_GITHUB_RE = /View on GitHub/;
+
+describe("Home", () => {
+  it("renders the heading", () => {
+    render(<Home />);
+    expect(
+      screen.getByRole("heading", { name: "The Magic Lab" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the main landmark with correct id", () => {
+    render(<Home />);
+    const main = screen.getByRole("main");
+    expect(main).toHaveAttribute("id", "main-content");
+  });
+
+  it("renders the under development message", () => {
+    render(<Home />);
+    expect(screen.getByText(UNDER_DEVELOPMENT_RE)).toBeInTheDocument();
+  });
+
+  it("renders the GitHub link with correct attributes", () => {
+    render(<Home />);
+    const link = screen.getByRole("link", {
+      name: VIEW_ON_GITHUB_RE,
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/julienroussel/tml"
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders the theme toggle", () => {
+    render(<Home />);
+    expect(
+      screen.getByRole("button", { name: "Theme Toggle" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders push notifications component", () => {
+    render(<Home />);
+    expect(screen.getByTestId("push-notifications")).toBeInTheDocument();
+  });
+
+  it("renders both logo images", () => {
+    render(<Home />);
+    const images = screen.getAllByRole("presentation");
+    const logos = images.filter(
+      (img) =>
+        img.getAttribute("src") === "/logo-light.svg" ||
+        img.getAttribute("src") === "/logo-dark.svg"
+    );
+    expect(logos).toHaveLength(2);
+  });
+
+  it("marks light logo as hidden in dark mode", () => {
+    render(<Home />);
+    const lightLogo = screen
+      .getAllByRole("presentation")
+      .find((img) => img.getAttribute("src") === "/logo-light.svg");
+    expect(lightLogo).toBeDefined();
+    expect((lightLogo as HTMLElement).className).toContain("dark:hidden");
+  });
+});

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import sitemap from "./sitemap";
+
+describe("sitemap", () => {
+  it("returns an array with at least one entry", () => {
+    const result = sitemap();
+    expect(result).toBeDefined();
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses the correct production URL", () => {
+    const [entry] = sitemap();
+    expect(entry.url).toBe("https://themagiclab.app");
+  });
+
+  it("has a valid changeFrequency", () => {
+    const [entry] = sitemap();
+    expect(entry.changeFrequency).toBe("weekly");
+  });
+
+  it("has a valid priority", () => {
+    const [entry] = sitemap();
+    expect(entry.priority).toBe(1);
+  });
+
+  it("sets lastModified to a Date instance", () => {
+    const [entry] = sitemap();
+    expect(entry.lastModified).toBeInstanceOf(Date);
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://themagiclab.app",
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Add HSTS and Content-Security-Policy security headers; remove deprecated X-XSS-Protection
- Add sitemap route (`src/app/sitemap.ts`) and maskable icon entry to web app manifest
- Fix robots.txt sitemap URL (`themagiclab.com` → `themagiclab.app`) and use origin-relative URL in service worker
- Remove unused Geist Mono font import and CSS custom property
- Add tests for security headers, home page, and sitemap

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (112 tests, 0 failures)
- [ ] Verify security headers with browser DevTools on Vercel preview deployment
- [ ] Confirm sitemap is accessible at `/sitemap.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)