### PR TITLE
chore: enable noUncheckedIndexedAccess for stricter type safety

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -48,5 +48,21 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": [
+        "**/ensure-user.test.ts",
+        "**/email.test.ts",
+        "**/connector.test.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noNonNullAssertion": "off"
+          }
+        }
+      }
+    }
+  ],
   "extends": ["ultracite/biome/core", "ultracite/biome/next"]
 }

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -220,7 +220,10 @@ async function deliverToSubscriptions(
     } else {
       const error: unknown = result.reason;
       if (isWebPushError(error) && error.statusCode === 410) {
-        goneEndpoints.push(subscriptions[i].endpoint);
+        const sub = subscriptions[i];
+        if (sub) {
+          goneEndpoints.push(sub.endpoint);
+        }
       }
       console.error("Failed to send push notification:", error);
     }

--- a/src/auth/ensure-user.test.ts
+++ b/src/auth/ensure-user.test.ts
@@ -168,7 +168,7 @@ describe("ensureUserExists", () => {
     // Invoke the callback captured by after() directly instead of
     // relying on microtask timing
     expect(mockAfter).toHaveBeenCalled();
-    const afterCallback = mockAfter.mock.calls[0][0] as () => Promise<void>;
+    const afterCallback = mockAfter.mock.calls[0]![0] as () => Promise<void>;
     await afterCallback();
 
     expect(mockSendWelcomeEmail).toHaveBeenCalledWith({

--- a/src/auth/ensure-user.ts
+++ b/src/auth/ensure-user.ts
@@ -73,7 +73,7 @@ export async function ensureUserExists(): Promise<void> {
   // New-user detection via Postgres xmax system column:
   // xmax = "0" means the row was just INSERTed (new user).
   // xmax != "0" means the row was UPDATEd via the ON CONFLICT branch (existing user).
-  const isNewUser = result.length > 0 && result[0].xmax === "0";
+  const isNewUser = result.length > 0 && result[0]?.xmax === "0";
 
   if (isNewUser) {
     after(() =>

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -242,7 +242,8 @@ describe("email", () => {
         name: "Houdini",
       });
 
-      const callArgs = mockSend.mock.calls[0][0];
+      expect(mockSend).toHaveBeenCalledOnce();
+      const callArgs = mockSend.mock.calls[0]![0];
       expect(callArgs.html).toContain("Hi Houdini");
     });
 
@@ -263,7 +264,8 @@ describe("email", () => {
         userId: TEST_USER_ID,
       });
 
-      const callArgs = mockSend.mock.calls[0][0];
+      expect(mockSend).toHaveBeenCalledOnce();
+      const callArgs = mockSend.mock.calls[0]![0];
       expect(callArgs.html).toContain("Hi, welcome to The Magic Lab!");
       expect(callArgs.html).not.toMatch(PERSONALIZED_GREETING_PATTERN);
     });
@@ -286,7 +288,8 @@ describe("email", () => {
         name: "Houdini",
       });
 
-      const callArgs = mockSend.mock.calls[0][0];
+      expect(mockSend).toHaveBeenCalledOnce();
+      const callArgs = mockSend.mock.calls[0]![0];
       expect(callArgs.subject).toBe("Welcome to The Magic Lab");
     });
   });
@@ -339,7 +342,8 @@ describe("email", () => {
         userId: TEST_USER_ID,
       });
 
-      const callArgs = mockSend.mock.calls[0][0];
+      expect(mockSend).toHaveBeenCalledOnce();
+      const callArgs = mockSend.mock.calls[0]![0];
       expect(callArgs.headers["List-Unsubscribe"]).toMatch(
         UNSUBSCRIBE_URL_PATTERN
       );
@@ -399,7 +403,8 @@ describe("email", () => {
         html: "<p>Hi</p>",
       });
 
-      const callArgs = mockSend.mock.calls[0][0];
+      expect(mockSend).toHaveBeenCalledOnce();
+      const callArgs = mockSend.mock.calls[0]![0];
       expect(callArgs.to).toBe("delivered@resend.dev");
     });
 

