### PR TITLE
chore(ci): bump pnpm/action-setup to v4.4.0 in e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: echo "value=$(openssl rand -base64 32)" >> "$GITHUB_OUTPUT"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
## Summary
- Bump `pnpm/action-setup` from v4.3.0 to v4.4.0 in the E2E Smoke Tests job to resolve the Node.js 20 deprecation warning.
- Aligns with the v4.4.0 version already used in the main CI job.

## Test plan
- [ ] CI passes — the E2E job installs pnpm successfully with the updated action.
- [ ] No more Node.js 20 deprecation warning in the workflow logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)