### PR TITLE
chore: replace TODO comments with GitHub issue references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     needs: [ci]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # TODO: Remove continue-on-error after E2E stability is confirmed
+    # Remove continue-on-error once E2E tests are stable — see #78
     continue-on-error: true
     # Dummy values — only needed so the dev server starts; not used for real auth
     env:

--- a/src/db/schema/goals.ts
+++ b/src/db/schema/goals.ts
@@ -27,9 +27,8 @@ export const goals = pgTable(
     currentValue: integer("current_value").default(0),
     deadline: date(),
     completedAt: timestamp("completed_at", { withTimezone: true }),
-    // TODO: When implementing database-level updated_at triggers (see GitHub
-    // issue #61), ensure SET NULL cascades also bump updated_at so PowerSync
-    // detects the change.
+    // IMPORTANT: When implementing updated_at triggers (#61), ensure SET NULL
+    // cascades on this FK also bump updated_at so PowerSync detects the change.
     trickId: uuid("trick_id").references(() => tricks.id, {
       onDelete: "set null",
     }),

--- a/src/db/schema/performances.ts
+++ b/src/db/schema/performances.ts
@@ -21,9 +21,8 @@ export const performances = pgTable(
     date: date().notNull(),
     venue: text(),
     eventName: text("event_name"),
-    // TODO: When implementing database-level updated_at triggers (see GitHub
-    // issue #61), ensure SET NULL cascades also bump updated_at so PowerSync
-    // detects the change.
+    // IMPORTANT: When implementing updated_at triggers (#61), ensure SET NULL
+    // cascades on this FK also bump updated_at so PowerSync detects the change.
     routineId: uuid("routine_id").references(() => routines.id, {
       onDelete: "set null",
     }),

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -51,7 +51,7 @@ const BASE_DIRECTIVES: CspDirectives = {
   // script that prevents a flash of unstyled content (FOUC) on page load.
   // next-themes injects an inline <script> in <head> before React hydrates,
   // so we cannot replace this with a nonce or hash without patching the library.
-  // TODO: migrate to nonce-based CSP once next-themes supports it, removing 'unsafe-inline'
+  // Migrate to nonce-based CSP — next-themes v0.4.6+ supports the nonce prop. See #44.
   "script-src": [
     "'self'",
     "'unsafe-inline'",

--- a/src/sync/connector.ts
+++ b/src/sync/connector.ts
@@ -443,9 +443,7 @@ function createNeonConnector(
       throw new Error("Unauthorized: userId is required for mutations");
     }
 
-    // TODO: Batch CRUD operations into fewer HTTP requests when the Neon Data API
-    // supports multi-statement transactions. Currently each mutation is a separate
-    // request, which adds latency proportional to the number of pending changes.
+    // Each mutation is a separate HTTP request — see #59 for batching plan.
     //
     // Idempotency on retry (PowerSync replays the entire transaction on failure):
     // - PUT: Uses INSERT ... ON CONFLICT (upsert) — fully idempotent.


### PR DESCRIPTION
## Summary

- Replaced all 6 TODO comments in the codebase with actionable issue references
- 5 TODOs were already tracked by existing issues (#44, #59, #61); 1 new issue created (#78)
- Updated the CSP TODO to note that `next-themes` v0.4.6 now supports the `nonce` prop, unblocking #44
- Added a cleanup reminder comment to #61 so the `goals.ts` / `performances.ts` warnings get removed when that issue is tackled

### Changes by file

| File | Change |
|------|--------|
| `src/sync/connector.ts` | `TODO` → short context line + `#59` ref (kept idempotency docs) |
| `src/db/schema/goals.ts` | `TODO` → `IMPORTANT` warning + `#61` ref |
| `src/db/schema/performances.ts` | Same as goals.ts |
| `src/lib/csp.ts` | Updated outdated condition — next-themes now supports nonce + `#44` ref |
| `.github/workflows/ci.yml` | `TODO` → `#78` ref |

## Test plan

- [x] No functional code changes — comments only
- [x] `pnpm lint` passes (verified by pre-commit hook)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)