### PR TITLE
feat: redesign landing page with feature pillars

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 import { Geist } from "next/font/google";
+import type { ReactElement, ReactNode } from "react";
 import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
@@ -17,11 +18,22 @@ export const metadata: Metadata = {
     template: "%s | The Magic Lab",
   },
   description:
-    "The Magic Lab — exploring the intersection of technology and creativity.",
+    "A personal workspace for magicians to organize their repertoire, plan routines, track practice sessions, and refine performances.",
+  keywords: [
+    "magic",
+    "magician",
+    "practice",
+    "repertoire",
+    "routine",
+    "performance",
+    "training",
+  ],
   openGraph: {
     type: "website",
     locale: "en_US",
     siteName: "The Magic Lab",
+    description:
+      "A personal workspace for magicians to organize their repertoire, plan routines, track practice sessions, and refine performances.",
   },
   twitter: {
     card: "summary_large_image",
@@ -40,8 +52,8 @@ export const viewport: Viewport = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
-}>) {
+  children: ReactNode;
+}>): ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} antialiased`}>

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,10 +1,22 @@
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import Home from "./page";
 
 vi.mock("next/image", () => ({
   default: ({ alt, ...props }: { alt: string } & Record<string, unknown>) => (
-    <div aria-label={alt} role="presentation" {...props} />
+    // biome-ignore lint/performance/noImgElement: test mock for next/image
+    // biome-ignore lint/correctness/useImageSize: test mock — dimensions passed via props spread
+    <img alt={alt} {...props} />
+  ),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    ...props
+  }: { children: ReactNode } & Record<string, unknown>) => (
+    <a {...props}>{children}</a>
   ),
 }));
 
@@ -12,16 +24,9 @@ vi.mock("@/components/theme-toggle", () => ({
   ThemeToggle: () => <button type="button">Theme Toggle</button>,
 }));
 
-vi.mock("@/components/push-notifications-lazy", () => ({
-  PushNotificationsLazy: () => (
-    <div data-testid="push-notifications">Push Notifications</div>
-  ),
-}));
+const GITHUB_RE = /GitHub/;
 
-const UNDER_DEVELOPMENT_RE = /under active development/;
-const VIEW_ON_GITHUB_RE = /View on GitHub/;
-
-describe("Home", () => {
+describe("Home (landing page)", () => {
   it("renders the heading", () => {
     render(<Home />);
     expect(
@@ -35,16 +40,32 @@ describe("Home", () => {
     expect(main).toHaveAttribute("id", "main-content");
   });
 
-  it("renders the under development message", () => {
+  it("renders the tagline", () => {
     render(<Home />);
-    expect(screen.getByText(UNDER_DEVELOPMENT_RE)).toBeInTheDocument();
+    expect(
+      screen.getByText("Train. Plan. Perform. Elevate your magic.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Launch App CTA", () => {
+    render(<Home />);
+    const cta = screen.getByRole("link", { name: "Launch App" });
+    expect(cta).toHaveAttribute("href", "/dashboard");
+  });
+
+  it("renders feature pillar section with all 6 modules", () => {
+    render(<Home />);
+    expect(screen.getByText("Improve")).toBeInTheDocument();
+    expect(screen.getByText("Train")).toBeInTheDocument();
+    expect(screen.getByText("Plan")).toBeInTheDocument();
+    expect(screen.getByText("Perform")).toBeInTheDocument();
+    expect(screen.getByText("Enhance")).toBeInTheDocument();
+    expect(screen.getByText("Collect")).toBeInTheDocument();
   });
 
   it("renders the GitHub link with correct attributes", () => {
     render(<Home />);
-    const link = screen.getByRole("link", {
-      name: VIEW_ON_GITHUB_RE,
-    });
+    const link = screen.getByRole("link", { name: GITHUB_RE });
     expect(link).toHaveAttribute(
       "href",
       "https://github.com/julienroussel/tml"
@@ -60,11 +81,6 @@ describe("Home", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders push notifications component", () => {
-    render(<Home />);
-    expect(screen.getByTestId("push-notifications")).toBeInTheDocument();
-  });
-
   it("renders both logo images", () => {
     render(<Home />);
     const images = screen.getAllByRole("presentation");
@@ -74,14 +90,5 @@ describe("Home", () => {
         img.getAttribute("src") === "/logo-dark.svg"
     );
     expect(logos).toHaveLength(2);
-  });
-
-  it("marks light logo as hidden in dark mode", () => {
-    render(<Home />);
-    const lightLogo = screen
-      .getAllByRole("presentation")
-      .find((img) => img.getAttribute("src") === "/logo-light.svg");
-    expect(lightLogo).toBeDefined();
-    expect((lightLogo as HTMLElement).className).toContain("dark:hidden");
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,61 +1,105 @@
 import Image from "next/image";
-
-import { PushNotificationsLazy } from "@/components/push-notifications-lazy";
+import Link from "next/link";
+import type { ReactElement } from "react";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
+import { getMainModules } from "@/lib/modules";
 
-export default function Home() {
+export default function Home(): ReactElement {
+  const modules = getMainModules();
+
   return (
-    <div className="relative flex min-h-screen items-center justify-center px-6">
-      <div className="fixed top-4 right-4">
+    <div className="relative flex min-h-screen flex-col">
+      <div className="fixed top-4 right-4 z-10">
         <ThemeToggle />
       </div>
-      <main
-        className="flex flex-col items-center gap-8 text-center"
-        id="main-content"
-      >
-        <div className="flex flex-col items-center gap-3">
-          <h1 className="sr-only">The Magic Lab</h1>
-          <Image
-            alt=""
-            className="block dark:hidden"
-            height={100}
-            priority
-            src="/logo-light.svg"
-            width={300}
-          />
-          <Image
-            alt=""
-            className="hidden dark:block"
-            height={100}
-            priority
-            src="/logo-dark.svg"
-            width={300}
-          />
-        </div>
-        <p className="max-w-md text-lg text-muted-foreground leading-relaxed">
-          This project is under active development and will be available soon.
-        </p>
-        <Button asChild className="rounded-full" size="lg" variant="outline">
+
+      <main className="flex flex-1 flex-col" id="main-content">
+        {/* Hero */}
+        <section
+          aria-labelledby="hero-title"
+          className="flex flex-1 flex-col items-center justify-center gap-8 px-6 py-24 text-center"
+        >
+          <div className="flex flex-col items-center gap-3">
+            <h1 className="sr-only" id="hero-title">
+              The Magic Lab
+            </h1>
+            <Image
+              alt=""
+              className="block dark:hidden"
+              height={100}
+              priority
+              src="/logo-light.svg"
+              width={300}
+            />
+            <Image
+              alt=""
+              className="hidden dark:block"
+              height={100}
+              priority
+              src="/logo-dark.svg"
+              width={300}
+            />
+          </div>
+          <p className="max-w-lg text-muted-foreground text-xl leading-relaxed">
+            Train. Plan. Perform. Elevate your magic.
+          </p>
+          <p className="max-w-md text-muted-foreground leading-relaxed">
+            A personal workspace built for magicians — organize your repertoire,
+            plan routines, track practice sessions, and refine performances.
+          </p>
+          <Button asChild className="rounded-full" size="lg">
+            <Link href="/dashboard">Launch App</Link>
+          </Button>
+        </section>
+
+        {/* Feature Pillars */}
+        <section
+          aria-labelledby="features"
+          className="border-t bg-muted/30 px-6 py-24"
+        >
+          <div className="mx-auto max-w-5xl">
+            <h2
+              className="mb-12 text-center font-semibold text-2xl tracking-tight"
+              id="features"
+            >
+              Everything you need to level up
+            </h2>
+            <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+              {modules.map((mod) => {
+                const Icon = mod.icon;
+                return (
+                  <div className="flex flex-col gap-3" key={mod.slug}>
+                    <div className="flex size-12 items-center justify-center rounded-xl bg-muted">
+                      <Icon className="size-6 text-muted-foreground" />
+                    </div>
+                    <h3 className="font-semibold">{mod.label}</h3>
+                    <p className="text-muted-foreground text-sm leading-relaxed">
+                      {mod.description}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t px-6 py-8">
+        <div className="mx-auto flex max-w-5xl items-center justify-between text-muted-foreground text-sm">
+          <p>&copy; {new Date().getFullYear()} The Magic Lab</p>
           <a
+            className="transition-colors hover:text-foreground"
             href="https://github.com/julienroussel/tml"
             rel="noopener noreferrer"
             target="_blank"
           >
-            <svg
-              aria-hidden="true"
-              className="size-5"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z" />
-            </svg>
-            View on GitHub
+            GitHub
             <span className="sr-only"> (opens in a new tab)</span>
           </a>
-        </Button>
-        <PushNotificationsLazy />
-      </main>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/src/lib/modules.test.ts
+++ b/src/lib/modules.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { ModuleSlug } from "./modules";
+import {
+  APP_MODULES,
+  getAdminModules,
+  getMainModules,
+  getModule,
+} from "./modules";
+
+describe("modules registry", () => {
+  it("contains all expected slugs", () => {
+    const slugs = APP_MODULES.map((m) => m.slug);
+    expect(slugs).toContain("improve");
+    expect(slugs).toContain("train");
+    expect(slugs).toContain("plan");
+    expect(slugs).toContain("perform");
+    expect(slugs).toContain("enhance");
+    expect(slugs).toContain("collect");
+    expect(slugs).toContain("admin");
+    expect(slugs).toHaveLength(7);
+  });
+
+  it("main + admin modules equal total", () => {
+    expect(getMainModules().length + getAdminModules().length).toBe(
+      APP_MODULES.length
+    );
+  });
+
+  it("every module has required fields", () => {
+    for (const mod of APP_MODULES) {
+      expect(mod.slug).toBeTruthy();
+      expect(mod.label).toBeTruthy();
+      expect(mod.description).toBeTruthy();
+      expect(mod.icon).toBeDefined();
+      expect(typeof mod.enabled).toBe("boolean");
+      expect(["main", "admin"]).toContain(mod.group);
+    }
+  });
+});
+
+describe("getModule", () => {
+  it("returns the correct module by slug", () => {
+    const mod = getModule("improve");
+    expect(mod.slug).toBe("improve");
+    expect(mod.label).toBe("Improve");
+  });
+
+  it("throws for an invalid slug", () => {
+    expect(() => getModule("nonexistent" as ModuleSlug)).toThrow(
+      "Module not found: nonexistent"
+    );
+  });
+});
+
+describe("getMainModules", () => {
+  it("returns only main modules", () => {
+    const mods = getMainModules();
+    expect(mods.length).toBeGreaterThan(0);
+    for (const mod of mods) {
+      expect(mod.group).toBe("main");
+    }
+  });
+});
+
+describe("getAdminModules", () => {
+  it("returns only admin modules", () => {
+    const mods = getAdminModules();
+    expect(mods.length).toBeGreaterThan(0);
+    for (const mod of mods) {
+      expect(mod.group).toBe("admin");
+    }
+  });
+});

--- a/src/lib/modules.ts
+++ b/src/lib/modules.ts
@@ -1,0 +1,117 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  BookOpen,
+  Dumbbell,
+  ListChecks,
+  Package,
+  Settings,
+  Sparkles,
+  Star,
+} from "lucide-react";
+
+type ModuleGroup = "admin" | "main";
+
+interface AppModuleBase {
+  description: string;
+  enabled: boolean;
+  group: ModuleGroup;
+  icon: LucideIcon;
+  label: string;
+  slug: string;
+}
+
+const APP_MODULES = [
+  {
+    slug: "improve",
+    label: "Improve",
+    description: "Track practice sessions and refine your skills over time.",
+    icon: Dumbbell,
+    enabled: false,
+    group: "main",
+  },
+  {
+    slug: "train",
+    label: "Train",
+    description: "Set goals, run drills, and build muscle memory.",
+    icon: ListChecks,
+    enabled: false,
+    group: "main",
+  },
+  {
+    slug: "plan",
+    label: "Plan",
+    description: "Design sets, routines, and show running orders.",
+    icon: BookOpen,
+    enabled: false,
+    group: "main",
+  },
+  {
+    slug: "perform",
+    label: "Perform",
+    description: "Log performances, track venues, and review feedback.",
+    icon: Star,
+    enabled: false,
+    group: "main",
+  },
+  {
+    slug: "enhance",
+    label: "Enhance",
+    description: "Discover insights and suggestions to elevate your magic.",
+    icon: Sparkles,
+    enabled: false,
+    group: "main",
+  },
+  {
+    slug: "collect",
+    label: "Collect",
+    description: "Manage your inventory of props, books, gimmicks, and more.",
+    icon: Package,
+    enabled: false,
+    group: "main",
+  },
+  {
+    slug: "admin",
+    label: "Admin",
+    description: "Application settings and administration.",
+    icon: Settings,
+    enabled: false,
+    group: "admin",
+  },
+] as const satisfies readonly AppModuleBase[];
+
+type ModuleSlug = (typeof APP_MODULES)[number]["slug"];
+
+type AppModuleEntry = (typeof APP_MODULES)[number];
+
+function getModule<S extends ModuleSlug>(
+  slug: S
+): Extract<AppModuleEntry, { slug: S }> {
+  const mod = APP_MODULES.find(
+    (m): m is Extract<AppModuleEntry, { slug: S }> => m.slug === slug
+  );
+  if (!mod) {
+    throw new Error(`Module not found: ${slug}`);
+  }
+  return mod;
+}
+
+function getMainModules(): readonly Extract<
+  AppModuleEntry,
+  { group: "main" }
+>[] {
+  return APP_MODULES.filter(
+    (m): m is Extract<AppModuleEntry, { group: "main" }> => m.group === "main"
+  );
+}
+
+function getAdminModules(): readonly Extract<
+  AppModuleEntry,
+  { group: "admin" }
+>[] {
+  return APP_MODULES.filter(
+    (m): m is Extract<AppModuleEntry, { group: "admin" }> => m.group === "admin"
+  );
+}
+
+export { APP_MODULES, getAdminModules, getMainModules, getModule };
+export type { AppModuleEntry, ModuleGroup, ModuleSlug };


### PR DESCRIPTION
## Summary
- Extract module definitions into `src/lib/modules.ts` for reuse across landing and app
- Redesign landing page with hero section, tagline, feature pillar grid, and footer
- Update metadata with keywords and OpenGraph description
- Update landing page and module tests

## Test plan
- [x] `pnpm test:run` — all landing page and module tests pass
- [x] `pnpm build` — production build succeeds
- [x] Visual check of landing page at `/`

## Split context
This is PR 3 of 4 from an automated split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>