### PR TITLE
chore(deps): bump ultracite from 7.3.1 to 7.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "tsx": "4.21.0",
     "tw-animate-css": "1.4.0",
     "typescript": "5.9.3",
-    "ultracite": "7.3.1",
+    "ultracite": "7.3.2",
     "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       ultracite:
-        specifier: 7.3.1
-        version: 7.3.1
+        specifier: 7.3.2
+        version: 7.3.2
       vite-tsconfig-paths:
         specifier: 6.1.1
         version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -6975,8 +6975,8 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
-  ultracite@7.3.1:
-    resolution: {integrity: sha512-kz8DFNfHmxtUkute+JTvMfsGGLdNc5o8hkpnuuvERPTDZIIxQ7+qVdERD9oDpxl2kFJJ1tYxiQxCHdVv9SGRJQ==}
+  ultracite@7.3.2:
+    resolution: {integrity: sha512-JV2TdeBDc1aaj3wFzXLjRcBlUZkXBdShMLAjHh9YLK0rXPSK42CzHqfWXUfibFUAUiUGNwoOFnIpS45EaJAcdg==}
     hasBin: true
     peerDependencies:
       oxlint: ^1.0.0
@@ -7952,7 +7952,7 @@ snapshots:
   '@dxup/nuxt@0.3.2(magicast@0.5.2)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.3.1(magicast@0.5.2)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       chokidar: 5.0.0
       pathe: 2.0.3
       tinyglobby: 0.2.15
@@ -14726,7 +14726,7 @@ snapshots:
   ufo@1.6.3:
     optional: true
 
-  ultracite@7.3.1:
+  ultracite@7.3.2:
     dependencies:
       '@clack/prompts': 1.1.0
       commander: 14.0.3


### PR DESCRIPTION
## Summary
- Bumps `ultracite` dev dependency from 7.3.1 to 7.3.2

## Test plan
- [ ] CI passes (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)