### PR TITLE
feat: add MemDeck companion project link to footer

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,15 +89,26 @@ export default function Home(): ReactElement {
       <footer className="border-t px-6 py-8">
         <div className="mx-auto flex max-w-5xl items-center justify-between text-muted-foreground text-sm">
           <p>&copy; {new Date().getFullYear()} The Magic Lab</p>
-          <a
-            className="transition-colors hover:text-foreground"
-            href="https://github.com/julienroussel/tml"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            GitHub
-            <span className="sr-only"> (opens in a new tab)</span>
-          </a>
+          <nav aria-label="Footer links" className="flex gap-4">
+            <a
+              className="transition-colors hover:text-foreground"
+              href="https://memdeck.org"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              MemDeck
+              <span className="sr-only"> (opens in a new tab)</span>
+            </a>
+            <a
+              className="transition-colors hover:text-foreground"
+              href="https://github.com/julienroussel/tml"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              GitHub
+              <span className="sr-only"> (opens in a new tab)</span>
+            </a>
+          </nav>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- Add a link to [memdeck.org](https://memdeck.org) in the landing page footer as a companion project reference
- Wrap footer links in a semantic `<nav>` element with `aria-label="Footer links"` for accessibility
- Maintain existing GitHub link alongside the new MemDeck link

## Test plan
- [ ] Verify MemDeck link appears in the footer and opens in a new tab
- [ ] Verify GitHub link still works correctly
- [ ] Verify screen readers announce the footer navigation landmark
- [ ] Check dark mode and light mode styling


🤖 Generated with [Claude Code](https://claude.com/claude-code)