### PR TITLE
security: use dedicated HMAC secret for unsubscribe tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Database (Neon)
+DATABASE_URL=postgresql://user:pass@ep-xxx-pooler.region.aws.neon.tech/neondb?sslmode=require
+
+# Sync (PowerSync) — leave empty for local-only mode
+NEXT_PUBLIC_POWERSYNC_URL=
+# Neon Data API — used by PowerSync connector for uploads
+NEXT_PUBLIC_NEON_DATA_API_URL=
+
+# Auth (Neon Auth) — copy Auth URL from Neon Console > Auth > Configuration
+NEON_AUTH_BASE_URL=
+NEON_AUTH_COOKIE_SECRET=  # openssl rand -base64 32
+
+# Push (VAPID) — npx web-push generate-vapid-keys
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=your_public_key_here
+VAPID_PRIVATE_KEY=your_private_key_here
+
+# App URL — used for email unsubscribe links (defaults to https://themagiclab.app)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Email (Resend)
+RESEND_API_KEY=
+
+# Email HMAC (unsubscribe token signing) — openssl rand -base64 32
+EMAIL_HMAC_SECRET=
+
+# Neon MCP (set in shell profile, not .env.local — used by MCP server)
+# NEON_API_KEY=  # Generate at: Neon Console > Account Settings > API Keys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         env:
           NEON_AUTH_BASE_URL: http://localhost:4000
           NEON_AUTH_COOKIE_SECRET: ci-dummy-secret-that-is-at-least-32-characters-long
+          EMAIL_HMAC_SECRET: ci-dummy-hmac-secret-at-least-32-characters-long
           DATABASE_URL: postgresql://unused:unused@localhost:5432/unused
 
   e2e:
@@ -90,9 +91,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Generate E2E cookie secret
+      - name: Generate E2E secrets
         id: e2e-secret
-        run: echo "value=$(openssl rand -base64 32)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "cookie=$(openssl rand -base64 32)" >> "$GITHUB_OUTPUT"
+          echo "hmac=$(openssl rand -base64 32)" >> "$GITHUB_OUTPUT"
 
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
@@ -128,7 +131,8 @@ jobs:
       - name: Run E2E tests
         run: pnpm test:e2e
         env:
