### PR TITLE
chore: automate database migrations in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
       - name: i18n completeness check
         run: pnpm i18n:check
 
+      - name: Check migration drift
+        run: |
+          pnpm db:generate
+          git diff --exit-code src/db/migrations/
+        env:
+          DATABASE_URL: postgresql://unused:unused@localhost:5432/unused
+
       - name: Check generated docs staleness
         run: |
           pnpm docs:generate

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm build"
+  "buildCommand": "pnpm db:migrate && pnpm build"
 }


### PR DESCRIPTION
## Summary

- Add a **migration drift detection** step to CI that runs `drizzle-kit generate` and fails if uncommitted migration files are produced — catches forgotten `pnpm db:generate` before merge.
- Auto-apply pending migrations on **Vercel deploy** by prepending `pnpm db:migrate` to the build command. Safe for all environments since the project uses Neon branching (preview deploys get their own database branch).

## Test plan

- [ ] Push a PR with no schema changes — CI drift check should pass
- [ ] Verify next Vercel deploy log shows `drizzle-kit migrate` output before the Next.js build
- [ ] Optionally test CI failure: temporarily modify a schema column without generating a migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)