### PR TITLE
feat: add user_id column to junction tables for RLS and sync filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,8 @@ Type safety is a first-class concern. All code must be rigorously typed.
 5. Update PowerSync client schema: `src/sync/schema.ts`
 6. Run `pnpm docs:generate` to update documentation
 
+**IMPORTANT — Single migration file rule**: The `@neondatabase/serverless` driver uses stateless HTTP requests. Each migration file runs as an independent HTTP call, so DDL changes from one migration (e.g., `ADD COLUMN`) are **not visible** to the next migration within the same `drizzle-kit migrate` run. **Never split dependent SQL across multiple migration files.** If a later statement references a column or object created earlier, it must be in the **same** migration file. Hand-written migrations (e.g., RLS policy updates) that depend on a generated migration must be appended to that migration file, not created as a separate file.
+
 ## UI/Design Conventions
 
 - **Mobile-first**: Design for <768px first, then tablet (768-1024px), then desktop (>1024px)

--- a/src/db/migrations/0006_wakeful_nemesis.sql
+++ b/src/db/migrations/0006_wakeful_nemesis.sql
@@ -1,0 +1,60 @@
+-- Add user_id column to junction tables for direct RLS filtering and sync.
+-- Strategy: add nullable → backfill from parent table → cleanup orphans → set NOT NULL → add FK + index.
+-- Also updates RLS policies to use direct user_id match for reads, with EXISTS
+-- checks on parent FKs for write-path defense-in-depth.
+
+-- routine_tricks: backfill from routines
+ALTER TABLE "routine_tricks" ADD COLUMN "user_id" uuid;--> statement-breakpoint
+UPDATE "routine_tricks" SET "user_id" = (SELECT "user_id" FROM "routines" WHERE "routines"."id" = "routine_tricks"."routine_id");--> statement-breakpoint
+DELETE FROM "routine_tricks" WHERE "user_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "routine_tricks" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+
+-- practice_session_tricks: backfill from practice_sessions
+ALTER TABLE "practice_session_tricks" ADD COLUMN "user_id" uuid;--> statement-breakpoint
+UPDATE "practice_session_tricks" SET "user_id" = (SELECT "user_id" FROM "practice_sessions" WHERE "practice_sessions"."id" = "practice_session_tricks"."practice_session_id");--> statement-breakpoint
+DELETE FROM "practice_session_tricks" WHERE "user_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "practice_session_tricks" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+
+-- item_tricks: backfill from items
+ALTER TABLE "item_tricks" ADD COLUMN "user_id" uuid;--> statement-breakpoint
+UPDATE "item_tricks" SET "user_id" = (SELECT "user_id" FROM "items" WHERE "items"."id" = "item_tricks"."item_id");--> statement-breakpoint
+DELETE FROM "item_tricks" WHERE "user_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "item_tricks" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+
+-- Foreign keys
+ALTER TABLE "item_tricks" ADD CONSTRAINT "item_tricks_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "practice_session_tricks" ADD CONSTRAINT "practice_session_tricks_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "routine_tricks" ADD CONSTRAINT "routine_tricks_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+-- Partial indexes
+CREATE INDEX "item_tricks_user_id_idx" ON "item_tricks" USING btree ("user_id") WHERE deleted_at IS NULL;--> statement-breakpoint
+CREATE INDEX "practice_session_tricks_user_id_idx" ON "practice_session_tricks" USING btree ("user_id") WHERE deleted_at IS NULL;--> statement-breakpoint
+CREATE INDEX "routine_tricks_user_id_idx" ON "routine_tricks" USING btree ("user_id") WHERE deleted_at IS NULL;--> statement-breakpoint
+
+-- Simplify junction table RLS policies: use direct user_id match for the read
+-- path (USING), but keep EXISTS subqueries on parent tables in the write path
+-- (WITH CHECK) to prevent cross-user FK references as defense-in-depth.
+DROP POLICY IF EXISTS "routine_tricks_rls_policy" ON "routine_tricks";--> statement-breakpoint
+CREATE POLICY "routine_tricks_rls_policy" ON "routine_tricks" FOR ALL TO authenticated
+  USING (user_id = auth.user_id()::uuid)
+  WITH CHECK (
+    user_id = auth.user_id()::uuid
+    AND EXISTS (SELECT 1 FROM "routines" WHERE "routines".id = "routine_tricks".routine_id AND "routines".user_id = auth.user_id()::uuid)
+    AND EXISTS (SELECT 1 FROM "tricks" WHERE "tricks".id = "routine_tricks".trick_id AND "tricks".user_id = auth.user_id()::uuid)
+  );--> statement-breakpoint
+DROP POLICY IF EXISTS "practice_session_tricks_rls_policy" ON "practice_session_tricks";--> statement-breakpoint
+CREATE POLICY "practice_session_tricks_rls_policy" ON "practice_session_tricks" FOR ALL TO authenticated
+  USING (user_id = auth.user_id()::uuid)
+  WITH CHECK (
+    user_id = auth.user_id()::uuid
+    AND EXISTS (SELECT 1 FROM "practice_sessions" WHERE "practice_sessions".id = "practice_session_tricks".practice_session_id AND "practice_sessions".user_id = auth.user_id()::uuid)
+    AND EXISTS (SELECT 1 FROM "tricks" WHERE "tricks".id = "practice_session_tricks".trick_id AND "tricks".user_id = auth.user_id()::uuid)
+  );--> statement-breakpoint
+DROP POLICY IF EXISTS "item_tricks_rls_policy" ON "item_tricks";--> statement-breakpoint
+CREATE POLICY "item_tricks_rls_policy" ON "item_tricks" FOR ALL TO authenticated
+  USING (user_id = auth.user_id()::uuid)
+  WITH CHECK (
+    user_id = auth.user_id()::uuid
+    AND EXISTS (SELECT 1 FROM "items" WHERE "items".id = "item_tricks".item_id AND "items".user_id = auth.user_id()::uuid)
+    AND EXISTS (SELECT 1 FROM "tricks" WHERE "tricks".id = "item_tricks".trick_id AND "tricks".user_id = auth.user_id()::uuid)
+  );

