### PR TITLE
chore: update dependabot schedule from 04:00 to 03:00

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
-      time: '04:00'
+      time: '03:00'
       timezone: 'Europe/Paris'
     labels:
       - 'dependencies'


### PR DESCRIPTION
## Summary

- Update Dependabot weekly check time from 04:00 to 03:00 (Europe/Paris)

## Test plan

- [x] Verify YAML syntax is valid
- No functional tests needed — configuration-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)