-          NEON_AUTH_COOKIE_SECRET: ${{ steps.e2e-secret.outputs.value }}
+          NEON_AUTH_COOKIE_SECRET: ${{ steps.e2e-secret.outputs.cookie }}
+          EMAIL_HMAC_SECRET: ${{ steps.e2e-secret.outputs.hmac }}
 
       - name: Upload test report
         if: '!cancelled()'

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,9 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
+# env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -28,7 +28,7 @@ describe("email", () => {
 
   describe("createUnsubscribeToken", () => {
     it("produces a token in userId.timestamp.hmac format", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { createUnsubscribeToken } = await import("@/lib/email");
       const token = createUnsubscribeToken(TEST_USER_ID);
@@ -42,7 +42,7 @@ describe("email", () => {
     });
 
     it("produces identical tokens when called at the same second", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
       vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
 
       try {
@@ -57,7 +57,7 @@ describe("email", () => {
     });
 
     it("produces different tokens for different users", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { createUnsubscribeToken } = await import("@/lib/email");
       const token1 = createUnsubscribeToken(TEST_USER_ID);
@@ -66,19 +66,28 @@ describe("email", () => {
       expect(token1).not.toBe(token2);
     });
 
-    it("throws when NEON_AUTH_COOKIE_SECRET is missing", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "");
+    it("throws when EMAIL_HMAC_SECRET is missing", async () => {
+      vi.stubEnv("EMAIL_HMAC_SECRET", "");
 
       const { createUnsubscribeToken } = await import("@/lib/email");
       expect(() => createUnsubscribeToken(TEST_USER_ID)).toThrow(
-        "NEON_AUTH_COOKIE_SECRET environment variable is required"
+        "EMAIL_HMAC_SECRET environment variable is required"
+      );
+    });
+
+    it("throws when EMAIL_HMAC_SECRET is too short", async () => {
+      vi.stubEnv("EMAIL_HMAC_SECRET", "short");
+
+      const { createUnsubscribeToken } = await import("@/lib/email");
+      expect(() => createUnsubscribeToken(TEST_USER_ID)).toThrow(
+        "EMAIL_HMAC_SECRET must be at least 32 characters"
       );
     });
   });
 
   describe("verifyUnsubscribeToken", () => {
     it("accepts a valid token and returns the userId", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { createUnsubscribeToken, verifyUnsubscribeToken } = await import(
         "@/lib/email"
@@ -90,7 +99,7 @@ describe("email", () => {
     });
 
     it("rejects a tampered token", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { verifyUnsubscribeToken } = await import("@/lib/email");
       const timestamp = Math.floor(Date.now() / 1000);
@@ -102,35 +111,35 @@ describe("email", () => {
     });
 
     it("rejects a token without a dot separator", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { verifyUnsubscribeToken } = await import("@/lib/email");
       expect(verifyUnsubscribeToken("notokenhere")).toBeNull();
     });
 
     it("rejects an empty string", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { verifyUnsubscribeToken } = await import("@/lib/email");
       expect(verifyUnsubscribeToken("")).toBeNull();
     });
 
     it("rejects a token with empty userId", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { verifyUnsubscribeToken } = await import("@/lib/email");
       expect(verifyUnsubscribeToken(".somehash")).toBeNull();
     });
 
     it("rejects a token with empty hmac", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { verifyUnsubscribeToken } = await import("@/lib/email");
       expect(verifyUnsubscribeToken("user-abc.12345.")).toBeNull();
     });
 
     it("rejects token with non-hex HMAC", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { verifyUnsubscribeToken } = await import("@/lib/email");
       const result = verifyUnsubscribeToken(
@@ -140,7 +149,7 @@ describe("email", () => {
     });
 
     it("rejects a token with non-UUID userId", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
 
       const { verifyUnsubscribeToken } = await import("@/lib/email");
       const result = verifyUnsubscribeToken(
@@ -151,7 +160,7 @@ describe("email", () => {
     });
 
     it("rejects an expired token", async () => {
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
       vi.useFakeTimers({ now: new Date("2025-01-01T00:00:00Z") });
 
       try {
@@ -192,7 +201,7 @@ describe("email", () => {
   describe("getAppUrl", () => {
     it("throws for non-HTTPS URL in production", async () => {
       vi.stubEnv("RESEND_API_KEY", "re_test_key");
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
       vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://example.com");
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("VERCEL_ENV", "production");
@@ -217,7 +226,7 @@ describe("email", () => {
   describe("sendWelcomeEmail", () => {
     it("includes personalized greeting when name is provided", async () => {
       vi.stubEnv("RESEND_API_KEY", "re_test_key");
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
       vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://themagiclab.app");
       vi.stubEnv("VERCEL_ENV", "production");
 
@@ -239,7 +248,7 @@ describe("email", () => {
 
     it("uses generic greeting when name is omitted", async () => {
       vi.stubEnv("RESEND_API_KEY", "re_test_key");
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
       vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://themagiclab.app");
       vi.stubEnv("VERCEL_ENV", "production");
 
@@ -261,7 +270,7 @@ describe("email", () => {
 
     it("calls sendEmail with correct subject", async () => {
       vi.stubEnv("RESEND_API_KEY", "re_test_key");
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
       vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://themagiclab.app");
       vi.stubEnv("VERCEL_ENV", "production");
 
@@ -285,7 +294,7 @@ describe("email", () => {
   describe("sendEmail", () => {
     it("calls Resend API with correct parameters", async () => {
       vi.stubEnv("RESEND_API_KEY", "re_test_key");
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
       vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://themagiclab.app");
       vi.stubEnv("VERCEL_ENV", "production");
 
@@ -313,7 +322,7 @@ describe("email", () => {
 
     it("includes unsubscribe headers when userId is provided", async () => {
       vi.stubEnv("RESEND_API_KEY", "re_test_key");
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
       vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://themagiclab.app");
       vi.stubEnv("VERCEL_ENV", "production");
 
@@ -374,7 +383,7 @@ describe("email", () => {
 
     it("redirects to delivered@resend.dev in non-production environments", async () => {
       vi.stubEnv("RESEND_API_KEY", "re_test_key");
-      vi.stubEnv("NEON_AUTH_COOKIE_SECRET", "test-secret-123");
+      vi.stubEnv("EMAIL_HMAC_SECRET", "test-secret-that-is-at-least-32-chars!");
       vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://themagiclab.app");
       vi.stubEnv("VERCEL_ENV", "preview");
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -21,12 +21,12 @@ function getHmacSecret(): Buffer {
   if (cachedHmacSecret) {
     return cachedHmacSecret;
   }
-  const secret =
-    process.env.EMAIL_HMAC_SECRET ?? process.env.NEON_AUTH_COOKIE_SECRET;
+  const secret = process.env.EMAIL_HMAC_SECRET;
   if (!secret) {
-    throw new Error(
-      "EMAIL_HMAC_SECRET or NEON_AUTH_COOKIE_SECRET environment variable is required"
-    );
+    throw new Error("EMAIL_HMAC_SECRET environment variable is required");
+  }
+  if (secret.length < 32) {
+    throw new Error("EMAIL_HMAC_SECRET must be at least 32 characters");
   }
   cachedHmacSecret = Buffer.from(
     crypto.hkdfSync("sha256", secret, "", "unsubscribe-token", 32)


### PR DESCRIPTION
## Summary

- Replace `NEON_AUTH_COOKIE_SECRET` fallback in `getHmacSecret()` with a dedicated `EMAIL_HMAC_SECRET` env var, decoupling token signing from auth session cookies
- Add minimum 32-character length validation on the secret
- Generate E2E secrets dynamically in CI (matching existing `NEON_AUTH_COOKIE_SECRET` pattern)
- Track `.env.example` in git (was previously gitignored by `.env*` glob)

Closes #49

## Test plan

- [x] `pnpm test:run` — 431/431 tests pass (new test for minimum-length validation)
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [ ] After merge: add `EMAIL_HMAC_SECRET` to Vercel env config (`openssl rand -base64 32`) for both production and preview (use different values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)