### PR TITLE
fix: add missing skipToContent i18n key and fix CSP for dev

### DIFF
--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -17,7 +17,8 @@
     "signIn": "Anmelden",
     "signOut": "Abmelden",
     "goToDashboard": "Zum Dashboard",
-    "toggleTheme": "Thema wechseln"
+    "toggleTheme": "Thema wechseln",
+    "skipToContent": "Zum Inhalt springen"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -17,7 +17,8 @@
     "signIn": "Sign In",
     "signOut": "Sign Out",
     "goToDashboard": "Go to Dashboard",
-    "toggleTheme": "Toggle theme"
+    "toggleTheme": "Toggle theme",
+    "skipToContent": "Skip to content"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -17,7 +17,8 @@
     "signIn": "Iniciar sesión",
     "signOut": "Cerrar sesión",
     "goToDashboard": "Ir al panel",
-    "toggleTheme": "Cambiar tema"
+    "toggleTheme": "Cambiar tema",
+    "skipToContent": "Saltar al contenido"
   },
   "nav": {
     "dashboard": "Panel",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -17,7 +17,8 @@
     "signIn": "Se connecter",
     "signOut": "Se déconnecter",
     "goToDashboard": "Accéder au tableau de bord",
-    "toggleTheme": "Changer le thème"
+    "toggleTheme": "Changer le thème",
+    "skipToContent": "Aller au contenu"
   },
   "nav": {
     "dashboard": "Tableau de bord",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -17,7 +17,8 @@
     "signIn": "Accedi",
     "signOut": "Esci",
     "goToDashboard": "Vai alla dashboard",
-    "toggleTheme": "Cambia tema"
+    "toggleTheme": "Cambia tema",
+    "skipToContent": "Salta al contenuto"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -17,7 +17,8 @@
     "signIn": "Inloggen",
     "signOut": "Uitloggen",
     "goToDashboard": "Naar dashboard",
-    "toggleTheme": "Thema wisselen"
+    "toggleTheme": "Thema wisselen",
+    "skipToContent": "Ga naar inhoud"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -17,7 +17,8 @@
     "signIn": "Entrar",
     "signOut": "Sair",
     "goToDashboard": "Ir para o painel",
-    "toggleTheme": "Alternar tema"
+    "toggleTheme": "Alternar tema",
+    "skipToContent": "Saltar para o conteúdo"
   },
   "nav": {
     "dashboard": "Painel",

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -52,7 +52,12 @@ const BASE_DIRECTIVES: CspDirectives = {
   // next-themes injects an inline <script> in <head> before React hydrates,
   // so we cannot replace this with a nonce or hash without patching the library.
   // TODO: migrate to nonce-based CSP once next-themes supports it, removing 'unsafe-inline'
-  "script-src": ["'self'", "'unsafe-inline'", "https://va.vercel-scripts.com"],
+  "script-src": [
+    "'self'",
+    "'unsafe-inline'",
+    "'wasm-unsafe-eval'",
+    "https://va.vercel-scripts.com",
+  ],
   "style-src": ["'self'", "'unsafe-inline'"],
   "img-src": ["'self'", "data:", "blob:"],
   "font-src": ["'self'"],
@@ -77,6 +82,7 @@ const BASE_DIRECTIVES: CspDirectives = {
 };
 
 const DEV_EXTENSIONS: Partial<CspDirectives> = {
+  "script-src": ["'unsafe-eval'"],
   "connect-src": ["ws://localhost:*"],
   "frame-src": ["https://local.drizzle.studio"],
 };


### PR DESCRIPTION
## Summary
- Add missing `common.skipToContent` translation key to all 7 locale files, fixing `MISSING_MESSAGE` error in dev
- Add `wasm-unsafe-eval` to base CSP `script-src` for PowerSync wa-sqlite WebAssembly compilation
- Add `unsafe-eval` to dev-only CSP `script-src` for React 19 dev-mode debugging features

## Test plan
- [ ] CI passes (lint, typecheck, tests, build)
- [ ] Dev server starts without `MISSING_MESSAGE` error
- [ ] Dev server starts without CSP `eval()` / WebAssembly errors

## Split context
This is PR 2 of 2 from an automated split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)