--- a/src/sync/connector.test.ts
+++ b/src/sync/connector.test.ts
@@ -423,7 +423,7 @@ describe("createNeonConnector", () => {
       );
 
       expect(fetchSpy).toHaveBeenCalledOnce();
-      const [url, init] = fetchSpy.mock.calls[0];
+      const [url, init] = fetchSpy.mock.calls[0]!;
       expect(url).toBe("https://neon.example.com");
       const body = JSON.parse((init as RequestInit).body as string) as {
         query: string;
@@ -436,7 +436,8 @@ describe("createNeonConnector", () => {
       expect((init as RequestInit).headers).toEqual(
         expect.objectContaining({ Authorization: "Bearer my-token" })
       );
-      const transaction = await db.getNextCrudTransaction.mock.results[0].value;
+      const transaction =
+        await db.getNextCrudTransaction.mock.results[0]!.value;
       expect(transaction).toEqual(
         expect.objectContaining({
           complete: expect.any(Function),
@@ -466,7 +467,7 @@ describe("createNeonConnector", () => {
         db as unknown as Parameters<typeof connector.uploadData>[0]
       );
 
-      const [, init] = fetchSpy.mock.calls[0];
+      const [, init] = fetchSpy.mock.calls[0]!;
       const body = JSON.parse((init as RequestInit).body as string) as {
         query: string;
         params: unknown[];
@@ -499,7 +500,7 @@ describe("createNeonConnector", () => {
       );
 
       expect(fetchSpy).toHaveBeenCalledOnce();
-      const [, patchInit] = fetchSpy.mock.calls[0];
+      const [, patchInit] = fetchSpy.mock.calls[0]!;
       const body = JSON.parse((patchInit as RequestInit).body as string) as {
         query: string;
         params: unknown[];
@@ -534,7 +535,7 @@ describe("createNeonConnector", () => {
         db as unknown as Parameters<typeof connector.uploadData>[0]
       );
 
-      const [, init] = fetchSpy.mock.calls[0];
+      const [, init] = fetchSpy.mock.calls[0]!;
       const body = JSON.parse((init as RequestInit).body as string) as {
         query: string;
         params: unknown[];
@@ -568,7 +569,7 @@ describe("createNeonConnector", () => {
       );
 
       expect(fetchSpy).toHaveBeenCalledOnce();
-      const [, deleteInit] = fetchSpy.mock.calls[0];
+      const [, deleteInit] = fetchSpy.mock.calls[0]!;
       const body = JSON.parse((deleteInit as RequestInit).body as string) as {
         query: string;
         params: unknown[];
@@ -602,7 +603,8 @@ describe("createNeonConnector", () => {
         db as unknown as Parameters<typeof connector.uploadData>[0]
       );
 
-      const transaction = await db.getNextCrudTransaction.mock.results[0].value;
+      const transaction =
+        await db.getNextCrudTransaction.mock.results[0]!.value;
       expect(transaction.complete).toHaveBeenCalledOnce();
     });
 
@@ -633,7 +635,8 @@ describe("createNeonConnector", () => {
         db as unknown as Parameters<typeof connector.uploadData>[0]
       );
 
-      const transaction = await db.getNextCrudTransaction.mock.results[0].value;
+      const transaction =
+        await db.getNextCrudTransaction.mock.results[0]!.value;
       expect(transaction.complete).toHaveBeenCalledOnce();
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("mutation dropped"),
@@ -667,7 +670,8 @@ describe("createNeonConnector", () => {
         )
       ).rejects.toThrow("Neon Data API error: 500");
 
-      const transaction = await db.getNextCrudTransaction.mock.results[0].value;
+      const transaction =
+        await db.getNextCrudTransaction.mock.results[0]!.value;
       expect(transaction.complete).not.toHaveBeenCalled();
     });
 
@@ -786,7 +790,8 @@ describe("createNeonConnector", () => {
         expect.stringContaining("mutation dropped"),
         expect.stringContaining("409")
       );
-      const transaction = await db.getNextCrudTransaction.mock.results[0].value;
+      const transaction =
+        await db.getNextCrudTransaction.mock.results[0]!.value;
       expect(transaction.complete).toHaveBeenCalledOnce();
     });
 
@@ -839,7 +844,7 @@ describe("createNeonConnector", () => {
 
       // No ownership check round-trips — just the mutation itself
       expect(fetchSpy).toHaveBeenCalledOnce();
-      const [, init] = fetchSpy.mock.calls[0];
+      const [, init] = fetchSpy.mock.calls[0]!;
       const body = JSON.parse((init as RequestInit).body as string) as {
         query: string;
         params: unknown[];
@@ -848,7 +853,8 @@ describe("createNeonConnector", () => {
       expect(body.params).toContain("server-user-id");
       expect(body.params).not.toContain("forged-user-id");
       expect(body.query).toContain('"user_id"');
-      const transaction = await db.getNextCrudTransaction.mock.results[0].value;
+      const transaction =
+        await db.getNextCrudTransaction.mock.results[0]!.value;
       expect(transaction.complete).toHaveBeenCalledOnce();
     });
 
@@ -877,7 +883,7 @@ describe("createNeonConnector", () => {
       );
 
       expect(fetchSpy).toHaveBeenCalledOnce();
-      const [, init] = fetchSpy.mock.calls[0];
+      const [, init] = fetchSpy.mock.calls[0]!;
       const body = JSON.parse((init as RequestInit).body as string) as {
         query: string;
         params: unknown[];
@@ -910,7 +916,7 @@ describe("createNeonConnector", () => {
       );
 
       expect(fetchSpy).toHaveBeenCalledOnce();
-      const [, init] = fetchSpy.mock.calls[0];
+      const [, init] = fetchSpy.mock.calls[0]!;
       const body = JSON.parse((init as RequestInit).body as string) as {
         query: string;
         params: unknown[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary

- Enable `noUncheckedIndexedAccess` in tsconfig, which adds `| undefined` to all indexed access types (`arr[0]`, `obj[key]`, etc.) catching potential undefined access bugs at compile time
- Fix 2 production files with idiomatic narrowing (optional chaining, guard clause)
- Fix 3 test files with non-null assertions on mock data access, scoped biome override for those files only
- Add missing `toHaveBeenCalledOnce()` guards before mock access in email.test.ts

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — clean
- [x] `pnpm test:run` — 49 files, 439 tests pass
- [x] `pnpm build` — verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)