--- a/src/db/migrations/meta/0006_snapshot.json
+++ b/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1654 @@
+{
+  "id": "37848c47-2aa3-49d0-b535-67b214c050b0",
+  "prevId": "58a99c71-e761-463d-be95-5fc366900f23",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_value": {
+          "name": "target_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "goals_user_id_idx": {
+          "name": "goals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "goals_trick_id_idx": {
+          "name": "goals_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goals_trick_id_tricks_id_fk": {
+          "name": "goals_trick_id_tricks_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_tricks": {
+      "name": "item_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "item_tricks_user_id_idx": {
+          "name": "item_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tricks_item_id_idx": {
+          "name": "item_tricks_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tricks_trick_id_idx": {
+          "name": "item_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tricks_item_trick_idx": {
+          "name": "item_tricks_item_trick_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_tricks_user_id_users_id_fk": {
+          "name": "item_tricks_user_id_users_id_fk",
+          "tableFrom": "item_tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_tricks_item_id_items_id_fk": {
+          "name": "item_tricks_item_id_items_id_fk",
+          "tableFrom": "item_tricks",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_tricks_trick_id_tricks_id_fk": {
+          "name": "item_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "item_tricks",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "items_user_id_idx": {
+          "name": "items_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "items_user_id_users_id_fk": {
+          "name": "items_user_id_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.performances": {
+      "name": "performances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_size": {
+          "name": "audience_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_type": {
+          "name": "audience_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "performances_user_id_idx": {
+          "name": "performances_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "performances_routine_id_idx": {
+          "name": "performances_routine_id_idx",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "performances_user_id_date_idx": {
+          "name": "performances_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "performances_user_id_users_id_fk": {
+          "name": "performances_user_id_users_id_fk",
+          "tableFrom": "performances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "performances_routine_id_routines_id_fk": {
+          "name": "performances_routine_id_routines_id_fk",
+          "tableFrom": "performances",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_session_tricks": {
+      "name": "practice_session_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_session_tricks_user_id_idx": {
+          "name": "practice_session_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_tricks_practice_session_id_idx": {
+          "name": "practice_session_tricks_practice_session_id_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_tricks_trick_id_idx": {
+          "name": "practice_session_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_tricks_session_trick_idx": {
+          "name": "practice_session_tricks_session_trick_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_session_tricks_user_id_users_id_fk": {
+          "name": "practice_session_tricks_user_id_users_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "practice_session_tricks_practice_session_id_practice_sessions_id_fk": {
+          "name": "practice_session_tricks_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "practice_session_tricks_trick_id_tricks_id_fk": {
+          "name": "practice_session_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_sessions": {
+      "name": "practice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_sessions_user_id_idx": {
+          "name": "practice_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_id_date_idx": {
+          "name": "practice_sessions_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_sessions_user_id_users_id_fk": {
+          "name": "practice_sessions_user_id_users_id_fk",
+          "tableFrom": "practice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine_tricks": {
+      "name": "routine_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_notes": {
+          "name": "transition_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "routine_tricks_user_id_idx": {
+          "name": "routine_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_tricks_routine_id_idx": {
+          "name": "routine_tricks_routine_id_idx",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_tricks_trick_id_idx": {
+          "name": "routine_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_tricks_routine_position_idx": {
+          "name": "routine_tricks_routine_position_idx",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine_tricks_user_id_users_id_fk": {
+          "name": "routine_tricks_user_id_users_id_fk",
+          "tableFrom": "routine_tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_tricks_routine_id_routines_id_fk": {
+          "name": "routine_tricks_routine_id_routines_id_fk",
+          "tableFrom": "routine_tricks",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_tricks_trick_id_tricks_id_fk": {
+          "name": "routine_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "routine_tricks",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routines": {
+      "name": "routines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_duration_minutes": {
+          "name": "estimated_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "routines_user_id_idx": {
+          "name": "routines_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routines_user_id_users_id_fk": {
+          "name": "routines_user_id_users_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tricks": {
+      "name": "tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tricks_user_id_idx": {
+          "name": "tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tricks_user_id_users_id_fk": {
+          "name": "tricks_user_id_users_id_fk",
+          "tableFrom": "tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "push_enabled": {
+          "name": "push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "practice_reminder_time": {
+          "name": "practice_reminder_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_reminder_days": {
+          "name": "practice_reminder_days",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_summary_enabled": {
+          "name": "weekly_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1774070400000,
       "tag": "0005_enable_rls",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1773872305136,
+      "tag": "0006_wakeful_nemesis",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/items.ts
+++ b/src/db/schema/items.ts
@@ -48,6 +48,9 @@ export const itemTricks = pgTable(
   "item_tricks",
   {
     id: uuid().primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
     // CASCADE is safe here because parent entities use soft-delete (setting
     // deleted_at), which does not trigger ON DELETE CASCADE. Hard-deletes only
     // occur during full user account removal.
@@ -67,6 +70,9 @@ export const itemTricks = pgTable(
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (table) => [
+    index("item_tricks_user_id_idx")
+      .on(table.userId)
+      .where(sql`deleted_at IS NULL`),
     index("item_tricks_item_id_idx")
       .on(table.itemId)
       .where(sql`deleted_at IS NULL`),

--- a/src/db/schema/practice-sessions.ts
+++ b/src/db/schema/practice-sessions.ts
@@ -46,6 +46,9 @@ export const practiceSessionTricks = pgTable(
   "practice_session_tricks",
   {
     id: uuid().primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
     // CASCADE is safe here because parent entities use soft-delete (setting
     // deleted_at), which does not trigger ON DELETE CASCADE. Hard-deletes only
     // occur during full user account removal.
@@ -68,6 +71,9 @@ export const practiceSessionTricks = pgTable(
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (table) => [
+    index("practice_session_tricks_user_id_idx")
+      .on(table.userId)
+      .where(sql`deleted_at IS NULL`),
     index("practice_session_tricks_practice_session_id_idx")
       .on(table.practiceSessionId)
       .where(sql`deleted_at IS NULL`),

--- a/src/db/schema/routines.ts
+++ b/src/db/schema/routines.ts
@@ -48,6 +48,9 @@ export const routineTricks = pgTable(
   "routine_tricks",
   {
     id: uuid().primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
     // CASCADE is safe here because parent entities use soft-delete (setting
     // deleted_at), which does not trigger ON DELETE CASCADE. Hard-deletes only
     // occur during full user account removal.
@@ -69,6 +72,9 @@ export const routineTricks = pgTable(
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (table) => [
+    index("routine_tricks_user_id_idx")
+      .on(table.userId)
+      .where(sql`deleted_at IS NULL`),
     index("routine_tricks_routine_id_idx")
       .on(table.routineId)
       .where(sql`deleted_at IS NULL`),

--- a/src/sync/connector.test.ts
+++ b/src/sync/connector.test.ts
@@ -258,20 +258,23 @@ describe("buildQuery with userId scoping", () => {
     expect(result.params).toContain("user-1");
   });
 
-  it("omits user_id clause for junction tables without user_id column", () => {
+  it("includes user_id clause for junction tables", () => {
     const result = buildQuery(
       UpdateType.PUT,
       "routine_tricks",
       "abc",
       {
         id: "abc",
+        user_id: "user-1",
         routine_id: "r1",
         trick_id: "t1",
+        position: 1,
       },
       "user-1"
     );
-    // Junction tables don't have user_id in SYNCED_COLUMNS, so no WHERE clause
-    expect(result.params).not.toContain("user-1");
+    // Junction tables now have user_id in SYNCED_COLUMNS
+    expect(result.params).toContain("user-1");
+    expect(result.query).toContain('"user_id"');
   });
 });
 
@@ -808,28 +811,13 @@ describe("createNeonConnector", () => {
       ).rejects.toThrow("Unauthorized: userId is required for mutations");
     });
 
-    it("allows PUT on junction table when parent ownership check succeeds", async () => {
+    it("injects authenticated userId into junction table PUT", async () => {
       const fetchSpy = vi
         .spyOn(globalThis, "fetch")
-        // First call: ownership check for routines — returns the owned row
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ rows: [{ id: "routine-1" }] }), {
-            status: 200,
-          })
-        )
-        // Second call: ownership check for tricks — returns the owned row
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ rows: [{ id: "trick-1" }] }), {
-            status: 200,
-          })
-        )
-        // Third call: the actual INSERT
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({}), { status: 200 })
-        );
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
       const mod = await importWithEnv(VALID_ENV);
       const connector = mod.createNeonConnector(async () => "my-token", {
-        getUserId: async () => "user-1",
+        getUserId: async () => "server-user-id",
       });
       const db = createMockDatabase([
         {
@@ -840,6 +828,7 @@ describe("createNeonConnector", () => {
             routine_id: "routine-1",
             trick_id: "trick-1",
             position: 1,
+            user_id: "forged-user-id",
           },
         },
       ]);
@@ -848,49 +837,87 @@ describe("createNeonConnector", () => {
         db as unknown as Parameters<typeof connector.uploadData>[0]
       );
 
-      // Ownership checks + actual mutation = 3 calls
-      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      // No ownership check round-trips — just the mutation itself
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string) as {
+        query: string;
+        params: unknown[];
+      };
+      // Authenticated userId must be used, not the forged one
+      expect(body.params).toContain("server-user-id");
+      expect(body.params).not.toContain("forged-user-id");
+      expect(body.query).toContain('"user_id"');
       const transaction = await db.getNextCrudTransaction.mock.results[0].value;
       expect(transaction.complete).toHaveBeenCalledOnce();
     });
 
-    it("rejects PUT on junction table when parent ownership check fails", async () => {
-      vi.spyOn(console, "error").mockImplementation(() => undefined);
-      vi.spyOn(globalThis, "fetch")
-        // First call: ownership check for routines — returns empty (not owned)
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ rows: [] }), { status: 200 })
-        )
-        // Second call: ownership check for tricks — returns the owned row
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ rows: [{ id: "trick-1" }] }), {
-            status: 200,
-          })
-        );
+    it("scopes junction table PATCH by authenticated userId", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
       const mod = await importWithEnv(VALID_ENV);
       const connector = mod.createNeonConnector(async () => "my-token", {
-        getUserId: async () => "user-1",
+        getUserId: async () => "server-user-id",
       });
       const db = createMockDatabase([
         {
           id: "rt-1",
-          op: "PUT",
+          op: "PATCH",
           table: "routine_tricks",
           opData: {
-            routine_id: "routine-1",
-            trick_id: "trick-1",
-            position: 1,
+            position: 2,
+            user_id: "forged-user-id",
           },
         },
       ]);
 
-      await expect(
-        connector.uploadData(
-          db as unknown as Parameters<typeof connector.uploadData>[0]
-        )
-      ).rejects.toThrow(
-        "Unauthorized: routines routine-1 does not belong to user"
+      await connector.uploadData(
+        db as unknown as Parameters<typeof connector.uploadData>[0]
       );
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string) as {
+        query: string;
+        params: unknown[];
+      };
+      expect(body.query).toContain("UPDATE");
+      expect(body.query).toContain('"user_id"');
+      expect(body.params).toContain("server-user-id");
+      expect(body.params).not.toContain("forged-user-id");
+    });
+
+    it("scopes junction table DELETE by authenticated userId", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const mod = await importWithEnv(VALID_ENV);
+      const connector = mod.createNeonConnector(async () => "my-token", {
+        getUserId: async () => "server-user-id",
+      });
+      const db = createMockDatabase([
+        {
+          id: "rt-1",
+          op: "DELETE",
+          table: "routine_tricks",
+          opData: {},
+        },
+      ]);
+
+      await connector.uploadData(
+        db as unknown as Parameters<typeof connector.uploadData>[0]
+      );
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string) as {
+        query: string;
+        params: unknown[];
+      };
+      expect(body.query).toContain('"deleted_at"');
+      expect(body.query).toContain('"user_id"');
+      expect(body.params).toContain("server-user-id");
     });
 
     it("throws when fetch rejects with a network error", async () => {

--- a/src/sync/connector.ts
+++ b/src/sync/connector.ts
@@ -45,6 +45,7 @@ const SYNCED_COLUMNS = {
   ]),
   item_tricks: new Set([
     "id",
+    "user_id",
     "item_id",
     "trick_id",
     "created_at",
@@ -85,6 +86,7 @@ const SYNCED_COLUMNS = {
   ]),
   practice_session_tricks: new Set([
     "id",
+    "user_id",
     "practice_session_id",
     "trick_id",
     "repetitions",
@@ -107,6 +109,7 @@ const SYNCED_COLUMNS = {
   ]),
   routine_tricks: new Set([
     "id",
+    "user_id",
     "routine_id",
     "trick_id",
     "position",
@@ -147,70 +150,16 @@ const SYNCED_COLUMNS = {
   ]),
 } satisfies Record<SyncedTableName, Set<string>>;
 
-/** Junction tables and their parent FK relationships for ownership validation. */
-const JUNCTION_PARENTS: Partial<
-  Record<SyncedTableName, { column: string; parentTable: string }[]>
-> = {
-  routine_tricks: [
-    { column: "routine_id", parentTable: "routines" },
-    { column: "trick_id", parentTable: "tricks" },
-  ],
-  practice_session_tricks: [
-    { column: "practice_session_id", parentTable: "practice_sessions" },
-    { column: "trick_id", parentTable: "tricks" },
-  ],
-  item_tricks: [
-    { column: "item_id", parentTable: "items" },
-    { column: "trick_id", parentTable: "tricks" },
-  ],
-};
-
 function isSyncedTable(table: string): table is SyncedTableName {
   return (SYNCED_TABLES as ReadonlySet<string>).has(table);
 }
 
 const quoteId = (id: string): string => `"${id.replaceAll('"', '""')}"`;
 
-/** Known parent table names from JUNCTION_PARENTS for allowlist validation. */
-const KNOWN_PARENT_TABLES = new Set(
-  Object.values(JUNCTION_PARENTS)
-    .flat()
-    .map(({ parentTable }) => parentTable)
-);
-
 /** HTTP status codes for permanent client errors — retrying won't help. */
 const PERMANENT_CLIENT_ERRORS = new Set([400, 404, 409, 422]);
 
 type SqlParam = string | number | boolean | null;
-
-interface NeonApiResponse {
-  rows: Record<string, SqlParam>[];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isNeonApiResponse(data: unknown): data is NeonApiResponse {
-  if (!(isRecord(data) && "rows" in data)) {
-    return false;
-  }
-  const { rows } = data;
-  if (!Array.isArray(rows)) {
-    return false;
-  }
-  for (const row of rows) {
-    if (!isRecord(row)) {
-      return false;
-    }
-    for (const value of Object.values(row)) {
-      if (!isSqlParam(value)) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
 
 function isSqlParam(value: unknown): value is SqlParam {
   return (
@@ -236,114 +185,6 @@ function validateRecord(
       throw new Error(`Disallowed column "${col}" on table "${table}"`);
     }
   }
-}
-
-/**
- * For junction tables (no user_id column), validates that referenced parent
- * rows belong to the authenticated user. Throws if any parent row is missing
- * or belongs to a different user.
- */
-async function validateJunctionOwnership(
-  table: SyncedTableName,
-  record: Record<string, SqlParam>,
-  userId: string,
-  apiUrl: string,
-  token: string
-): Promise<void> {
-  const parents = JUNCTION_PARENTS[table];
-  if (!parents) {
-    return;
-  }
-
-  // Collect all FK checks that need validation
-  const checks: { fkColumn: string; fkValue: string; parentTable: string }[] =
-    [];
-  for (const { column: fkColumn, parentTable } of parents) {
-    const fkValue = record[fkColumn];
-    if (!fkValue || typeof fkValue !== "string") {
-      continue;
-    }
-    checks.push({ fkColumn, fkValue, parentTable });
-  }
-
-  if (checks.length === 0) {
-    return;
-  }
-
-  // Group checks by parent table so we can batch with WHERE id IN (...)
-  const byParent = new Map<string, string[]>();
-  for (const { fkValue, parentTable } of checks) {
-    const existing = byParent.get(parentTable);
-    if (existing) {
-      existing.push(fkValue);
-    } else {
-      byParent.set(parentTable, [fkValue]);
-    }
-  }
-
-  // Issue one batched ownership query per parent table
-  await Promise.all(
-    [...byParent.entries()].map(async ([parentTable, fkValues]) => {
-      // Defense-in-depth: validate parentTable against known allowlist
-      if (!KNOWN_PARENT_TABLES.has(parentTable)) {
-        throw new Error(`Unknown parent table: ${parentTable}`);
-      }
-      const placeholders = fkValues.map((_, i) => `$${i + 1}`);
-      const params: SqlParam[] = [...fkValues, userId];
-      const userIdPlaceholder = `$${params.length}`;
-
-      let checkResponse: Response;
-      try {
-        checkResponse = await fetch(apiUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            query: `SELECT "id" FROM ${quoteId(parentTable)} WHERE "id" IN (${placeholders.join(", ")}) AND "user_id" = ${userIdPlaceholder}`,
-            params,
-          }),
-          signal: AbortSignal.timeout(30_000),
-        });
-      } catch (error: unknown) {
-        throw new Error(
-          `Failed to validate ownership of ${parentTable} records [${fkValues.join(", ")}]`,
-          { cause: error }
-        );
-      }
-      if (!checkResponse.ok) {
-        throw new Error(
-          `Ownership check failed for ${parentTable}: ${checkResponse.status}`
-        );
-      }
-      const checkData: unknown = await checkResponse.json();
-      if (!isNeonApiResponse(checkData)) {
-        throw new Error(
-          `Unexpected response from ownership check for ${parentTable}`
-        );
-      }
-
-      const ownedIds = new Set(
-        checkData.rows.map((row) => {
-          const id = row.id;
-          if (typeof id !== "string") {
-            throw new Error(
-              `Expected string id from ownership check, got ${typeof id}`
-            );
-          }
-          return id;
-        })
-      );
-      for (const fkValue of fkValues) {
-        if (!ownedIds.has(fkValue)) {
-          throw new Error(
-            `Unauthorized: ${parentTable} ${fkValue} does not belong to user`
-          );
-        }
-      }
-    })
-  );
 }
 
 function buildQuery(
@@ -511,82 +352,6 @@ interface ConnectorOptions {
   onUploadError?: UploadErrorHandler;
 }
 
-/**
- * For DELETE on junction tables, fetch the FK columns needed for ownership
- * validation (not SELECT *) since opData may be empty.
- *
- * TOCTOU caveat: There is a small window between the ownership SELECT
- * and the subsequent soft-delete UPDATE where a concurrent mutation could
- * reassign the junction row's FK to a different parent. This is acceptable
- * because (1) UUIDs make accidental collision negligible, (2) the
- * ownership check prevents the common case of unauthorized access, and
- * (3) true atomic row-level locking would require SELECT ... FOR UPDATE
- * inside a serializable transaction, which the Neon Data API does not
- * currently support in a single round-trip.
- */
-async function validateJunctionDeleteOwnership(
-  table: SyncedTableName,
-  rowId: string,
-  userId: string,
-  neonDataApiUrl: string,
-  token: string
-): Promise<void> {
-  const parents = JUNCTION_PARENTS[table];
-  if (!parents) {
-    return;
-  }
-
-  const fkColumns = parents.map(({ column }) => quoteId(column)).join(", ");
-  let fetchResponse: Response;
-  try {
-    fetchResponse = await fetch(neonDataApiUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({
-        query: `SELECT ${fkColumns} FROM ${quoteId(table)} WHERE "id" = $1 AND "deleted_at" IS NULL`,
-        params: [rowId],
-      }),
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch (error: unknown) {
-    throw new Error(
-      `Failed to fetch ${table} record ${rowId} for ownership validation`,
-      { cause: error }
-    );
-  }
-  if (!fetchResponse.ok) {
-    throw new Error(
-      `Failed to fetch junction row for ownership check: ${fetchResponse.status}`
-    );
-  }
-  const fetchData: unknown = await fetchResponse.json();
-  if (!isNeonApiResponse(fetchData) || fetchData.rows.length === 0) {
-    throw new Error(
-      `Junction row ${rowId} not found in ${table} for ownership check`
-    );
-  }
-  const existingRow = fetchData.rows[0];
-  // Verify all expected FK columns are present and non-null before
-  // ownership validation — a missing FK would silently skip the check.
-  for (const { column: fkColumn } of parents) {
-    if (!(fkColumn in existingRow) || existingRow[fkColumn] === null) {
-      throw new Error(
-        `Junction row ${rowId} in ${table} is missing FK column "${fkColumn}" — cannot verify ownership`
-      );
-    }
-  }
-  await validateJunctionOwnership(
-    table,
-    existingRow,
-    userId,
-    neonDataApiUrl,
-    token
-  );
-}
-
 async function processOperation(
   op: CrudOp,
   userId: string,
@@ -608,26 +373,6 @@ async function processOperation(
   const hasUserId = SYNCED_COLUMNS[table].has("user_id");
   if (hasUserId) {
     record.user_id = userId;
-  }
-
-  // For junction tables (no user_id column), validate that referenced
-  // parent rows belong to the authenticated user before allowing mutations.
-  if (op.op === UpdateType.PUT || op.op === UpdateType.PATCH) {
-    await validateJunctionOwnership(
-      table,
-      record,
-      userId,
-      neonDataApiUrl,
-      token
-    );
-  } else if (op.op === UpdateType.DELETE && JUNCTION_PARENTS[table]) {
-    await validateJunctionDeleteOwnership(
-      table,
-      op.id,
-      userId,
-      neonDataApiUrl,
-      token
-    );
   }
 
   const { query, params } = buildQuery(op.op, table, op.id, record, userId);
@@ -701,9 +446,6 @@ function createNeonConnector(
     // TODO: Batch CRUD operations into fewer HTTP requests when the Neon Data API
     // supports multi-statement transactions. Currently each mutation is a separate
     // request, which adds latency proportional to the number of pending changes.
-    // Junction table ownership validation (validateJunctionOwnership) adds
-    // additional round-trips per mutation — batching should combine these into a
-    // single multi-statement request alongside the mutation itself.
     //
     // Idempotency on retry (PowerSync replays the entire transaction on failure):
     // - PUT: Uses INSERT ... ON CONFLICT (upsert) — fully idempotent.
@@ -746,6 +488,5 @@ export {
   defaultUploadErrorHandler,
   isSqlParam,
   isSyncedTable,
-  JUNCTION_PARENTS,
   validateRecord,
 };

--- a/src/sync/schema.ts
+++ b/src/sync/schema.ts
@@ -37,6 +37,7 @@ const routines = new Table({
 });
 
 const routine_tricks = new Table({
+  user_id: column.text,
   routine_id: column.text,
   trick_id: column.text,
   position: column.integer,
@@ -58,6 +59,7 @@ const practice_sessions = new Table({
 });
 
 const practice_session_tricks = new Table({
+  user_id: column.text,
   practice_session_id: column.text,
   trick_id: column.text,
   repetitions: column.integer,
@@ -103,6 +105,7 @@ const items = new Table({
 });
 
 const item_tricks = new Table({
+  user_id: column.text,
   item_id: column.text,
   trick_id: column.text,
   created_at: column.text,


### PR DESCRIPTION
## Summary

- Add `user_id` column (with FK to `users.id`) to `routine_tricks`, `practice_session_tricks`, and `item_tricks` junction tables
- Migration backfills `user_id` from parent tables, cleans up orphans, then sets `NOT NULL` + FK + partial index
- RLS policies simplified: `USING(user_id = auth.user_id())` for fast reads, `WITH CHECK(user_id + EXISTS on parent FKs)` for write-path defense-in-depth
- PowerSync client schema updated with `user_id` on all 3 junction tables
- Connector simplified: removed `JUNCTION_PARENTS`, `validateJunctionOwnership`, `validateJunctionDeleteOwnership` — junction tables now treated identically to other user-owned tables via `hasUserId` path
- Added PATCH and DELETE tests for junction table `user_id` scoping
- Documented single-migration-file rule for Neon serverless driver in CLAUDE.md

Closes #56

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (432 tests, including 3 new junction table tests)
- [x] `pnpm db:generate` reports no pending schema diff
- [x] `pnpm db:migrate` applies cleanly to Neon
- [x] Two rounds of automated review (security, database, TypeScript, testing) — 0 findings on second pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)