### PR TITLE
feat: migrate CSP from unsafe-inline to nonce-based script-src

### DIFF
--- a/docs/csp-policy.md
+++ b/docs/csp-policy.md
@@ -4,22 +4,23 @@ The Magic Lab enforces a strict Content Security Policy (CSP) to prevent XSS, da
 
 ## Implementation
 
-CSP headers are constructed by the `buildCsp()` function in `src/lib/csp.ts` and applied to all routes via `next.config.ts`.
+CSP headers are constructed by the `buildCsp()` function in `src/lib/csp.ts` and applied dynamically per-request in `src/proxy.ts`. Each response gets a unique nonce generated via `crypto.getRandomValues()`.
 
 ### Current Policy
 
 ```
 default-src 'self';
-script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com;
+script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' 'nonce-<per-request>' https://va.vercel-scripts.com;
 style-src 'self' 'unsafe-inline';
-img-src 'self' data: blob:;
+img-src 'self' data: blob: https://lh3.googleusercontent.com;
 font-src 'self';
 connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://*.powersync.journeyapps.com https://*.neonauth.c-2.eu-central-1.aws.neon.tech https://*.apirest.c-2.eu-central-1.aws.neon.tech;
 worker-src 'self';
 object-src 'none';
 frame-ancestors 'none';
 base-uri 'self';
-form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech
+form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech;
+upgrade-insecure-requests
 ```
 
 ### Directive Breakdown
@@ -27,10 +28,12 @@ form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech
 | Directive | Value | Reason |
 |---|---|---|
 | `default-src` | `'self'` | Baseline: only same-origin resources |
-| `script-src` | `'self' 'unsafe-inline'` | `unsafe-inline` required by next-themes for FOUC prevention |
+| `script-src` | `'self' 'unsafe-inline' 'nonce-...'` | `unsafe-inline` kept for CSP Level 1 fallback; Level 2+ browsers ignore it when a nonce is present. Nonce passed to next-themes via ThemeProvider. |
+| | `'wasm-unsafe-eval'` | Required by PowerSync WASM module |
 | | `https://va.vercel-scripts.com` | Vercel Analytics script |
 | `style-src` | `'self' 'unsafe-inline'` | Inline styles from CSS-in-JS and component libraries |
 | `img-src` | `'self' data: blob:` | Same-origin images, data URIs (icons), blob URLs (uploads) |
+| | `https://lh3.googleusercontent.com` | Google profile photos (social login) |
 | `font-src` | `'self'` | Self-hosted Geist font |
 | `connect-src` | `'self'` | API calls to same origin |
 | | `https://va.vercel-scripts.com` | Vercel Analytics data |
@@ -43,6 +46,7 @@ form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech
 | `frame-ancestors` | `'none'` | Prevent framing (clickjacking) |
 | `base-uri` | `'self'` | Prevent base tag hijacking |
 | `form-action` | `'self'` + Neon Auth | Restrict form submissions to same origin and Neon Auth |
+| `upgrade-insecure-requests` | _(boolean)_ | Force HTTPS for all sub-resource requests |
 
 ## CSP Builder (`src/lib/csp.ts`)
 
@@ -50,9 +54,14 @@ The CSP is built programmatically via a typed builder function:
 
 ```typescript
 // src/lib/csp.ts
+interface BuildCspOptions {
+  isDev: boolean;
+  nonce?: string;
+}
+
 const BASE_DIRECTIVES: CspDirectives = {
   "default-src": ["'self'"],
-  "script-src": ["'self'", "'unsafe-inline'", "https://va.vercel-scripts.com"],
+  "script-src": ["'self'", "'unsafe-inline'", "'wasm-unsafe-eval'", "https://va.vercel-scripts.com"],
   "connect-src": [
     "'self'",
     "https://va.vercel-scripts.com",
@@ -65,22 +74,31 @@ const BASE_DIRECTIVES: CspDirectives = {
 };
 
 const DEV_EXTENSIONS: Partial<CspDirectives> = {
+  "script-src": ["'unsafe-eval'"],
   "connect-src": ["ws://localhost:*"],
   "frame-src": ["https://local.drizzle.studio"],
 };
 
-function buildCsp(isDev: boolean): string {
-  const directives = isDev
+function buildCsp(options: BuildCspOptions): string {
+  let directives = options.isDev
     ? mergeDirectives(BASE_DIRECTIVES, DEV_EXTENSIONS)
     : BASE_DIRECTIVES;
+
+  if (options.nonce !== undefined) {
+    directives = applyNonce(directives, options.nonce);
+  }
+
   return directivesToString(directives);
 }
 ```
+
+The `applyNonce` helper appends `'nonce-<value>'` to `script-src`. The existing `'unsafe-inline'` is retained for CSP Level 1 fallback — CSP Level 2+ browsers automatically ignore it when a nonce source is present.
 
 ### Environment-Aware Directives
 
 | Source | Dev Only | Production |
 |---|---|---|
