### PR TITLE
fix: add updated_at trigger for FK cascade SET NULL (#62)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -140,7 +140,7 @@ A logged performance or show.
 | date | date | NOT NULL |
 | venue | text | |
 | event_name | text | Show/event name |
-| routine_id | UUID (FK -> routines) | Optional, set null on routine delete |
+| routine_id | UUID (FK -> routines) | Optional, set null on routine delete (trigger bumps `updated_at`) |
 | audience_size | integer | |
 | audience_type | text | `"birthday"`, `"corporate"`, `"other"`, `"private"`, `"street"`, `"theater"`, `"wedding"` |
 | duration_minutes | integer | |
@@ -201,7 +201,7 @@ Practice goals and training objectives.
 | current_value | integer | Default 0 |
 | deadline | date | |
 | completed_at | timestamptz | |
-| trick_id | UUID (FK -> tricks) | Optional, set null on trick delete |
+| trick_id | UUID (FK -> tricks) | Optional, set null on trick delete (trigger bumps `updated_at`) |
 | created_at | timestamptz | NOT NULL, default now() |
 | updated_at | timestamptz | NOT NULL, default now() |
 | deleted_at | timestamptz | Soft-delete |

--- a/docs/sync-engine.md
+++ b/docs/sync-engine.md
@@ -65,6 +65,16 @@ The sync engine uses **Last-Write-Wins (LWW)** with `updated_at` timestamps:
 - PowerSync Cloud handles conflict detection and resolution automatically
 - The LWW strategy is simple and predictable -- suitable for a single-user workspace
 
+## FK Cascade and Sync
+
+When the hard-delete cleanup job permanently removes parent rows (routines, tricks), Postgres `ON DELETE SET NULL` cascades null out the FK columns on child rows (`performances.routine_id`, `goals.trick_id`). These cascades:
+
+1. **Are detected by PowerSync** via the Postgres WAL replication stream
+2. **Bump `updated_at`** via database triggers (`bump_updated_at_on_fk_null`) to ensure correct LWW conflict resolution
+3. **Require no client schema changes** -- PowerSync `column.text` is nullable by default
+
+Without the `updated_at` trigger, a concurrent client write could win the LWW comparison with a stale timestamp, causing the cascade to be silently overwritten.
+
 ## Deletion Strategy
 
 The app uses **soft-delete with tombstones** to ensure reliable sync:

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -521,7 +521,7 @@ A logged performance or show.
 | date | date | NOT NULL |
 | venue | text | |
 | event_name | text | Show/event name |
-| routine_id | UUID (FK -> routines) | Optional, set null on routine delete |
+| routine_id | UUID (FK -> routines) | Optional, set null on routine delete (trigger bumps `updated_at`) |
 | audience_size | integer | |
 | audience_type | text | `"birthday"`, `"corporate"`, `"other"`, `"private"`, `"street"`, `"theater"`, `"wedding"` |
 | duration_minutes | integer | |
@@ -582,7 +582,7 @@ Practice goals and training objectives.
 | current_value | integer | Default 0 |
 | deadline | date | |
 | completed_at | timestamptz | |
-| trick_id | UUID (FK -> tricks) | Optional, set null on trick delete |
+| trick_id | UUID (FK -> tricks) | Optional, set null on trick delete (trigger bumps `updated_at`) |
 | created_at | timestamptz | NOT NULL, default now() |
 | updated_at | timestamptz | NOT NULL, default now() |
 | deleted_at | timestamptz | Soft-delete |
@@ -2072,6 +2072,16 @@ The sync engine uses **Last-Write-Wins (LWW)** with `updated_at` timestamps:
 - When two clients modify the same row, the write with the later `updated_at` wins
 - PowerSync Cloud handles conflict detection and resolution automatically
 - The LWW strategy is simple and predictable -- suitable for a single-user workspace
+
+## FK Cascade and Sync
+
+When the hard-delete cleanup job permanently removes parent rows (routines, tricks), Postgres `ON DELETE SET NULL` cascades null out the FK columns on child rows (`performances.routine_id`, `goals.trick_id`). These cascades:
+
+1. **Are detected by PowerSync** via the Postgres WAL replication stream
+2. **Bump `updated_at`** via database triggers (`bump_updated_at_on_fk_null`) to ensure correct LWW conflict resolution
+3. **Require no client schema changes** -- PowerSync `column.text` is nullable by default
+
+Without the `updated_at` trigger, a concurrent client write could win the LWW comparison with a stale timestamp, causing the cascade to be silently overwritten.
 
 ## Deletion Strategy
 

--- a/src/db/migrations/0007_fk_cascade_updated_at.sql
+++ b/src/db/migrations/0007_fk_cascade_updated_at.sql
@@ -1,0 +1,36 @@
+-- Bump updated_at when a foreign key cascade sets a nullable FK column to NULL.
+-- This ensures PowerSync's LWW conflict resolution works correctly when the
+-- hard-delete cleanup job (#55) triggers ON DELETE SET NULL cascades.
+--
+-- Without this trigger, the cascade modifies the FK column but leaves updated_at
+-- unchanged. A concurrent client write could then win the LWW comparison with a
+-- stale timestamp, causing the server-side cascade to be silently overwritten.
+--
+-- The WHEN clause on each trigger ensures it only fires when the FK column
+-- transitions from non-null to null. The guard inside the function
+-- (NEW.updated_at = OLD.updated_at) prevents double-writes when the application
+-- explicitly nulls the FK and sets updated_at in the same statement.
+
+CREATE OR REPLACE FUNCTION bump_updated_at_on_fk_null()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.updated_at = OLD.updated_at THEN
+    NEW.updated_at = NOW();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+-- performances.routine_id → routines.id (ON DELETE SET NULL)
+CREATE OR REPLACE TRIGGER performances_fk_cascade_updated_at
+  BEFORE UPDATE ON performances
+  FOR EACH ROW
+  WHEN (OLD.routine_id IS NOT NULL AND NEW.routine_id IS NULL)
+  EXECUTE FUNCTION bump_updated_at_on_fk_null();--> statement-breakpoint
+
+-- goals.trick_id → tricks.id (ON DELETE SET NULL)
+CREATE OR REPLACE TRIGGER goals_fk_cascade_updated_at
+  BEFORE UPDATE ON goals
+  FOR EACH ROW
+  WHEN (OLD.trick_id IS NOT NULL AND NEW.trick_id IS NULL)
+  EXECUTE FUNCTION bump_updated_at_on_fk_null();

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1773872305136,
       "tag": "0006_wakeful_nemesis",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1774243200000,
+      "tag": "0007_fk_cascade_updated_at",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/goals.ts
+++ b/src/db/schema/goals.ts
@@ -27,8 +27,7 @@ export const goals = pgTable(
     currentValue: integer("current_value").default(0),
     deadline: date(),
     completedAt: timestamp("completed_at", { withTimezone: true }),
-    // IMPORTANT: When implementing updated_at triggers (#61), ensure SET NULL
-    // cascades on this FK also bump updated_at so PowerSync detects the change.
+    // FK cascade SET NULL bumps updated_at via DB trigger (migration 0007).
     trickId: uuid("trick_id").references(() => tricks.id, {
       onDelete: "set null",
     }),

--- a/src/db/schema/performances.ts
+++ b/src/db/schema/performances.ts
@@ -21,8 +21,7 @@ export const performances = pgTable(
     date: date().notNull(),
     venue: text(),
     eventName: text("event_name"),
-    // IMPORTANT: When implementing updated_at triggers (#61), ensure SET NULL
-    // cascades on this FK also bump updated_at so PowerSync detects the change.
+    // FK cascade SET NULL bumps updated_at via DB trigger (migration 0007).
     routineId: uuid("routine_id").references(() => routines.id, {
       onDelete: "set null",
     }),


### PR DESCRIPTION
## Summary

- Add a Postgres `BEFORE UPDATE` trigger (`bump_updated_at_on_fk_null`) that bumps `updated_at` when an `ON DELETE SET NULL` FK cascade nulls out a foreign key column
- Covers both affected FKs: `performances.routine_id → routines.id` and `goals.trick_id → tricks.id`
- The trigger only fires on non-null → null transitions and includes a guard to avoid double-bumping on normal app writes

Without this trigger, PowerSync's LWW conflict resolution could silently overwrite the cascade because `updated_at` was never bumped by the FK cascade.

### Changes
- **Migration 0007**: trigger function + 2 trigger attachments (idempotent via `CREATE OR REPLACE`)
- **Schema comments**: replaced `IMPORTANT` TODOs with trigger references
- **Docs**: new "FK Cascade and Sync" section in `sync-engine.md`, trigger notes in `data-model.md`
- **Generated**: `llms-full.txt` regenerated

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test:run` — 439/439 tests pass
- [x] `pnpm db:migrate` — migration applied successfully to Neon
- [ ] CI passes

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)