### PR TITLE
feat: persist push subscriptions to database

### DIFF
--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -28,6 +28,28 @@ vi.mock("@/auth/server", () => ({
   },
 }));
 
+const mockReturning = vi.fn().mockResolvedValue([{ id: "test-uuid" }]);
+const mockOnConflictDoUpdate = vi.fn(() => ({ returning: mockReturning }));
+const mockInsertValues = vi.fn(() => ({
+  onConflictDoUpdate: mockOnConflictDoUpdate,
+}));
+const mockInsert = vi.fn(() => ({ values: mockInsertValues }));
+
+const mockSelectWhere = vi.fn().mockResolvedValue([]);
+const mockSelectFrom = vi.fn(() => ({ where: mockSelectWhere }));
+const mockSelect = vi.fn(() => ({ from: mockSelectFrom }));
+
+const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
+
+vi.mock("@/db", () => ({
+  getDb: () => ({
+    insert: mockInsert,
+    select: mockSelect,
+    delete: mockDelete,
+  }),
+}));
+
 // p256dh: 88 chars base64url (65 bytes), auth: 22 chars base64url (16 bytes)
 const validSubscription: PushSubscriptionInput = {
   endpoint: "https://fcm.googleapis.com/push/abc",
@@ -36,6 +58,12 @@ const validSubscription: PushSubscriptionInput = {
       "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8p8REfWLkA",
     auth: "tBHItJI5svbpC7-M3xJrOw",
   },
+};
+
+const validSubscriptionRow = {
+  endpoint: validSubscription.endpoint,
+  p256dh: validSubscription.keys.p256dh,
+  authKey: validSubscription.keys.auth,
 };
 
 function stubVapidEnv(): void {
@@ -53,6 +81,7 @@ async function setupSubscribedUser(): Promise<{
   const webpush = (await import("web-push")).default;
   const actions = await import("./actions");
   await actions.subscribeUser(validSubscription);
+  mockSelectWhere.mockResolvedValue([validSubscriptionRow]);
   return { webpush, ...actions };
 }
 
@@ -61,6 +90,8 @@ describe("server actions", () => {
     vi.clearAllMocks();
     vi.resetModules();
     vi.unstubAllEnvs();
+    mockReturning.mockResolvedValue([{ id: "test-uuid" }]);
+    mockSelectWhere.mockResolvedValue([]);
   });
 
   describe("unauthenticated user rejection", () => {
@@ -78,7 +109,7 @@ describe("server actions", () => {
       vi.mocked(auth.getSession).mockResolvedValueOnce(unauthenticatedSession);
 
       const { unsubscribeUser } = await import("./actions");
-      const result = await unsubscribeUser();
+      const result = await unsubscribeUser("https://example.com");
       expect(result).toEqual({ success: false, error: "Not authenticated" });
     });
 
@@ -97,6 +128,43 @@ describe("server actions", () => {
       const { subscribeUser } = await import("./actions");
       const result = await subscribeUser(validSubscription);
       expect(result).toEqual({ success: true });
+      expect(mockInsert).toHaveBeenCalled();
+      expect(mockInsertValues).toHaveBeenCalledWith({
+        userId: "test-user",
+        endpoint: validSubscription.endpoint,
+        p256dh: validSubscription.keys.p256dh,
+        authKey: validSubscription.keys.auth,
+      });
+      expect(mockOnConflictDoUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.anything(),
+          set: expect.objectContaining({
+            p256dh: validSubscription.keys.p256dh,
+            authKey: validSubscription.keys.auth,
+          }),
+          where: expect.anything(),
+        })
+      );
+    });
+
+    it("returns error when database insert fails", async () => {
+      mockReturning.mockRejectedValueOnce(new Error("DB error"));
+      const { subscribeUser } = await import("./actions");
+      const result = await subscribeUser(validSubscription);
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to save subscription",
+      });
+    });
+
+    it("returns error when endpoint is owned by another user", async () => {
+      mockReturning.mockResolvedValueOnce([]);
+      const { subscribeUser } = await import("./actions");
+      const result = await subscribeUser(validSubscription);
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to save subscription",
+      });
     });
 
     it("returns error on missing endpoint", async () => {
@@ -197,16 +265,18 @@ describe("server actions", () => {
   });
 
   describe("unsubscribeUser", () => {
-    it("clears the subscription so sendNotification fails", async () => {
+    it("deletes the subscription from the database", async () => {
       const { subscribeUser, unsubscribeUser, sendNotification } = await import(
         "./actions"
       );
-      const subResult = await subscribeUser(validSubscription);
-      expect(subResult).toEqual({ success: true });
+      await subscribeUser(validSubscription);
 
-      const result = await unsubscribeUser();
+      const result = await unsubscribeUser(validSubscription.endpoint);
       expect(result).toEqual({ success: true });
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+      expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
 
+      // Select returns empty after unsubscribe (default mock)
       const sendResult = await sendNotification("Hello");
       expect(sendResult).toEqual({
         success: false,
@@ -214,10 +284,39 @@ describe("server actions", () => {
       });
     });
 
+    it("returns error on empty endpoint", async () => {
+      const { unsubscribeUser } = await import("./actions");
+      const result = await unsubscribeUser("");
+      expect(result).toEqual({ success: false, error: "Invalid endpoint" });
+    });
+
+    it("returns error on non-https endpoint", async () => {
+      const { unsubscribeUser } = await import("./actions");
+      const result = await unsubscribeUser("http://example.com/push");
+      expect(result).toEqual({ success: false, error: "Invalid endpoint" });
+    });
+
+    it("returns error on endpoint exceeding length limit", async () => {
+      const { unsubscribeUser } = await import("./actions");
+      const longEndpoint = `https://fcm.googleapis.com/${"a".repeat(2048)}`;
+      const result = await unsubscribeUser(longEndpoint);
+      expect(result).toEqual({ success: false, error: "Invalid endpoint" });
+    });
+
     it("succeeds even without a prior subscription", async () => {
       const { unsubscribeUser } = await import("./actions");
-      const result = await unsubscribeUser();
+      const result = await unsubscribeUser("https://example.com/nonexistent");
       expect(result).toEqual({ success: true });
+    });
+
+    it("returns error when database delete fails", async () => {
+      mockDeleteWhere.mockRejectedValueOnce(new Error("DB error"));
+      const { unsubscribeUser } = await import("./actions");
+      const result = await unsubscribeUser(validSubscription.endpoint);
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to remove subscription",
+      });
     });
   });
 
@@ -272,6 +371,17 @@ describe("server actions", () => {
       });
     });
 
+    it("returns error when database select fails", async () => {
+      stubVapidEnv();
+      mockSelectWhere.mockRejectedValueOnce(new Error("DB error"));
+      const { sendNotification } = await import("./actions");
+      const result = await sendNotification("Hello");
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to send notification",
+      });
+    });
+
     it("sends notification after subscribing", async () => {
       const { webpush, sendNotification } = await setupSubscribedUser();
 
@@ -284,13 +394,121 @@ describe("server actions", () => {
         "test-private-key"
       );
       expect(webpush.sendNotification).toHaveBeenCalledWith(
-        validSubscription,
+        {
+          endpoint: validSubscription.endpoint,
+          keys: {
+            p256dh: validSubscription.keys.p256dh,
+            auth: validSubscription.keys.auth,
+          },
+        },
         JSON.stringify({
           title: "The Magic Lab",
           body: "Hello world",
           icon: "/icon-192x192.png",
         })
       );
+    });
+
+    it("sends to multiple subscriptions", async () => {
+      stubVapidEnv();
+      const secondSub = {
+        endpoint: "https://fcm.googleapis.com/push/def",
+        p256dh: "second-p256dh",
+        authKey: "second-auth",
+      };
+      mockSelectWhere.mockResolvedValue([validSubscriptionRow, secondSub]);
+
+      const webpush = (await import("web-push")).default;
+      const { sendNotification } = await import("./actions");
+
+      const result = await sendNotification("Hello all devices");
+      expect(result).toEqual({ success: true });
+      expect(webpush.sendNotification).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns success when at least one device succeeds", async () => {
+      stubVapidEnv();
+      const secondSub = {
+        endpoint: "https://fcm.googleapis.com/push/def",
+        p256dh: "second-p256dh",
+        authKey: "second-auth",
+      };
+      mockSelectWhere.mockResolvedValue([validSubscriptionRow, secondSub]);
+
+      const webpush = (await import("web-push")).default;
+      const { sendNotification } = await import("./actions");
+
+      const goneError = Object.assign(new Error("Gone"), { statusCode: 410 });
+      vi.mocked(webpush.sendNotification)
+        .mockResolvedValueOnce({} as never)
+        .mockRejectedValueOnce(goneError);
+
+      const result = await sendNotification("Partial");
+      expect(result).toEqual({ success: true });
+      // 410 endpoint should be cleaned up — exactly one delete with a WHERE clause
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+      expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns success even when 410 cleanup fails", async () => {
+      stubVapidEnv();
+      const secondSub = {
+        endpoint: "https://fcm.googleapis.com/push/def",
+        p256dh: "second-p256dh",
+        authKey: "second-auth",
+      };
+      mockSelectWhere.mockResolvedValue([validSubscriptionRow, secondSub]);
+
+      const webpush = (await import("web-push")).default;
+      const { sendNotification } = await import("./actions");
+
+      const goneError = Object.assign(new Error("Gone"), { statusCode: 410 });
+      vi.mocked(webpush.sendNotification)
+        .mockResolvedValueOnce({} as never)
+        .mockRejectedValueOnce(goneError);
+
+      // Set up DB cleanup failure. This must be placed before sendNotification
+      // because the 410 handler triggers the delete during that call.
+      mockDeleteWhere.mockRejectedValueOnce(new Error("DB cleanup failed"));
+
+      const consoleError = vi
+        .spyOn(console, "error")
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: suppress console.error output during test
+        .mockImplementation(() => {});
+
+      const result = await sendNotification("Hello");
+      expect(result).toEqual({ success: true });
+      expect(consoleError).toHaveBeenCalledWith(
+        "Failed to clean up stale subscriptions:",
+        expect.any(Error)
+      );
+      consoleError.mockRestore();
+    });
+
+    it("returns error when all deliveries fail with non-410 errors", async () => {
+      stubVapidEnv();
+      const secondSub = {
+        endpoint: "https://fcm.googleapis.com/push/def",
+        p256dh: "second-p256dh",
+        authKey: "second-auth",
+      };
+      mockSelectWhere.mockResolvedValue([validSubscriptionRow, secondSub]);
+
+      const webpush = (await import("web-push")).default;
+      const { sendNotification } = await import("./actions");
+
+      const serverError = new Error("Internal Server Error");
+      vi.mocked(webpush.sendNotification)
+        .mockRejectedValueOnce(serverError)
+        .mockRejectedValueOnce(serverError);
+
+      const result = await sendNotification("Hello");
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to send notification",
+      });
+      // Non-410 errors should NOT trigger cleanup
+      expect(mockDelete).not.toHaveBeenCalled();
     });
 
     it("returns error when webpush.sendNotification fails", async () => {
@@ -318,6 +536,7 @@ describe("server actions", () => {
       vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
       try {
         stubVapidEnv();
+        mockSelectWhere.mockResolvedValue([validSubscriptionRow]);
 
         const { subscribeUser, sendNotification } = await import("./actions");
         await subscribeUser(validSubscription);
@@ -342,6 +561,7 @@ describe("server actions", () => {
       vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
       try {
         stubVapidEnv();
+        mockSelectWhere.mockResolvedValue([validSubscriptionRow]);
 
         const { subscribeUser, sendNotification } = await import("./actions");
         await subscribeUser(validSubscription);
@@ -367,6 +587,7 @@ describe("server actions", () => {
       vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
       try {
         stubVapidEnv();
+        mockSelectWhere.mockResolvedValue([validSubscriptionRow]);
 
         const { subscribeUser, sendNotification } = await import("./actions");
         await subscribeUser(validSubscription);
@@ -464,8 +685,12 @@ describe("server actions", () => {
         error: "Failed to send notification",
       });
 
+      // Verify the 410 handler cleaned up the subscription via DB delete
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+
       // Subsequent send should fail with "No subscription available" since
-      // the 410 handler removed the subscription.
+      // the DB now returns empty.
+      mockSelectWhere.mockResolvedValue([]);
       const retryResult = await sendNotification("Retry");
       expect(retryResult).toEqual({
         success: false,
@@ -487,8 +712,10 @@ describe("server actions", () => {
         error: "Failed to send notification",
       });
 
-      // Subscription should still exist — next send should not fail with
-      // "No subscription available".
+      // Delete should NOT have been called for non-410 errors
+      expect(mockDelete).not.toHaveBeenCalled();
+
+      // Subscription should still exist — next send should succeed
       vi.mocked(webpush.sendNotification).mockResolvedValueOnce({} as never);
       const retryResult = await sendNotification("Retry");
       expect(retryResult).toEqual({ success: true });
@@ -508,10 +735,39 @@ describe("server actions", () => {
     it("returns error when VAPID keys are not configured", async () => {
       vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", "");
       vi.stubEnv("VAPID_PRIVATE_KEY", "");
+      mockSelectWhere.mockResolvedValue([validSubscriptionRow]);
 
       const { subscribeUser, sendNotification } = await import("./actions");
       await subscribeUser(validSubscription);
 
+      const result = await sendNotification("Hello");
+      expect(result).toEqual({
+        success: false,
+        error: "Notification service unavailable",
+      });
+    });
+
+    it("returns error when only public VAPID key is configured", async () => {
+      vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", "test-public-key");
+      vi.stubEnv("VAPID_PRIVATE_KEY", "");
+      mockSelectWhere.mockResolvedValue([validSubscriptionRow]);
+
+      const { subscribeUser, sendNotification } = await import("./actions");
+      await subscribeUser(validSubscription);
+      const result = await sendNotification("Hello");
+      expect(result).toEqual({
+        success: false,
+        error: "Notification service unavailable",
+      });
+    });
+
+    it("returns error when only private VAPID key is configured", async () => {
+      vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", "");
+      vi.stubEnv("VAPID_PRIVATE_KEY", "test-private-key");
+      mockSelectWhere.mockResolvedValue([validSubscriptionRow]);
+
+      const { subscribeUser, sendNotification } = await import("./actions");
+      await subscribeUser(validSubscription);
       const result = await sendNotification("Hello");
       expect(result).toEqual({
         success: false,

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,8 +1,11 @@
 "use server";
 
 import "server-only";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import webpush from "web-push";
 import { auth } from "@/auth/server";
+import { getDb } from "@/db";
+import { pushSubscriptions } from "@/db/schema/push-subscriptions";
 
 export type ActionResult =
   | { success: true }
@@ -65,14 +68,6 @@ function ensureVapidInitialized(): void {
   vapidReady = true;
 }
 
-// WARNING: Per-user in-memory subscription map. Prevents cross-user leaks
-// within the same instance, but subscriptions are lost on every Vercel
-// serverless cold start — each invocation may land on a different isolate.
-// TODO(critical): Migrate to the `push_subscriptions` database table
-// (src/db/schema/push-subscriptions.ts) before enabling push in production.
-// Without this, subscriptions are effectively useless in a serverless env.
-const subscriptionsByUser = new Map<string, PushSubscriptionInput>();
-
 // NOTE: In-memory rate limiting resets on serverless cold starts. For production
 // hardening, replace with Redis/Upstash-based rate limiting. This provides
 // basic protection against rapid repeated submissions within a single instance.
@@ -113,13 +108,18 @@ export async function subscribeUser(
   if (!sub?.endpoint || typeof sub.endpoint !== "string") {
     return { success: false, error: "Invalid subscription" };
   }
-  if (!sub.endpoint.startsWith("https://")) {
+  if (!sub.endpoint.startsWith("https://") || sub.endpoint.length > 2048) {
     return { success: false, error: "Invalid endpoint URL" };
   }
 
   try {
     const endpointUrl = new URL(sub.endpoint);
     const hostname = endpointUrl.hostname.toLowerCase();
+    // Suffix entries start with a leading dot (e.g. ".push.apple.com"), so
+    // `endsWith` already guarantees a label-boundary match — "evilpush.apple.com"
+    // will NOT match ".push.apple.com". Deeply nested subdomains like
+    // "a.b.push.apple.com" still match, but those are controlled by the
+    // respective push-service operators (Apple, Microsoft), not by end users.
     const isAllowed =
       ALLOWED_PUSH_HOSTS.includes(hostname) ||
       ALLOWED_PUSH_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
@@ -141,18 +141,157 @@ export async function subscribeUser(
   ) {
     return { success: false, error: "Invalid subscription keys" };
   }
-  subscriptionsByUser.set(session.user.id, sub);
+  try {
+    const db = getDb();
+    const result = await db
+      .insert(pushSubscriptions)
+      .values({
+        userId: session.user.id,
+        endpoint: sub.endpoint,
+        p256dh: sub.keys.p256dh,
+        authKey: sub.keys.auth,
+      })
+      .onConflictDoUpdate({
+        target: pushSubscriptions.endpoint,
+        set: {
+          p256dh: sub.keys.p256dh,
+          authKey: sub.keys.auth,
+          lastUsedAt: sql`NOW()`,
+        },
+        where: eq(pushSubscriptions.userId, session.user.id),
+      })
+      .returning({ id: pushSubscriptions.id });
+
+    if (result.length === 0) {
+      return { success: false, error: "Failed to save subscription" };
+    }
+  } catch (error: unknown) {
+    console.error("Failed to save push subscription:", {
+      userId: session.user.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { success: false, error: "Failed to save subscription" };
+  }
+
   return { success: true };
 }
 
-export async function unsubscribeUser(): Promise<ActionResult> {
+export async function unsubscribeUser(endpoint: string): Promise<ActionResult> {
   const { data: session } = await auth.getSession();
   if (!session?.user) {
     return { success: false, error: "Not authenticated" };
   }
 
-  subscriptionsByUser.delete(session.user.id);
+  if (!endpoint?.startsWith("https://") || endpoint.length > 2048) {
+    return { success: false, error: "Invalid endpoint" };
+  }
+
+  try {
+    const db = getDb();
+    await db
+      .delete(pushSubscriptions)
+      .where(
+        and(
+          eq(pushSubscriptions.userId, session.user.id),
+          eq(pushSubscriptions.endpoint, endpoint)
+        )
+      );
+  } catch (error: unknown) {
+    console.error("Failed to remove push subscription:", {
+      userId: session.user.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { success: false, error: "Failed to remove subscription" };
+  }
+
   return { success: true };
+}
+
+function checkRateLimit(userId: string): boolean {
+  const now = Date.now();
+  let rateLimit = rateLimitsByUser.get(userId);
+  if (rateLimit && now > rateLimit.reset) {
+    rateLimit = undefined;
+  }
+  if (!rateLimit) {
+    rateLimit = { count: 0, reset: now + RATE_LIMIT_WINDOW };
+    rateLimitsByUser.set(userId, rateLimit);
+    cleanupExpiredRateLimits(userId, now);
+  }
+  rateLimit.count++;
+  return rateLimit.count > RATE_LIMIT_MAX;
+}
+
+function fetchUserSubscriptions(userId: string) {
+  const db = getDb();
+  return db
+    .select({
+      endpoint: pushSubscriptions.endpoint,
+      p256dh: pushSubscriptions.p256dh,
+      authKey: pushSubscriptions.authKey,
+    })
+    .from(pushSubscriptions)
+    .where(eq(pushSubscriptions.userId, userId));
+}
+
+type SubscriptionRow = Awaited<
+  ReturnType<typeof fetchUserSubscriptions>
+>[number];
+
+async function deliverToSubscriptions(
+  subscriptions: SubscriptionRow[],
+  payload: string
+): Promise<{ anySuccess: boolean; goneEndpoints: string[] }> {
+  const goneEndpoints: string[] = [];
+  let anySuccess = false;
+
+  const results = await Promise.allSettled(
+    subscriptions.map((sub) =>
+      webpush.sendNotification(
+        {
+          endpoint: sub.endpoint,
+          keys: { p256dh: sub.p256dh, auth: sub.authKey },
+        },
+        payload
+      )
+    )
+  );
+
+  for (const [i, result] of results.entries()) {
+    if (result.status === "fulfilled") {
+      anySuccess = true;
+    } else {
+      const error: unknown = result.reason;
+      if (isWebPushError(error) && error.statusCode === 410) {
+        goneEndpoints.push(subscriptions[i].endpoint);
+      }
+      console.error("Failed to send push notification:", error);
+    }
+  }
+
+  return { anySuccess, goneEndpoints };
+}
+
+async function cleanupGoneSubscriptions(
+  endpoints: string[],
+  userId: string
+): Promise<void> {
+  if (endpoints.length === 0) {
+    return;
+  }
+  try {
+    const db = getDb();
+    await db
+      .delete(pushSubscriptions)
+      .where(
+        and(
+          inArray(pushSubscriptions.endpoint, endpoints),
+          eq(pushSubscriptions.userId, userId)
+        )
+      );
+  } catch (cleanupError: unknown) {
+    console.error("Failed to clean up stale subscriptions:", cleanupError);
+  }
 }
 
 export async function sendNotification(message: string): Promise<ActionResult> {
@@ -168,23 +307,22 @@ export async function sendNotification(message: string): Promise<ActionResult> {
 
   const userId = session.user.id;
 
-  const now = Date.now();
-  let rateLimit = rateLimitsByUser.get(userId);
-  if (rateLimit && now > rateLimit.reset) {
-    rateLimit = undefined;
-  }
-  if (!rateLimit) {
-    rateLimit = { count: 0, reset: now + RATE_LIMIT_WINDOW };
-    rateLimitsByUser.set(userId, rateLimit);
-    cleanupExpiredRateLimits(userId, now);
-  }
-  rateLimit.count++;
-  if (rateLimit.count > RATE_LIMIT_MAX) {
+  if (checkRateLimit(userId)) {
     return { success: false, error: "Rate limit exceeded" };
   }
 
-  const subscription = subscriptionsByUser.get(userId);
-  if (!subscription) {
+  let subscriptions: SubscriptionRow[];
+  try {
+    subscriptions = await fetchUserSubscriptions(userId);
+  } catch (error: unknown) {
+    console.error("Failed to fetch push subscriptions:", {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { success: false, error: "Failed to send notification" };
+  }
+
+  if (subscriptions.length === 0) {
     return { success: false, error: "No subscription available" };
   }
 
@@ -200,22 +338,16 @@ export async function sendNotification(message: string): Promise<ActionResult> {
     icon: "/icon-192x192.png",
   });
 
-  try {
-    await webpush.sendNotification(
-      {
-        endpoint: subscription.endpoint,
-        keys: {
-          p256dh: subscription.keys.p256dh,
-          auth: subscription.keys.auth,
-        },
-      },
-      payload
-    );
-  } catch (error: unknown) {
-    if (isWebPushError(error) && error.statusCode === 410) {
-      subscriptionsByUser.delete(userId);
-    }
-    console.error("Failed to send push notification:", error);
+  const { anySuccess, goneEndpoints } = await deliverToSubscriptions(
+    subscriptions,
+    payload
+  );
+
+  if (goneEndpoints.length > 0) {
+    await cleanupGoneSubscriptions(goneEndpoints, userId);
+  }
+
+  if (!anySuccess) {
     return { success: false, error: "Failed to send notification" };
   }
 

--- a/src/components/push-notifications.test.tsx
+++ b/src/components/push-notifications.test.tsx
@@ -213,7 +213,9 @@ describe("PushNotifications", () => {
     await user.click(disableButton);
 
     expect(mockUnsubscribe).toHaveBeenCalled();
-    expect(vi.mocked(unsubscribeUser)).toHaveBeenCalled();
+    expect(vi.mocked(unsubscribeUser)).toHaveBeenCalledWith(
+      "https://example.com"
+    );
     expect(
       await screen.findByRole("button", { name: "pushNotifications.enable" })
     ).toBeInTheDocument();

--- a/src/components/push-notifications.tsx
+++ b/src/components/push-notifications.tsx
@@ -107,7 +107,10 @@ function PushNotificationManager(): ReactElement {
 
   async function unsubscribeFromPush() {
     try {
-      const result = await unsubscribeUser();
+      if (!subscription) {
+        return;
+      }
+      const result = await unsubscribeUser(subscription.endpoint);
       if (!result.success) {
         console.error("Failed to remove server subscription:", result.error);
         return;


### PR DESCRIPTION
## Summary

- Replace the in-memory `Map<string, PushSubscriptionInput>` with Drizzle ORM queries against the existing `push_subscriptions` table so subscriptions survive serverless cold starts
- `subscribeUser` now performs an upsert (INSERT ... ON CONFLICT) with `.returning()` to detect ownership conflicts
- `unsubscribeUser` now accepts an `endpoint` argument for per-device unsubscribe, scoped by `userId + endpoint`
- `sendNotification` fetches all user subscriptions from DB, delivers concurrently via `Promise.allSettled`, and batch-cleans 410 Gone endpoints with `inArray`
- Extract focused helpers: `fetchUserSubscriptions`, `deliverToSubscriptions`, `cleanupGoneSubscriptions`, `checkRateLimit`

Closes #45

## Test plan

- [x] All 430 existing tests pass (`pnpm test:run`)
- [x] New tests for DB insert/select/delete error paths
- [x] New tests for multi-device delivery (concurrent send, partial failure, 410 cleanup)
- [x] New tests for endpoint ownership conflict (upsert returns empty)
- [x] New tests for `unsubscribeUser` input validation (empty, non-https, length limit)
- [x] New tests for partial VAPID configuration
- [x] Lint (`pnpm lint`) and typecheck (`pnpm typecheck`) pass
- [ ] Verify push notifications work end-to-end in preview deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)