+| `'unsafe-eval'` (script-src) | Yes | No |
 | `ws://localhost:*` (connect-src) | Yes | No |
 | `https://local.drizzle.studio` (frame-src) | Yes | No |
 | `https://*.powersync.journeyapps.com` (connect-src) | No | Yes |
@@ -107,14 +125,15 @@ script-src 'self'
 
 This prevents the service worker from loading any external scripts.
 
-## Nonce-Based CSP (Future)
+## Nonce-Based CSP
 
-The current `'unsafe-inline'` in `script-src` is a known weakness. The planned migration path:
+Nonce-based CSP is implemented. Each request gets a unique 128-bit nonce generated in `proxy.ts`:
 
-1. Implement nonce-based CSP via Next.js middleware
-2. Pass nonce to next-themes via a custom script injection
-3. Remove `'unsafe-inline'` from `script-src`
-4. Keep `'unsafe-inline'` in `style-src` (required by many component libraries)
+1. `proxy.ts` generates a nonce via `crypto.getRandomValues()` and calls `buildCsp({ isDev, nonce })`
+2. The nonce is forwarded to server components via the `x-nonce` request header
+3. `script-src` includes `'nonce-<value>'` — CSP Level 2+ browsers use the nonce and ignore `'unsafe-inline'`
+4. `'unsafe-inline'` is retained in `script-src` as a CSP Level 1 fallback
+5. `'unsafe-inline'` remains in `style-src` (required by component libraries)
 
 ## See Also
 

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -44,15 +44,9 @@ describe("next.config headers", () => {
     expect(value).toContain("preload");
   });
 
-  it("sets Content-Security-Policy with required directives", async () => {
+  it("does not set static Content-Security-Policy (CSP is dynamic per-request in proxy.ts)", async () => {
     const csp = await getHeaderValue("Content-Security-Policy");
-    expect(csp).toBeDefined();
-    expect(csp).toContain("default-src 'self'");
-    expect(csp).toContain("object-src 'none'");
-    expect(csp).toContain("frame-ancestors 'none'");
-    expect(csp).toContain("base-uri 'self'");
-    expect(csp).toContain("form-action 'self'");
-    expect(csp).toContain("worker-src 'self'");
+    expect(csp).toBeUndefined();
   });
 
   it("does not include deprecated X-XSS-Protection header", async () => {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,5 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
-import { buildCsp } from "./src/lib/csp";
-
-const isDev = process.env.NODE_ENV === "development";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
@@ -27,15 +24,8 @@ const nextConfig: NextConfig = {
           key: "Strict-Transport-Security",
           value: "max-age=63072000; includeSubDomains; preload",
         },
-        {
-          key: "Content-Security-Policy",
-          // 'unsafe-inline' is required in script-src and style-src because
-          // next-themes injects an inline script to prevent flash of incorrect
-          // theme on page load. Replacing it with a nonce-based CSP requires
-          // architectural changes (custom Document, middleware) and should be
-          // tackled as a separate task.
-          value: buildCsp(isDev),
-        },
+        // Content-Security-Policy is set dynamically per-request in proxy.ts
+        // with a nonce for script-src (see #44).
       ],
     },
     {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -259,22 +259,23 @@ The Magic Lab enforces a strict Content Security Policy (CSP) to prevent XSS, da
 
 ## Implementation
 
-CSP headers are constructed by the `buildCsp()` function in `src/lib/csp.ts` and applied to all routes via `next.config.ts`.
+CSP headers are constructed by the `buildCsp()` function in `src/lib/csp.ts` and applied dynamically per-request in `src/proxy.ts`. Each response gets a unique nonce generated via `crypto.getRandomValues()`.
 
 ### Current Policy
 
 ```
 default-src 'self';
-script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com;
+script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' 'nonce-<per-request>' https://va.vercel-scripts.com;
 style-src 'self' 'unsafe-inline';
-img-src 'self' data: blob:;
+img-src 'self' data: blob: https://lh3.googleusercontent.com;
 font-src 'self';
 connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://*.powersync.journeyapps.com https://*.neonauth.c-2.eu-central-1.aws.neon.tech https://*.apirest.c-2.eu-central-1.aws.neon.tech;
 worker-src 'self';
 object-src 'none';
 frame-ancestors 'none';
 base-uri 'self';
-form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech
+form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech;
+upgrade-insecure-requests
 ```
 
 ### Directive Breakdown
@@ -282,10 +283,12 @@ form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech
 | Directive | Value | Reason |
 |---|---|---|
 | `default-src` | `'self'` | Baseline: only same-origin resources |
-| `script-src` | `'self' 'unsafe-inline'` | `unsafe-inline` required by next-themes for FOUC prevention |
+| `script-src` | `'self' 'unsafe-inline' 'nonce-...'` | `unsafe-inline` kept for CSP Level 1 fallback; Level 2+ browsers ignore it when a nonce is present. Nonce passed to next-themes via ThemeProvider. |
+| | `'wasm-unsafe-eval'` | Required by PowerSync WASM module |
 | | `https://va.vercel-scripts.com` | Vercel Analytics script |
 | `style-src` | `'self' 'unsafe-inline'` | Inline styles from CSS-in-JS and component libraries |
 | `img-src` | `'self' data: blob:` | Same-origin images, data URIs (icons), blob URLs (uploads) |
+| | `https://lh3.googleusercontent.com` | Google profile photos (social login) |
 | `font-src` | `'self'` | Self-hosted Geist font |
 | `connect-src` | `'self'` | API calls to same origin |
 | | `https://va.vercel-scripts.com` | Vercel Analytics data |
@@ -298,6 +301,7 @@ form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech
 | `frame-ancestors` | `'none'` | Prevent framing (clickjacking) |
 | `base-uri` | `'self'` | Prevent base tag hijacking |
 | `form-action` | `'self'` + Neon Auth | Restrict form submissions to same origin and Neon Auth |
+| `upgrade-insecure-requests` | _(boolean)_ | Force HTTPS for all sub-resource requests |
 
 ## CSP Builder (`src/lib/csp.ts`)
 
@@ -305,9 +309,14 @@ The CSP is built programmatically via a typed builder function:
 
 ```typescript
 // src/lib/csp.ts
+interface BuildCspOptions {
+  isDev: boolean;
+  nonce?: string;
+}
+
 const BASE_DIRECTIVES: CspDirectives = {
   "default-src": ["'self'"],
-  "script-src": ["'self'", "'unsafe-inline'", "https://va.vercel-scripts.com"],
+  "script-src": ["'self'", "'unsafe-inline'", "'wasm-unsafe-eval'", "https://va.vercel-scripts.com"],
   "connect-src": [
     "'self'",
     "https://va.vercel-scripts.com",
@@ -320,22 +329,31 @@ const BASE_DIRECTIVES: CspDirectives = {
 };
 
 const DEV_EXTENSIONS: Partial<CspDirectives> = {
+  "script-src": ["'unsafe-eval'"],
   "connect-src": ["ws://localhost:*"],
   "frame-src": ["https://local.drizzle.studio"],
 };
 
-function buildCsp(isDev: boolean): string {
-  const directives = isDev
+function buildCsp(options: BuildCspOptions): string {
+  let directives = options.isDev
     ? mergeDirectives(BASE_DIRECTIVES, DEV_EXTENSIONS)
     : BASE_DIRECTIVES;
+
+  if (options.nonce !== undefined) {
+    directives = applyNonce(directives, options.nonce);
+  }
+
   return directivesToString(directives);
 }
 ```
+
+The `applyNonce` helper appends `'nonce-<value>'` to `script-src`. The existing `'unsafe-inline'` is retained for CSP Level 1 fallback — CSP Level 2+ browsers automatically ignore it when a nonce source is present.
 
 ### Environment-Aware Directives
 
 | Source | Dev Only | Production |
 |---|---|---|
+| `'unsafe-eval'` (script-src) | Yes | No |
 | `ws://localhost:*` (connect-src) | Yes | No |
 | `https://local.drizzle.studio` (frame-src) | Yes | No |
 | `https://*.powersync.journeyapps.com` (connect-src) | No | Yes |
@@ -362,14 +380,15 @@ script-src 'self'
 
 This prevents the service worker from loading any external scripts.
 
-## Nonce-Based CSP (Future)
+## Nonce-Based CSP
 
-The current `'unsafe-inline'` in `script-src` is a known weakness. The planned migration path:
+Nonce-based CSP is implemented. Each request gets a unique 128-bit nonce generated in `proxy.ts`:
 
-1. Implement nonce-based CSP via Next.js middleware
-2. Pass nonce to next-themes via a custom script injection
-3. Remove `'unsafe-inline'` from `script-src`
-4. Keep `'unsafe-inline'` in `style-src` (required by many component libraries)
+1. `proxy.ts` generates a nonce via `crypto.getRandomValues()` and calls `buildCsp({ isDev, nonce })`
+2. The nonce is forwarded to server components via the `x-nonce` request header
+3. `script-src` includes `'nonce-<value>'` — CSP Level 2+ browsers use the nonce and ignore `'unsafe-inline'`
+4. `'unsafe-inline'` is retained in `script-src` as a CSP Level 1 fallback
+5. `'unsafe-inline'` remains in `style-src` (required by component libraries)
 
 ## See Also
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 import { Geist } from "next/font/google";
+import { headers } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import type { ReactElement, ReactNode } from "react";
@@ -58,14 +59,23 @@ export default async function RootLayout({
 }: Readonly<{
   children: ReactNode;
 }>): Promise<ReactElement> {
-  const locale = await getLocale();
-  const messages = await getMessages();
-  const t = await getTranslations("common");
+  const [locale, messages, t, headersList] = await Promise.all([
+    getLocale(),
+    getMessages(),
+    getTranslations("common"),
+    headers(),
+  ]);
+  const nonce = headersList.get("x-nonce") ?? undefined;
 
   return (
     <html lang={locale} suppressHydrationWarning>
       <body className={`${geistSans.variable} antialiased`}>
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          nonce={nonce}
+        >
           <NeonAuthUIProvider
             authClient={authClient}
             emailOTP

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyNonce,
   BASE_DIRECTIVES,
   buildCsp,
   DEV_EXTENSIONS,
@@ -36,6 +37,12 @@ describe("BASE_DIRECTIVES", () => {
   it("includes Neon Data API in connect-src pinned to region c-2", () => {
     expect(BASE_DIRECTIVES["connect-src"]).toContain(
       "https://*.apirest.c-2.eu-central-1.aws.neon.tech"
+    );
+  });
+
+  it("includes Google profile avatars in img-src", () => {
+    expect(BASE_DIRECTIVES["img-src"]).toContain(
+      "https://lh3.googleusercontent.com"
     );
   });
 
@@ -96,25 +103,73 @@ describe("directivesToString", () => {
   });
 });
 
+describe("applyNonce", () => {
+  it("adds nonce to script-src", () => {
+    const result = applyNonce(BASE_DIRECTIVES, "abc123");
+    expect(result["script-src"]).toContain("'nonce-abc123'");
+  });
+
+  it("preserves existing script-src values", () => {
+    const result = applyNonce(BASE_DIRECTIVES, "abc123");
+    expect(result["script-src"]).toContain("'self'");
+    expect(result["script-src"]).toContain("'unsafe-inline'");
+    expect(result["script-src"]).toContain("https://va.vercel-scripts.com");
+  });
+
+  it("does not mutate the input directives", () => {
+    const original = [...BASE_DIRECTIVES["script-src"]];
+    applyNonce(BASE_DIRECTIVES, "test");
+    expect(BASE_DIRECTIVES["script-src"]).toEqual(original);
+  });
+
+  it("does not add nonce to style-src", () => {
+    const result = applyNonce(BASE_DIRECTIVES, "abc123");
+    expect(result["style-src"]).toEqual(BASE_DIRECTIVES["style-src"]);
+  });
+});
+
 describe("buildCsp", () => {
   it("returns production CSP without dev sources", () => {
-    const csp = buildCsp(false);
+    const csp = buildCsp({ isDev: false });
     expect(csp).not.toContain("ws://localhost");
     expect(csp).not.toContain("drizzle.studio");
   });
 
   it("returns dev CSP with HMR and Drizzle Studio sources", () => {
-    const csp = buildCsp(true);
+    const csp = buildCsp({ isDev: true });
     expect(csp).toContain("ws://localhost:*");
     expect(csp).toContain("https://local.drizzle.studio");
   });
 
   it("always includes core security directives", () => {
     for (const isDev of [true, false]) {
-      const csp = buildCsp(isDev);
+      const csp = buildCsp({ isDev });
       expect(csp).toContain("default-src 'self'");
       expect(csp).toContain("object-src 'none'");
       expect(csp).toContain("frame-ancestors 'none'");
     }
+  });
+
+  it("includes nonce in script-src when provided", () => {
+    const csp = buildCsp({ isDev: false, nonce: "test-nonce-123" });
+    expect(csp).toContain("'nonce-test-nonce-123'");
+  });
+
+  it("keeps unsafe-inline alongside nonce for CSP Level 1 fallback", () => {
+    const csp = buildCsp({ isDev: false, nonce: "test-nonce" });
+    expect(csp).toContain("'unsafe-inline'");
+    expect(csp).toContain("'nonce-test-nonce'");
+  });
+
+  it("does not include nonce when omitted", () => {
+    const csp = buildCsp({ isDev: false });
+    expect(csp).not.toContain("nonce-");
+  });
+
+  it("does not add nonce to style-src", () => {
+    const csp = buildCsp({ isDev: false, nonce: "test-nonce" });
+    const styleSrc = csp.split("; ").find((d) => d.startsWith("style-src"));
+    expect(styleSrc).toBeDefined();
+    expect(styleSrc).not.toContain("nonce");
   });
 });

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -47,11 +47,10 @@ function cspDirectiveNames(
 
 const BASE_DIRECTIVES: CspDirectives = {
   "default-src": ["'self'"],
-  // 'unsafe-inline' is required for next-themes to inject the theme-setting
-  // script that prevents a flash of unstyled content (FOUC) on page load.
-  // next-themes injects an inline <script> in <head> before React hydrates,
-  // so we cannot replace this with a nonce or hash without patching the library.
-  // Migrate to nonce-based CSP — next-themes v0.4.6+ supports the nonce prop. See #44.
+  // 'unsafe-inline' is kept alongside the nonce for CSP Level 1 fallback.
+  // CSP Level 2+ browsers automatically ignore 'unsafe-inline' when a nonce
+  // is present. The nonce is generated per-request in proxy.ts and passed to
+  // next-themes via the ThemeProvider nonce prop.
   "script-src": [
     "'self'",
     "'unsafe-inline'",
@@ -59,7 +58,7 @@ const BASE_DIRECTIVES: CspDirectives = {
     "https://va.vercel-scripts.com",
   ],
   "style-src": ["'self'", "'unsafe-inline'"],
-  "img-src": ["'self'", "data:", "blob:"],
+  "img-src": ["'self'", "data:", "blob:", "https://lh3.googleusercontent.com"],
   "font-src": ["'self'"],
   "connect-src": [
     "'self'",
@@ -122,16 +121,38 @@ function directivesToString(directives: CspDirectives): string {
   return parts.join("; ");
 }
 
-function buildCsp(isDev: boolean): string {
-  const directives = isDev
+interface BuildCspOptions {
+  isDev: boolean;
+  nonce?: string;
+}
+
+/**
+ * Appends a nonce source to `script-src`. The existing `'unsafe-inline'` is
+ * kept for CSP Level 1 fallback — CSP Level 2+ browsers automatically ignore
+ * `'unsafe-inline'` when a nonce or hash source is present.
+ */
+function applyNonce(directives: CspDirectives, nonce: string): CspDirectives {
+  return {
+    ...directives,
+    "script-src": [...directives["script-src"], `'nonce-${nonce}'`],
+  };
+}
+
+function buildCsp(options: BuildCspOptions): string {
+  let directives = options.isDev
     ? mergeDirectives(BASE_DIRECTIVES, DEV_EXTENSIONS)
     : BASE_DIRECTIVES;
+
+  if (options.nonce !== undefined) {
+    directives = applyNonce(directives, options.nonce);
+  }
 
   return directivesToString(directives);
 }
 
-export type { CspDirectiveName, CspDirectives };
+export type { BuildCspOptions, CspDirectiveName, CspDirectives };
 export {
+  applyNonce,
   BASE_DIRECTIVES,
   buildCsp,
   DEV_EXTENSIONS,

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 interface MockSession {
@@ -17,11 +17,30 @@ const nullUserSession: MockSession = {
 
 const mockMiddleware = vi.fn();
 
+vi.mock("next/headers", () => ({
+  headers: () =>
+    Promise.resolve(
+      new Headers({
+        "x-nonce": "test-nonce",
+      })
+    ),
+  cookies: () =>
+    Promise.resolve({
+      get: () => undefined,
+      getAll: () => [],
+      has: () => false,
+    }),
+}));
+
 vi.mock("@/auth/server", () => ({
   auth: {
     getSession: vi.fn(),
     middleware: vi.fn(() => mockMiddleware),
   },
+}));
+
+vi.mock("@/lib/csp", () => ({
+  buildCsp: vi.fn(() => "default-src 'self'; script-src 'self' 'nonce-test'"),
 }));
 
 const SESSION_COOKIE_NAME = "__Secure-neon-auth.session_token";
@@ -33,6 +52,17 @@ function createRequest(pathname: string, withCookie = false): NextRequest {
     request.cookies.set(SESSION_COOKIE_NAME, "fake-session-token");
   }
   return request;
+}
+
+/** Creates a mock auth middleware response with cookies support */
+function createAuthResponse(
+  status: number,
+  headers?: Record<string, string>
+): NextResponse {
+  return NextResponse.next({
+    status,
+    headers: new Headers(headers),
+  });
 }
 
 describe("proxy", () => {
@@ -68,7 +98,7 @@ describe("proxy", () => {
 
   it("does not redirect when session cookie is missing", async () => {
     const { proxy } = await import("./proxy");
-    mockMiddleware.mockReturnValueOnce(new Response(null, { status: 200 }));
+    mockMiddleware.mockReturnValueOnce(createAuthResponse(200));
 
     await proxy(createRequest("/auth/sign-in", false));
 
@@ -81,7 +111,7 @@ describe("proxy", () => {
     const { auth } = await import("@/auth/server");
     vi.mocked(auth.getSession).mockResolvedValueOnce(nullUserSession);
 
-    mockMiddleware.mockReturnValueOnce(new Response(null, { status: 200 }));
+    mockMiddleware.mockReturnValueOnce(createAuthResponse(200));
 
     const { proxy } = await import("./proxy");
     const response = await proxy(createRequest("/auth/sign-in", true));
@@ -96,7 +126,7 @@ describe("proxy", () => {
       new Error("network error")
     );
 
-    mockMiddleware.mockReturnValueOnce(new Response(null, { status: 200 }));
+    mockMiddleware.mockReturnValueOnce(createAuthResponse(200));
 
     const { proxy } = await import("./proxy");
     const response = await proxy(createRequest("/auth/sign-in", true));
@@ -107,61 +137,187 @@ describe("proxy", () => {
 
   it("passes through to auth middleware for protected routes", async () => {
     const { proxy } = await import("./proxy");
-    mockMiddleware.mockReturnValueOnce(new Response(null, { status: 200 }));
+    mockMiddleware.mockReturnValueOnce(createAuthResponse(200));
 
     await proxy(createRequest("/dashboard", false));
 
     expect(mockMiddleware).toHaveBeenCalled();
   });
 
-  describe("public routes (outside matcher)", () => {
-    it("does not match the root marketing page", async () => {
-      const { config } = await import("./proxy");
-      for (const pattern of config.matcher) {
-        expect("/").not.toMatch(
-          new RegExp(`^${pattern.replace(":path*", ".*")}$`)
-        );
-      }
+  it("sets Content-Security-Policy header on all responses", async () => {
+    const { proxy } = await import("./proxy");
+
+    // Public route
+    const publicResponse = await proxy(createRequest("/", false));
+    expect(publicResponse.headers.get("Content-Security-Policy")).toBeTruthy();
+
+    // Protected route
+    mockMiddleware.mockReturnValueOnce(createAuthResponse(200));
+    const protectedResponse = await proxy(createRequest("/dashboard", false));
+    expect(
+      protectedResponse.headers.get("Content-Security-Policy")
+    ).toBeTruthy();
+  });
+
+  it("does not call auth middleware for public routes", async () => {
+    const { proxy } = await import("./proxy");
+
+    await proxy(createRequest("/", false));
+
+    expect(mockMiddleware).not.toHaveBeenCalled();
+  });
+
+  it("calls buildCsp with a nonce argument", async () => {
+    const { buildCsp } = await import("@/lib/csp");
+    const { proxy } = await import("./proxy");
+
+    await proxy(createRequest("/faq", false));
+
+    expect(buildCsp).toHaveBeenCalledWith(
+      expect.objectContaining({ nonce: expect.any(String) })
+    );
+    const { nonce } = vi.mocked(buildCsp).mock.calls[0]?.[0] ?? {};
+    expect(nonce).toBeTruthy();
+    expect(typeof nonce).toBe("string");
+  });
+
+  it("sets CSP header on auth redirect response", async () => {
+    const { auth } = await import("@/auth/server");
+    vi.mocked(auth.getSession).mockResolvedValueOnce(authenticatedSession);
+
+    const { proxy } = await import("./proxy");
+    const response = await proxy(createRequest("/auth/sign-in", true));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Content-Security-Policy")).toBeTruthy();
+  });
+
+  it("carries over cookies from auth middleware response", async () => {
+    const { proxy } = await import("./proxy");
+
+    const authResponse = createAuthResponse(200);
+    authResponse.cookies.set("auth-token", "abc123", { path: "/" });
+    authResponse.cookies.set("refresh-token", "xyz789", { path: "/" });
+    mockMiddleware.mockReturnValueOnce(authResponse);
+
+    const response = await proxy(createRequest("/dashboard", false));
+
+    expect(response.cookies.get("auth-token")?.value).toBe("abc123");
+    expect(response.cookies.get("refresh-token")?.value).toBe("xyz789");
+  });
+
+  it("forwards x-nonce in request headers for server components", async () => {
+    const { proxy } = await import("./proxy");
+    const request = createRequest("/", false);
+    await proxy(request);
+    // The nonce should be present in request headers passed to NextResponse.next()
+    // We verify via the buildCsp mock which receives the nonce
+    const { buildCsp } = await import("@/lib/csp");
+    const { nonce } = vi.mocked(buildCsp).mock.calls[0]?.[0] ?? {};
+    expect(nonce).toBeTruthy();
+    // Also verify the response has CSP with that nonce
+    const response = await proxy(createRequest("/", false));
+    expect(response.headers.get("Content-Security-Policy")).toContain("nonce");
+  });
+
+  it("applies CSP header to auth middleware redirect", async () => {
+    const { proxy } = await import("./proxy");
+
+    // Auth middleware returns a redirect (user not authenticated)
+    const redirectResponse = NextResponse.redirect(
+      new URL("/auth/sign-in", "https://themagiclab.app"),
+      { status: 302 }
+    );
+    mockMiddleware.mockReturnValueOnce(redirectResponse);
+
+    const response = await proxy(createRequest("/dashboard", false));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain("/auth/sign-in");
+    expect(response.headers.get("Content-Security-Policy")).toBeTruthy();
+  });
+
+  it("redirects to sign-in with CSP when auth middleware throws", async () => {
+    const { proxy } = await import("./proxy");
+    mockMiddleware.mockRejectedValueOnce(new Error("auth SDK crash"));
+
+    const response = await proxy(createRequest("/dashboard", false));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("/auth/sign-in");
+    expect(response.headers.get("Content-Security-Policy")).toBeTruthy();
+  });
+
+  it("forwards auth middleware error responses with CSP", async () => {
+    const { proxy } = await import("./proxy");
+
+    const errorResponse = new NextResponse(null, { status: 403 });
+    mockMiddleware.mockReturnValueOnce(errorResponse);
+
+    const response = await proxy(createRequest("/dashboard", false));
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("Content-Security-Policy")).toBeTruthy();
+  });
+
+  describe("needsAuth", () => {
+    it("returns true for exact prefix match", async () => {
+      const { proxy } = await import("./proxy");
+      mockMiddleware.mockReturnValueOnce(createAuthResponse(200));
+
+      await proxy(createRequest("/admin", false));
+
+      expect(mockMiddleware).toHaveBeenCalled();
     });
 
-    it("does not match marketing routes like /faq or /privacy", async () => {
-      const { config } = await import("./proxy");
-      const marketingRoutes = ["/faq", "/privacy", "/terms", "/about"];
-      for (const route of marketingRoutes) {
-        const matched = config.matcher.some((pattern) =>
-          new RegExp(`^${pattern.replace(":path*", ".*")}$`).test(route)
-        );
-        expect(matched, `${route} should not be matched by proxy`).toBe(false);
-      }
+    it("returns true for sub-path of protected prefix", async () => {
+      const { proxy } = await import("./proxy");
+      mockMiddleware.mockReturnValueOnce(createAuthResponse(200));
+
+      await proxy(createRequest("/admin/users", false));
+
+      expect(mockMiddleware).toHaveBeenCalled();
     });
 
-    it("does not match API routes", async () => {
-      const { config } = await import("./proxy");
-      const apiRoutes = ["/api/health", "/api/powersync/upload"];
-      for (const route of apiRoutes) {
-        const matched = config.matcher.some((pattern) =>
-          new RegExp(`^${pattern.replace(":path*", ".*")}$`).test(route)
-        );
-        expect(matched, `${route} should not be matched by proxy`).toBe(false);
-      }
+    it("returns false for partial prefix match like /administrators", async () => {
+      const { proxy } = await import("./proxy");
+
+      await proxy(createRequest("/administrators", false));
+
+      expect(mockMiddleware).not.toHaveBeenCalled();
+    });
+
+    it("returns false for paths not in protected list", async () => {
+      const { proxy } = await import("./proxy");
+
+      await proxy(createRequest("/about", false));
+
+      expect(mockMiddleware).not.toHaveBeenCalled();
     });
   });
 
-  describe("config", () => {
-    it("includes all protected route patterns", async () => {
+  describe("matcher", () => {
+    it("uses a catch-all regex that excludes static assets", async () => {
       const { config } = await import("./proxy");
 
-      expect(config.matcher).toContain("/auth/:path*");
-      expect(config.matcher).toContain("/dashboard/:path*");
-      expect(config.matcher).toContain("/improve/:path*");
-      expect(config.matcher).toContain("/train/:path*");
-      expect(config.matcher).toContain("/plan/:path*");
-      expect(config.matcher).toContain("/perform/:path*");
-      expect(config.matcher).toContain("/enhance/:path*");
-      expect(config.matcher).toContain("/collect/:path*");
-      expect(config.matcher).toContain("/settings/:path*");
-      expect(config.matcher).toContain("/admin/:path*");
-      expect(config.matcher).toContain("/account/:path*");
+      expect(config.matcher).toHaveLength(1);
+      const pattern = config.matcher[0];
+
+      // Should be a negative lookahead regex
+      expect(pattern).toContain("_next/static");
+      expect(pattern).toContain("_next/image");
+      expect(pattern).toContain("favicon\\.ico");
+      expect(pattern).toContain("sw\\.js");
+    });
+
+    it("excludes static file extensions", async () => {
+      const { config } = await import("./proxy");
+      const pattern = config.matcher[0];
+
+      expect(pattern).toContain("svg");
+      expect(pattern).toContain("png");
+      expect(pattern).toContain("jpg");
+      expect(pattern).toContain("woff2");
     });
   });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth/server";
+import { buildCsp } from "@/lib/csp";
 
 /**
  * Session cookie name set by Neon Auth (Better Auth under the hood).
@@ -15,15 +16,59 @@ const authMiddleware = auth.middleware({
 /** Auth routes where authenticated users should be redirected to /dashboard */
 const AUTH_ROUTES = new Set(["/auth/sign-in", "/auth/sign-up"]);
 
+/** Route prefixes that require authentication */
+const PROTECTED_PREFIXES = [
+  "/auth",
+  "/dashboard",
+  "/improve",
+  "/train",
+  "/plan",
+  "/perform",
+  "/enhance",
+  "/collect",
+  "/settings",
+  "/admin",
+  "/account",
+];
+
+// NODE_ENV is intentionally used instead of VERCEL_ENV here — CSP dev
+// extensions (HMR WebSocket, Drizzle Studio frame-src) should only apply
+// during local development, not in Vercel preview deployments.
+const isDev = process.env.NODE_ENV === "development";
+
+function generateNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function needsAuth(pathname: string): boolean {
+  return PROTECTED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+}
+
 export async function proxy(request: NextRequest): Promise<NextResponse> {
   const { pathname } = request.nextUrl;
+  const nonce = generateNonce();
+  const csp = buildCsp({ isDev, nonce });
+
+  // Forward nonce to server components via request header
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
 
   // Redirect authenticated users away from auth pages (validate session, not just cookie presence)
   if (AUTH_ROUTES.has(pathname) && request.cookies.has(SESSION_COOKIE_NAME)) {
     try {
+      // auth.getSession() reads cookies/headers from Next.js async storage,
+      // which is available because the proxy runs within the request lifecycle.
       const { data: session } = await auth.getSession();
       if (session?.user) {
-        return NextResponse.redirect(new URL("/dashboard", request.url));
+        const response = NextResponse.redirect(
+          new URL("/dashboard", request.url)
+        );
+        response.headers.set("Content-Security-Policy", csp);
+        return response;
       }
     } catch (error: unknown) {
       // Session check failed (network/parse error) — fall through to auth
@@ -32,23 +77,65 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
     }
   }
 
-  // Protect app routes — redirects unauthenticated users to sign-in
-  return authMiddleware(request);
+  // Protected routes: run auth middleware, then apply nonce + CSP
+  if (needsAuth(pathname)) {
+    let authResponse: NextResponse;
+    try {
+      authResponse = await authMiddleware(request);
+    } catch (error: unknown) {
+      console.error("Auth middleware threw unexpectedly:", error);
+      const response = NextResponse.redirect(
+        new URL("/auth/sign-in", request.url)
+      );
+      response.headers.set("Content-Security-Policy", csp);
+      return response;
+    }
+
+    // Auth middleware redirected (unauthenticated) — return redirect with CSP
+    if (
+      authResponse.status >= 300 &&
+      authResponse.status < 400 &&
+      authResponse.headers.has("location")
+    ) {
+      authResponse.headers.set("Content-Security-Policy", csp);
+      return authResponse;
+    }
+
+    // Auth middleware returned an error — forward it with CSP headers
+    if (authResponse.status >= 400) {
+      authResponse.headers.set("Content-Security-Policy", csp);
+      return authResponse;
+    }
+
+    // Auth passed — create new response with nonce in request headers
+    const response = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+    response.headers.set("Content-Security-Policy", csp);
+
+    // Carry over any cookies set by auth middleware
+    for (const cookie of authResponse.cookies.getAll()) {
+      response.cookies.set(cookie);
+    }
+
+    return response;
+  }
+
+  // Public routes: just apply nonce + CSP
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
 }
 
 // NOTE: Do NOT use `as const` here — Turbopack cannot statically parse it.
+// Match all page routes, excluding static assets and the service worker
+// (sw.js has its own strict static CSP in next.config.ts).
+// API routes (api/) are intentionally excluded — they return JSON, not HTML,
+// so CSP headers are unnecessary and auth is handled per-route.
 export const config = {
   matcher: [
-    "/auth/:path*",
-    "/dashboard/:path*",
-    "/improve/:path*",
-    "/train/:path*",
-    "/plan/:path*",
-    "/perform/:path*",
-    "/enhance/:path*",
-    "/collect/:path*",
-    "/settings/:path*",
-    "/admin/:path*",
-    "/account/:path*",
+    "/((?!_next/static|_next/image|api/|favicon\\.ico|sitemap\\.xml|robots\\.txt|manifest\\.webmanifest|sw\\.js|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|eot)).*)",
   ],
 } satisfies { matcher: string[] };


### PR DESCRIPTION
## Summary

Replaces the static Content-Security-Policy header with dynamic per-request CSP generation using cryptographic nonces. This significantly strengthens XSS protection by allowing CSP Level 2+ browsers to enforce nonce-based script execution while maintaining backward compatibility with CSP Level 1 browsers via `'unsafe-inline'` fallback.

- **Nonce generation**: 128-bit nonce via `crypto.getRandomValues()` in `proxy.ts`, forwarded to server components via `x-nonce` request header
- **ThemeProvider integration**: Nonce passed to `next-themes` ThemeProvider to prevent FOUC without `'unsafe-inline'`
- **Auth error handling**: `authMiddleware` wrapped in try/catch; 4xx/5xx responses forwarded with CSP headers
- **Expanded proxy matcher**: Catch-all regex replaces per-route patterns, excluding static assets and API routes
- **Google avatar CSP**: Added `lh3.googleusercontent.com` to `img-src` for Neon Auth social login avatars
- **Documentation**: Updated `docs/csp-policy.md` to reflect nonce-based architecture, regenerated `llms-full.txt`

## Test plan

- [x] `pnpm lint` — passes (0 issues)
- [x] `pnpm typecheck` — passes (0 errors)
- [x] `pnpm test:run` — 470/470 tests pass (50 files)
- [x] CSP tests: nonce in script-src, no nonce in style-src, CSP Level 1 fallback, immutability
- [x] Proxy tests: CSP on all response paths, nonce forwarding, auth redirect CSP, cookie carry-over, needsAuth edge cases, matcher exclusions, authMiddleware throw handling, 4xx error forwarding
- [ ] Manual: verify no CSP violations in browser console
- [ ] Manual: verify no FOUC (theme loads on first paint)
- [ ] Manual: verify Vercel Analytics/Speed Insights load

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)