### PR TITLE
chore: add PowerSync agent skill and MCP docs server

### DIFF
--- a/.claude/skills/powersync/AGENTS.md
+++ b/.claude/skills/powersync/AGENTS.md
@@ -1,0 +1,234 @@
+# PowerSync Skills
+
+Use this skill to onboard a project onto PowerSync without trial-and-error. Treat this as a guided workflow first and a reference library second.
+
+## Always Use the PowerSync CLI
+
+**The [PowerSync CLI](https://docs.powersync.com/tools/cli.md) is the default tool for all PowerSync operations.** Do not manually create config files, do not direct users to the dashboard, and do not write service.yaml or sync-config.yaml from scratch. The CLI handles all of this.
+
+What the CLI does — use it instead of doing these things manually:
+
+- **Create a Cloud instance:** `powersync init cloud` → `powersync link cloud --create --project-id=<id>` (scaffolds config, creates the instance, and links it in one flow)
+- **Link an existing Cloud instance:** `powersync pull instance --project-id=<id> --instance-id=<id>` (downloads config to local files)
+- **Create a local self-hosted instance:** `powersync init self-hosted` → `powersync docker configure` → `powersync docker start` (spins up a full local PowerSync stack via Docker — no manual Docker setup needed)
+- **Deploy config:** `powersync deploy service-config`, `powersync deploy sync-config` (validates and deploys — don't copy-paste YAML to a dashboard)
+- **Generate client schema:** `powersync generate schema --output=ts` (generates TypeScript schema from deployed sync config — don't write it by hand)
+- **Generate dev tokens:** `powersync generate token --subject=user-1` (for local testing — don't hardcode JWTs)
+
+Only fall back to manual config or dashboard instructions when the user explicitly says they can't use the CLI.
+
+Full CLI reference: `references/powersync-cli.md` — **always load this file** when setting up or modifying a PowerSync instance.
+
+## Onboarding Playbook
+
+When the task is to add PowerSync to an app, follow this sequence in order:
+
+1. Identify the platform: **Cloud** or **self-hosted**.
+2. Identify the backend: **Supabase** or another database.
+3. If the backend is Supabase and it is unclear whether the user means **online (Supabase Cloud)** or **locally hosted** (e.g. `supabase start`), **ask the user** before choosing connection strings, auth config, or references.
+4. Collect required inputs before coding.
+5. Generate sync config and any required source database setup (e.g. Supabase publication SQL, Postgres publication, MongoDB replica set).
+6. **Create/link the instance and deploy config before writing app code.** Use the CLI — do not create config files manually. For Cloud: `powersync init cloud` → edit config → `powersync link cloud --create` → `powersync deploy`. For self-hosted: `powersync init self-hosted` → `powersync docker configure` → `powersync docker start`. For source database setup the agent cannot run (e.g. Supabase publication SQL), present the exact SQL and ask the user to confirm it is done. The app will not sync without deployed config.
+7. Only after backend readiness is confirmed, implement app-side PowerSync integration.
+
+Do not start client-side debugging while the PowerSync service is still unconfigured. If the UI is stuck on `Syncing...`, the default diagnosis is incomplete backend setup, not a frontend bug.
+
+## Critical Footguns
+
+Apply these rules without exception:
+
+- `powersync/service.yaml` uses `replication.connections`, not a top-level `connections` key.
+- `powersync/sync-config.yaml` must begin with:
+  ```yaml
+  config:
+    edition: 3
+  ```
+- `powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`.
+- For existing Cloud instances, pull config before manual edits. Never pull after editing unless you have backed up the local files.
+- The self-hosted Docker image listens on port **8080**, not 80. Use `-p 8080:8080` in port mapping.
+- The Docker image does **not** accept a `-s` flag for sync config. Use the `POWERSYNC_SYNC_CONFIG_B64` environment variable or the `-sync64` flag.
+- For local Postgres / local Supabase, set `sslmode: disable` as a YAML key on the connection — the `sslmode=disable` URI query string is ignored by pgwire.
+- `PowerSyncBackendConnector`, `PowerSyncCredentials`, and `AbstractPowerSyncDatabase` are **type-only exports** in the JS SDK. Use `import type` — a regular import causes runtime errors in Vite/bundlers.
+
+## Default Benchmark Path
+
+For a React web app using Supabase auth and PowerSync Cloud, load these files in this order:
+
+1. `references/onboarding-supabase-web.md`
+2. `references/supabase-auth.md`
+3. `references/powersync-cli.md`
+4. `references/powersync-service.md`
+5. `references/sync-config.md`
+6. `references/sdks/powersync-js.md`
+7. `references/sdks/powersync-js-react.md`
+
+Use the onboarding recipe as the primary workflow. Use the other references to fill in details, not to invent a different sequence.
+
+## Required Inputs Before Coding
+
+Collect the minimum required information for the chosen path before changing app code.
+
+### Cloud + Supabase
+
+- Whether the PowerSync instance already exists
+- **Whether Supabase is online (hosted at supabase.com) or locally hosted** (e.g. `supabase start`) — if you cannot infer this from the project or env, **prompt the user**
+- PowerSync instance URL, if an instance already exists
+- Project ID and instance ID, if using CLI with an existing instance
+- Supabase Postgres connection string, if PowerSync still needs the source DB connection
+- Whether Supabase JWT signing uses new signing keys or legacy JWT secret, if not obvious from the setup
+
+Only ask for secrets when you are at the step that actually needs them.
+
+## Cloud Readiness Gate
+
+Do not proceed to app-side code until all items below are verified:
+
+- PowerSync instance exists
+- Source database connection is configured
+- Sync config is deployed
+- Client auth is configured
+- Instance URL is available for `fetchCredentials()`
+- Source database replication/publication setup is complete
+
+If any item is missing, finish the service setup first.
+
+Use the CLI to verify and complete any missing items. For steps the agent cannot perform (e.g. running SQL in Supabase SQL Editor), present the exact commands and ask the user to confirm completion before writing app code.
+
+## First Response for `Syncing...`
+
+When the app shows `Syncing...`, check these in order before asking for browser console logs:
+
+1. Confirm the PowerSync endpoint URL returned by `fetchCredentials()`.
+2. Confirm the PowerSync service has a valid source DB connection.
+3. Confirm sync config is deployed and uses `config: edition: 3`.
+4. Confirm client auth is configured correctly.
+5. Confirm the Supabase publication exists for the synced tables.
+6. Only then inspect frontend connector or SDK state.
+
+Before requesting console logs, ask the user to confirm:
+
+- whether the instance exists
+- whether database connection is configured
+- whether sync config was deployed
+- whether client auth was enabled
+- whether the Supabase SQL was run
+
+## Setup Paths
+
+Choose the matching path after the preflight. The CLI is the default for all paths.
+
+### Path 1: Cloud + CLI (Recommended)
+
+Load `references/powersync-cli.md` and prefer the CLI for every step it supports:
+
+- Create and link the instance: `powersync link cloud --create --project-id=<project-id>`
+- Deploy service config: `powersync deploy service-config`
+- Deploy sync config: `powersync deploy sync-config`
+- Prefer `PS_ADMIN_TOKEN` in autonomous or noninteractive environments; use `powersync login` only when interactive auth is acceptable
+
+### Path 2: Cloud + Dashboard
+
+Only use this path if the user explicitly prefers the dashboard or the CLI is unavailable.
+
+Guide the user through the dashboard sequence:
+
+1. Create or open the PowerSync project and instance.
+2. Connect the source database.
+3. Deploy sync config.
+4. Configure client auth.
+5. Copy the instance URL.
+6. Verify source database replication/publication setup.
+
+If the backend is Supabase, also load `references/supabase-auth.md`.
+
+### Path 3: Self-Hosted + CLI (Recommended)
+
+Load `references/powersync-cli.md`, `references/powersync-service.md`, and `references/sync-config.md`. Prefer the CLI for Docker runs (`powersync docker run`, `powersync docker reset`), schema generation, and any supported self-hosted operations. See [PowerSync CLI](https://docs.powersync.com/tools/cli.md).
+
+### Path 4: Self-Hosted + Manual Docker
+
+Only when the CLI cannot be used. Load `references/powersync-service.md` and `references/sync-config.md`. If the backend is **not** Supabase, also load `references/custom-backend.md`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+
+  subgraph BACKEND["Your Backend"]
+    direction TB
+    DB["Backend Database (Postgres | MongoDB | MySQL | Supabase | …)"]
+    API["Backend API (Your server / cloud functions)"]
+    API -- "Applies writes" --> DB
+  end
+
+  subgraph PS_SERVICE["PowerSync Service"]
+    direction TB
+    SYNC["Partial Sync (sync rules filter data per user)"]
+  end
+
+  subgraph APP["Your App"]
+    direction TB
+    SDK["PowerSync SDK"]
+    SQLITE["In-app SQLite (local replica — reads are instant)"]
+    QUEUE["Upload Queue (offline write buffer)"]
+    UI["UI"]
+    SDK --- SQLITE
+    SDK --- QUEUE
+    SQLITE <--> UI
+    QUEUE <--> UI
+  end
+
+  DB -- "Replicates changes (CDC / logical replication)" --> PS_SERVICE
+  PS_SERVICE -- "Streams changes (real-time sync)" --> SDK
+  QUEUE -- "Uploads writes (when connectivity resumes)" --> API
+```
+
+Key rule: **client writes never go through PowerSync**. They go from the app's upload queue to your backend API. PowerSync handles the read and sync path only.
+
+## What to Load for Your Task
+
+| Task | Load these files |
+|------|-----------------|
+| React web app + Supabase + Cloud onboarding | `references/onboarding-supabase-web.md` + `references/supabase-auth.md` + `references/powersync-cli.md` + `references/powersync-service.md` + `references/sync-config.md` + `references/sdks/powersync-js.md` + `references/sdks/powersync-js-react.md` |
+| New project setup | `references/powersync-cli.md` + `references/powersync-service.md` + `references/sync-config.md` + SDK files for your platform |
+| Setting up PowerSync with Supabase | `references/onboarding-supabase-web.md` + `references/supabase-auth.md` |
+| Debugging sync / connection issues | `references/powersync-debug.md` |
+| Writing or migrating sync config | `references/sync-config.md` |
+| Configuring the service / self-hosting | `references/powersync-service.md` + `references/powersync-cli.md` |
+| Using the PowerSync CLI | `references/powersync-cli.md` + `references/sync-config.md` |
+| Handling file uploads / attachments | `references/attachments.md` |
+| Custom backend (non-Supabase) | `references/custom-backend.md` + `references/powersync-service.md` + `references/sync-config.md` + SDK files for your platform |
+| Understanding the overall architecture | This file is sufficient; see `references/powersync-overview.md` for deep links |
+
+## SDK Reference Files
+
+### JavaScript / TypeScript
+
+Always load `references/sdks/powersync-js.md` for any JS/TS project, then load the applicable framework file.
+
+| Framework | Load when… | File |
+|-----------|-----------|------|
+| React / Next.js | React web app or Next.js | `references/sdks/powersync-js-react.md` |
+| React Native / Expo | React Native, Expo, or Expo Go | `references/sdks/powersync-js-react-native.md` |
+| Vue / Nuxt | Vue or Nuxt | `references/sdks/powersync-js-vue.md` |
+| Node.js / Electron | Node.js CLI/server or Electron | `references/sdks/powersync-js-node.md` |
+| TanStack | TanStack Query or TanStack DB | `references/sdks/powersync-js-tanstack.md` |
+
+### Other SDKs
+
+| Platform | Load when… | File |
+|----------|-----------|------|
+| Dart / Flutter | Dart / Flutter | `references/sdks/powersync-dart.md` |
+| .NET | .NET | `references/sdks/powersync-dotnet.md` |
+| Kotlin | Kotlin | `references/sdks/powersync-kotlin.md` |
+| Swift | Swift / iOS / macOS | `references/sdks/powersync-swift.md` |
+
+## Key Rules to Apply Without Being Asked
+
+- Use Sync Streams for new projects. Sync Rules are legacy.
+- Never define the `id` column in a PowerSync table schema; it is created automatically.
+- Use `column.integer` for booleans and `column.text` for ISO date strings.
+- `connect()` is fire-and-forget. Use `waitForFirstSync()` if you need readiness.
+- `transaction.complete()` is mandatory or the upload queue stalls permanently.
+- `disconnectAndClear()` is required on logout or user switch when local data must be wiped.
+- A 4xx response from `uploadData` blocks the upload queue permanently; return 2xx for validation errors.

--- a/.claude/skills/powersync/CLAUDE.md
+++ b/.claude/skills/powersync/CLAUDE.md
@@ -1,0 +1,234 @@
+# PowerSync Skills
+
+Use this skill to onboard a project onto PowerSync without trial-and-error. Treat this as a guided workflow first and a reference library second.
+
+## Always Use the PowerSync CLI
+
+**The [PowerSync CLI](https://docs.powersync.com/tools/cli.md) is the default tool for all PowerSync operations.** Do not manually create config files, do not direct users to the dashboard, and do not write service.yaml or sync-config.yaml from scratch. The CLI handles all of this.
+
+What the CLI does — use it instead of doing these things manually:
+
+- **Create a Cloud instance:** `powersync init cloud` → `powersync link cloud --create --project-id=<id>` (scaffolds config, creates the instance, and links it in one flow)
+- **Link an existing Cloud instance:** `powersync pull instance --project-id=<id> --instance-id=<id>` (downloads config to local files)
+- **Create a local self-hosted instance:** `powersync init self-hosted` → `powersync docker configure` → `powersync docker start` (spins up a full local PowerSync stack via Docker — no manual Docker setup needed)
+- **Deploy config:** `powersync deploy service-config`, `powersync deploy sync-config` (validates and deploys — don't copy-paste YAML to a dashboard)
+- **Generate client schema:** `powersync generate schema --output=ts` (generates TypeScript schema from deployed sync config — don't write it by hand)
+- **Generate dev tokens:** `powersync generate token --subject=user-1` (for local testing — don't hardcode JWTs)
+
+Only fall back to manual config or dashboard instructions when the user explicitly says they can't use the CLI.
+
+Full CLI reference: `references/powersync-cli.md` — **always load this file** when setting up or modifying a PowerSync instance.
+
+## Onboarding Playbook
+
+When the task is to add PowerSync to an app, follow this sequence in order:
+
+1. Identify the platform: **Cloud** or **self-hosted**.
+2. Identify the backend: **Supabase** or another database.
+3. If the backend is Supabase and it is unclear whether the user means **online (Supabase Cloud)** or **locally hosted** (e.g. `supabase start`), **ask the user** before choosing connection strings, auth config, or references.
+4. Collect required inputs before coding.
+5. Generate sync config and any required source database setup (e.g. Supabase publication SQL, Postgres publication, MongoDB replica set).
+6. **Create/link the instance and deploy config before writing app code.** Use the CLI — do not create config files manually. For Cloud: `powersync init cloud` → edit config → `powersync link cloud --create` → `powersync deploy`. For self-hosted: `powersync init self-hosted` → `powersync docker configure` → `powersync docker start`. For source database setup the agent cannot run (e.g. Supabase publication SQL), present the exact SQL and ask the user to confirm it is done. The app will not sync without deployed config.
+7. Only after backend readiness is confirmed, implement app-side PowerSync integration.
+
+Do not start client-side debugging while the PowerSync service is still unconfigured. If the UI is stuck on `Syncing...`, the default diagnosis is incomplete backend setup, not a frontend bug.
+
+## Critical Footguns
+
+Apply these rules without exception:
+
+- `powersync/service.yaml` uses `replication.connections`, not a top-level `connections` key.
+- `powersync/sync-config.yaml` must begin with:
+  ```yaml
+  config:
+    edition: 3
+  ```
+- `powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`.
+- For existing Cloud instances, pull config before manual edits. Never pull after editing unless you have backed up the local files.
+- The self-hosted Docker image listens on port **8080**, not 80. Use `-p 8080:8080` in port mapping.
+- The Docker image does **not** accept a `-s` flag for sync config. Use the `POWERSYNC_SYNC_CONFIG_B64` environment variable or the `-sync64` flag.
+- For local Postgres / local Supabase, set `sslmode: disable` as a YAML key on the connection — the `sslmode=disable` URI query string is ignored by pgwire.
+- `PowerSyncBackendConnector`, `PowerSyncCredentials`, and `AbstractPowerSyncDatabase` are **type-only exports** in the JS SDK. Use `import type` — a regular import causes runtime errors in Vite/bundlers.
+
+## Default Benchmark Path
+
+For a React web app using Supabase auth and PowerSync Cloud, load these files in this order:
+
+1. `references/onboarding-supabase-web.md`
+2. `references/supabase-auth.md`
+3. `references/powersync-cli.md`
+4. `references/powersync-service.md`
+5. `references/sync-config.md`
+6. `references/sdks/powersync-js.md`
+7. `references/sdks/powersync-js-react.md`
+
+Use the onboarding recipe as the primary workflow. Use the other references to fill in details, not to invent a different sequence.
+
+## Required Inputs Before Coding
+
+Collect the minimum required information for the chosen path before changing app code.
+
+### Cloud + Supabase
+
+- Whether the PowerSync instance already exists
+- **Whether Supabase is online (hosted at supabase.com) or locally hosted** (e.g. `supabase start`) — if you cannot infer this from the project or env, **prompt the user**
+- PowerSync instance URL, if an instance already exists
+- Project ID and instance ID, if using CLI with an existing instance
+- Supabase Postgres connection string, if PowerSync still needs the source DB connection
+- Whether Supabase JWT signing uses new signing keys or legacy JWT secret, if not obvious from the setup
+
+Only ask for secrets when you are at the step that actually needs them.
+
+## Cloud Readiness Gate
+
+Do not proceed to app-side code until all items below are verified:
+
+- PowerSync instance exists
+- Source database connection is configured
+- Sync config is deployed
+- Client auth is configured
+- Instance URL is available for `fetchCredentials()`
+- Source database replication/publication setup is complete
+
+If any item is missing, finish the service setup first.
+
+Use the CLI to verify and complete any missing items. For steps the agent cannot perform (e.g. running SQL in Supabase SQL Editor), present the exact commands and ask the user to confirm completion before writing app code.
+
+## First Response for `Syncing...`
+
+When the app shows `Syncing...`, check these in order before asking for browser console logs:
+
+1. Confirm the PowerSync endpoint URL returned by `fetchCredentials()`.
+2. Confirm the PowerSync service has a valid source DB connection.
+3. Confirm sync config is deployed and uses `config: edition: 3`.
+4. Confirm client auth is configured correctly.
+5. Confirm the Supabase publication exists for the synced tables.
+6. Only then inspect frontend connector or SDK state.
+
+Before requesting console logs, ask the user to confirm:
+
+- whether the instance exists
+- whether database connection is configured
+- whether sync config was deployed
+- whether client auth was enabled
+- whether the Supabase SQL was run
+
+## Setup Paths
+
+Choose the matching path after the preflight. The CLI is the default for all paths.
+
+### Path 1: Cloud + CLI (Recommended)
+
+Load `references/powersync-cli.md` and prefer the CLI for every step it supports:
+
+- Create and link the instance: `powersync link cloud --create --project-id=<project-id>`
+- Deploy service config: `powersync deploy service-config`
+- Deploy sync config: `powersync deploy sync-config`
+- Prefer `PS_ADMIN_TOKEN` in autonomous or noninteractive environments; use `powersync login` only when interactive auth is acceptable
+
+### Path 2: Cloud + Dashboard
+
+Only use this path if the user explicitly prefers the dashboard or the CLI is unavailable.
+
+Guide the user through the dashboard sequence:
+
+1. Create or open the PowerSync project and instance.
+2. Connect the source database.
+3. Deploy sync config.
+4. Configure client auth.
+5. Copy the instance URL.
+6. Verify source database replication/publication setup.
+
+If the backend is Supabase, also load `references/supabase-auth.md`.
+
+### Path 3: Self-Hosted + CLI (Recommended)
+
+Load `references/powersync-cli.md`, `references/powersync-service.md`, and `references/sync-config.md`. Prefer the CLI for Docker runs (`powersync docker run`, `powersync docker reset`), schema generation, and any supported self-hosted operations. See [PowerSync CLI](https://docs.powersync.com/tools/cli.md).
+
+### Path 4: Self-Hosted + Manual Docker
+
+Only when the CLI cannot be used. Load `references/powersync-service.md` and `references/sync-config.md`. If the backend is **not** Supabase, also load `references/custom-backend.md`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+
+  subgraph BACKEND["Your Backend"]
+    direction TB
+    DB["Backend Database (Postgres | MongoDB | MySQL | Supabase | …)"]
+    API["Backend API (Your server / cloud functions)"]
+    API -- "Applies writes" --> DB
+  end
+
+  subgraph PS_SERVICE["PowerSync Service"]
+    direction TB
+    SYNC["Partial Sync (sync rules filter data per user)"]
+  end
+
+  subgraph APP["Your App"]
+    direction TB
+    SDK["PowerSync SDK"]
+    SQLITE["In-app SQLite (local replica — reads are instant)"]
+    QUEUE["Upload Queue (offline write buffer)"]
+    UI["UI"]
+    SDK --- SQLITE
+    SDK --- QUEUE
+    SQLITE <--> UI
+    QUEUE <--> UI
+  end
+
+  DB -- "Replicates changes (CDC / logical replication)" --> PS_SERVICE
+  PS_SERVICE -- "Streams changes (real-time sync)" --> SDK
+  QUEUE -- "Uploads writes (when connectivity resumes)" --> API
+```
+
+Key rule: **client writes never go through PowerSync**. They go from the app's upload queue to your backend API. PowerSync handles the read and sync path only.
+
+## What to Load for Your Task
+
+| Task | Load these files |
+|------|-----------------|
+| React web app + Supabase + Cloud onboarding | `references/onboarding-supabase-web.md` + `references/supabase-auth.md` + `references/powersync-cli.md` + `references/powersync-service.md` + `references/sync-config.md` + `references/sdks/powersync-js.md` + `references/sdks/powersync-js-react.md` |
+| New project setup | `references/powersync-cli.md` + `references/powersync-service.md` + `references/sync-config.md` + SDK files for your platform |
+| Setting up PowerSync with Supabase | `references/onboarding-supabase-web.md` + `references/supabase-auth.md` |
+| Debugging sync / connection issues | `references/powersync-debug.md` |
+| Writing or migrating sync config | `references/sync-config.md` |
+| Configuring the service / self-hosting | `references/powersync-service.md` + `references/powersync-cli.md` |
+| Using the PowerSync CLI | `references/powersync-cli.md` + `references/sync-config.md` |
+| Handling file uploads / attachments | `references/attachments.md` |
+| Custom backend (non-Supabase) | `references/custom-backend.md` + `references/powersync-service.md` + `references/sync-config.md` + SDK files for your platform |
+| Understanding the overall architecture | This file is sufficient; see `references/powersync-overview.md` for deep links |
+
+## SDK Reference Files
+
+### JavaScript / TypeScript
+
+Always load `references/sdks/powersync-js.md` for any JS/TS project, then load the applicable framework file.
+
+| Framework | Load when… | File |
+|-----------|-----------|------|
+| React / Next.js | React web app or Next.js | `references/sdks/powersync-js-react.md` |
+| React Native / Expo | React Native, Expo, or Expo Go | `references/sdks/powersync-js-react-native.md` |
+| Vue / Nuxt | Vue or Nuxt | `references/sdks/powersync-js-vue.md` |
+| Node.js / Electron | Node.js CLI/server or Electron | `references/sdks/powersync-js-node.md` |
+| TanStack | TanStack Query or TanStack DB | `references/sdks/powersync-js-tanstack.md` |
+
+### Other SDKs
+
+| Platform | Load when… | File |
+|----------|-----------|------|
+| Dart / Flutter | Dart / Flutter | `references/sdks/powersync-dart.md` |
+| .NET | .NET | `references/sdks/powersync-dotnet.md` |
+| Kotlin | Kotlin | `references/sdks/powersync-kotlin.md` |
+| Swift | Swift / iOS / macOS | `references/sdks/powersync-swift.md` |
+
+## Key Rules to Apply Without Being Asked
+
+- Use Sync Streams for new projects. Sync Rules are legacy.
+- Never define the `id` column in a PowerSync table schema; it is created automatically.
+- Use `column.integer` for booleans and `column.text` for ISO date strings.
+- `connect()` is fire-and-forget. Use `waitForFirstSync()` if you need readiness.
+- `transaction.complete()` is mandatory or the upload queue stalls permanently.
+- `disconnectAndClear()` is required on logout or user switch when local data must be wiped.
+- A 4xx response from `uploadData` blocks the upload queue permanently; return 2xx for validation errors.

--- a/.claude/skills/powersync/SKILL.md
+++ b/.claude/skills/powersync/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: powersync
+description: Guided onboarding and best practices for building applications with PowerSync — Cloud and self-hosted setup, sync configuration, client SDK usage, Supabase integration, and debugging.
+license: MIT
+compatibility: Works with any skills-compatible agent. Some references include CLI commands requiring the @powersync/cli package.
+metadata:
+  author: powersync
+  version: "1.1.0"
+  organization: PowerSync
+  tags: powersync, offline-first, local-first, sync-streams, sqlite, replication, supabase, uploadData, fetchCredentials, service-config, sync-config, cloud, cli, debugging
+---
+
+# PowerSync Skills
+
+Use this skill to onboard a project onto PowerSync without trial-and-error. Treat this as a guided workflow first and a reference library second.
+
+## Always Use the PowerSync CLI
+
+**The [PowerSync CLI](https://docs.powersync.com/tools/cli.md) is the default tool for all PowerSync operations.** Do not manually create config files, do not direct users to the dashboard, and do not write service.yaml or sync-config.yaml from scratch. The CLI handles all of this.
+
+What the CLI does — use it instead of doing these things manually:
+
+- **Create a Cloud instance:** `powersync init cloud` → `powersync link cloud --create --project-id=<id>` (scaffolds config, creates the instance, and links it in one flow)
+- **Link an existing Cloud instance:** `powersync pull instance --project-id=<id> --instance-id=<id>` (downloads config to local files)
+- **Create a local self-hosted instance:** `powersync init self-hosted` → `powersync docker configure` → `powersync docker start` (spins up a full local PowerSync stack via Docker — no manual Docker setup needed)
+- **Deploy config:** `powersync deploy service-config`, `powersync deploy sync-config` (validates and deploys — don't copy-paste YAML to a dashboard)
+- **Generate client schema:** `powersync generate schema --output=ts` (generates TypeScript schema from deployed sync config — don't write it by hand)
+- **Generate dev tokens:** `powersync generate token --subject=user-1` (for local testing — don't hardcode JWTs)
+
+Only fall back to manual config or dashboard instructions when the user explicitly says they can't use the CLI.
+
+Full CLI reference: `references/powersync-cli.md` — **always load this file** when setting up or modifying a PowerSync instance.
+
+## Onboarding Playbook
+
+When the task is to add PowerSync to an app, follow this sequence in order:
+
+1. Identify the platform: **Cloud** or **self-hosted**.
+2. Identify the backend: **Supabase** or another database.
+3. If the backend is Supabase and it is unclear whether the user means **online (Supabase Cloud)** or **locally hosted** (e.g. `supabase start`), **ask the user** before choosing connection strings, auth config, or references.
+4. Collect required inputs before coding.
+5. Generate sync config and any required source database setup (e.g. Supabase publication SQL, Postgres publication, MongoDB replica set).
+6. **Create/link the instance and deploy config before writing app code.** Use the CLI — do not create config files manually. For Cloud: `powersync init cloud` → edit config → `powersync link cloud --create` → `powersync deploy`. For self-hosted: `powersync init self-hosted` → `powersync docker configure` → `powersync docker start`. For source database setup the agent cannot run (e.g. Supabase publication SQL), present the exact SQL and ask the user to confirm it is done. The app will not sync without deployed config.
+7. Only after backend readiness is confirmed, implement app-side PowerSync integration.
+
+Do not start client-side debugging while the PowerSync service is still unconfigured. If the UI is stuck on `Syncing...`, the default diagnosis is incomplete backend setup, not a frontend bug.
+
+## Critical Footguns
+
+Apply these rules without exception:
+
+- `powersync/service.yaml` uses `replication.connections`, not a top-level `connections` key.
+- `powersync/sync-config.yaml` must begin with:
+  ```yaml
+  config:
+    edition: 3
+  ```
+- `powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`.
+- For existing Cloud instances, pull config before manual edits. Never pull after editing unless you have backed up the local files.
+- The self-hosted Docker image listens on port **8080**, not 80. Use `-p 8080:8080` in port mapping.
+- The Docker image does **not** accept a `-s` flag for sync config. Use the `POWERSYNC_SYNC_CONFIG_B64` environment variable or the `-sync64` flag.
+- For local Postgres / local Supabase, set `sslmode: disable` as a YAML key on the connection — the `sslmode=disable` URI query string is ignored by pgwire.
+
+## Default Benchmark Path
+
+For a React web app using Supabase auth and PowerSync Cloud, load these files in this order:
+
+1. `references/onboarding-supabase-web.md`
+2. `references/supabase-auth.md`
+3. `references/powersync-cli.md`
+4. `references/powersync-service.md`
+5. `references/sync-config.md`
+6. `references/sdks/powersync-js.md`
+7. `references/sdks/powersync-js-react.md`
+
+Use the onboarding recipe as the primary workflow. Use the other references to fill in details, not to invent a different sequence.
+
+## Required Inputs Before Coding
+
+Collect the minimum required information for the chosen path before changing app code.
+
+### Cloud + Supabase
+
+- Whether the PowerSync instance already exists
+- **Whether Supabase is online (hosted at supabase.com) or locally hosted** (e.g. `supabase start`) — if you cannot infer this from the project or env, **prompt the user**
+- PowerSync instance URL, if an instance already exists
+- Project ID and instance ID, if using CLI with an existing instance
+- Supabase Postgres connection string, if PowerSync still needs the source DB connection
+- Whether Supabase JWT signing uses new signing keys or legacy JWT secret, if not obvious from the setup
+
+Only ask for secrets when you are at the step that actually needs them.
+
+## Cloud Readiness Gate
+
+Do not proceed to app-side code until all items below are verified:
+
+- PowerSync instance exists
+- Source database connection is configured
+- Sync config is deployed
+- Client auth is configured
+- Instance URL is available for `fetchCredentials()`
+- Source database replication/publication setup is complete
+
+If any item is missing, finish the service setup first.
+
+Use the CLI to verify and complete any missing items. For steps the agent cannot perform (e.g. running SQL in Supabase SQL Editor), present the exact commands and ask the user to confirm completion before writing app code.
+
+## First Response for `Syncing...`
+
+When the app shows `Syncing...`, check these in order before asking for browser console logs:
+
+1. Confirm the PowerSync endpoint URL returned by `fetchCredentials()`.
+2. Confirm the PowerSync service has a valid source DB connection.
+3. Confirm sync config is deployed and uses `config: edition: 3`.
+4. Confirm client auth is configured correctly.
+5. Confirm the Supabase publication exists for the synced tables.
+6. Only then inspect frontend connector or SDK state.
+
+Before requesting console logs, ask the user to confirm:
+
+- whether the instance exists
+- whether database connection is configured
+- whether sync config was deployed
+- whether client auth was enabled
+- whether the Supabase SQL was run
+
+## Setup Paths
+
+Choose the matching path after the preflight. The CLI is the default for all paths.
+
+### Path 1: Cloud + CLI (Recommended)
+
+Load `references/powersync-cli.md` and prefer the CLI for every step it supports:
+
+- Create and link the instance: `powersync link cloud --create --project-id=<project-id>`
+- Deploy service config: `powersync deploy service-config`
+- Deploy sync config: `powersync deploy sync-config`
+- Prefer `PS_ADMIN_TOKEN` in autonomous or noninteractive environments; use `powersync login` only when interactive auth is acceptable
+
+### Path 2: Cloud + Dashboard
+
+Only use this path if the user explicitly prefers the dashboard or the CLI is unavailable.
+
+Guide the user through the dashboard sequence:
+
+1. Create or open the PowerSync project and instance.
+2. Connect the source database.
+3. Deploy sync config.
+4. Configure client auth.
+5. Copy the instance URL.
+6. Verify source database replication/publication setup.
+
+If the backend is Supabase, also load `references/supabase-auth.md`.
+
+### Path 3: Self-Hosted + CLI (Recommended)
+
+Load `references/powersync-cli.md`, `references/powersync-service.md`, and `references/sync-config.md`. Prefer the CLI for Docker runs (`powersync docker run`, `powersync docker reset`), schema generation, and any supported self-hosted operations. See [PowerSync CLI](https://docs.powersync.com/tools/cli.md).
+
+### Path 4: Self-Hosted + Manual Docker
+
+Only when the CLI cannot be used. Load `references/powersync-service.md` and `references/sync-config.md`. If the backend is **not** Supabase, also load `references/custom-backend.md`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+
+  subgraph BACKEND["Your Backend"]
+    direction TB
+    DB["Backend Database (Postgres | MongoDB | MySQL | Supabase | …)"]
+    API["Backend API (Your server / cloud functions)"]
+    API -- "Applies writes" --> DB
+  end
+
+  subgraph PS_SERVICE["PowerSync Service"]
+    direction TB
+    SYNC["Partial Sync (sync rules filter data per user)"]
+  end
+
+  subgraph APP["Your App"]
+    direction TB
+    SDK["PowerSync SDK"]
+    SQLITE["In-app SQLite (local replica — reads are instant)"]
+    QUEUE["Upload Queue (offline write buffer)"]
+    UI["UI"]
+    SDK --- SQLITE
+    SDK --- QUEUE
+    SQLITE <--> UI
+    QUEUE <--> UI
+  end
+
+  DB -- "Replicates changes (CDC / logical replication)" --> PS_SERVICE
+  PS_SERVICE -- "Streams changes (real-time sync)" --> SDK
+  QUEUE -- "Uploads writes (when connectivity resumes)" --> API
+```
+
+Key rule: **client writes never go through PowerSync**. They go from the app's upload queue to your backend API. PowerSync handles the read and sync path only.
+
+## What to Load for Your Task
+
+| Task | Load these files |
+|------|-----------------|
+| React web app + Supabase + Cloud onboarding | `references/onboarding-supabase-web.md` + `references/supabase-auth.md` + `references/powersync-cli.md` + `references/powersync-service.md` + `references/sync-config.md` + `references/sdks/powersync-js.md` + `references/sdks/powersync-js-react.md` |
+| New project setup | `references/powersync-cli.md` + `references/powersync-service.md` + `references/sync-config.md` + SDK files for your platform |
+| Setting up PowerSync with Supabase | `references/onboarding-supabase-web.md` + `references/supabase-auth.md` |
+| Debugging sync / connection issues | `references/powersync-debug.md` |
+| Writing or migrating sync config | `references/sync-config.md` |
+| Configuring the service / self-hosting | `references/powersync-service.md` + `references/powersync-cli.md` |
+| Using the PowerSync CLI | `references/powersync-cli.md` + `references/sync-config.md` |
+| Handling file uploads / attachments | `references/attachments.md` |
+| Custom backend (non-Supabase) | `references/custom-backend.md` + `references/powersync-service.md` + `references/sync-config.md` + SDK files for your platform |
+| Understanding the overall architecture | This file is sufficient; see `references/powersync-overview.md` for deep links |
+
+## SDK Reference Files
+
+### JavaScript / TypeScript
+
+Always load `references/sdks/powersync-js.md` for any JS/TS project, then load the applicable framework file.
+
+| Framework | Load when… | File |
+|-----------|-----------|------|
+| React / Next.js | React web app or Next.js | `references/sdks/powersync-js-react.md` |
+| React Native / Expo | React Native, Expo, or Expo Go | `references/sdks/powersync-js-react-native.md` |
+| Vue / Nuxt | Vue or Nuxt | `references/sdks/powersync-js-vue.md` |
+| Node.js / Electron | Node.js CLI/server or Electron | `references/sdks/powersync-js-node.md` |
+| TanStack | TanStack Query or TanStack DB | `references/sdks/powersync-js-tanstack.md` |
+
+### Other SDKs
+
+| Platform | Load when… | File |
+|----------|-----------|------|
+| Dart / Flutter | Dart / Flutter | `references/sdks/powersync-dart.md` |
+| .NET | .NET | `references/sdks/powersync-dotnet.md` |
+| Kotlin | Kotlin | `references/sdks/powersync-kotlin.md` |
+| Swift | Swift / iOS / macOS | `references/sdks/powersync-swift.md` |
+
+## Key Rules to Apply Without Being Asked
+
+- Use Sync Streams for new projects. Sync Rules are legacy.
+- Never define the `id` column in a PowerSync table schema; it is created automatically.
+- Use `column.integer` for booleans and `column.text` for ISO date strings.
+- `connect()` is fire-and-forget. Use `waitForFirstSync()` if you need readiness.
+- `transaction.complete()` is mandatory or the upload queue stalls permanently.
+- `disconnectAndClear()` is required on logout or user switch when local data must be wiped.
+- A 4xx response from `uploadData` blocks the upload queue permanently; return 2xx for validation errors.

--- a/.claude/skills/powersync/references/attachments.md
+++ b/.claude/skills/powersync/references/attachments.md
@@ -1,0 +1,330 @@
+---
+name: powersync-attachments
+description: PowerSync built-in attachment queue — offline-first file uploads/downloads, storage adapters, AttachmentQueue lifecycle, saveFile, watchAttachments, and error handling
+metadata:
+  tags: attachments, files, uploads, downloads, offline-first, storage, AttachmentQueue, saveFile, watchAttachments, images, blobs, media
+---
+
+# PowerSync Attachments
+
+PowerSync handles file attachments using a **metadata + storage provider** pattern: structured metadata syncs through PowerSync while actual files live in a purpose-built storage system (S3, Supabase Storage, Cloudflare R2, etc.). An offline-first queue manages uploads, downloads, and retries automatically in the background.
+
+| Resource | Description |
+|----------|-------------|
+| [Attachments docs](https://docs.powersync.com/client-sdks/advanced/attachments.md) | Full reference including migration notes and platform demos |
+
+> **Deprecated packages:** `@powersync/attachments` (JS/TS) and `powersync_attachments_helper` (Dart/Flutter) are deprecated. Attachment functionality is now built in to the platform SDK packages. Do not install the old packages for new projects.
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+  participant DevA as Device A
+  participant AQueue as Attachment Queue (A)
+  participant Remote as Remote Storage (S3/Supabase)
+  participant PS as PowerSync Service
+  participant BQueue as Attachment Queue (B)
+  participant DevB as Device B
+
+  DevA->>AQueue: 1. saveFile()
+  Note over AQueue: 2. File saved locally,<br/>state = QUEUED_UPLOAD
+  AQueue->>Remote: 3. Upload file
+  Note over Remote: 4. File stored in Bucket/id-123
+  AQueue->>DevA: 5. updateHook() — data model updated<br/>(photo_id = "id-123"), state = SYNCED
+  DevA->>PS: 6. PowerSync syncs data model change
+  PS->>DevB: 7. Data model updated (photo_id = "id-123")
+  DevB->>BQueue: 8. watchAttachments() detects new ID,<br/>state = QUEUED_DOWNLOAD
+  BQueue->>Remote: 9. Download file
+  Remote-->>BQueue: 10. File stored locally
+  Note over BQueue: 11. State = SYNCED
+```
+
+1. App calls `saveFile()` — file is written to local storage immediately, a record is inserted into the local attachments table with state `QUEUED_UPLOAD`, and the `updateHook` links the attachment ID to your data model in the same transaction.
+2. The attachment queue uploads the file to remote storage in the background.
+3. On upload success, the record transitions to `SYNCED`.
+4. PowerSync syncs the data model change (e.g. `user.photo_id`) to other devices.
+5. Those devices' `watchAttachments` query detects the new ID, creates a `QUEUED_DOWNLOAD` record, and the queue downloads the file automatically.
+
+### Attachment States
+
+| State | Meaning |
+|-------|---------|
+| `QUEUED_UPLOAD` | Saved locally, waiting to upload |
+| `QUEUED_DOWNLOAD` | ID received from sync, file not yet downloaded |
+| `SYNCED` | File exists locally and in remote storage |
+| `QUEUED_DELETE` | Marked for deletion from both local and remote |
+| `ARCHIVED` | No longer referenced in data model; candidate for cleanup |
+
+## Package Setup
+
+**Web / Node.js** — built in, no separate install:
+```bash
+# Already included in @powersync/web and @powersync/node
+```
+
+**React Native** — built in to `@powersync/react-native`, but local storage adapter requires a separate package:
+```bash
+# Expo (requires Expo 54+)
+npx expo install @powersync/attachments-storage-react-native expo-file-system
+
+# Bare React Native
+npm install @powersync/attachments-storage-react-native @dr.pogodin/react-native-fs
+```
+
+**Flutter/Dart, Kotlin, Swift** — built in to the respective SDK, no additional package needed.
+
+## Schema Setup
+
+Add `AttachmentTable` as a local-only table alongside your regular tables. It is not synced through PowerSync — it is managed entirely by the attachment queue on each device.
+
+**JavaScript / TypeScript:**
+```ts
+import { Schema, Table, column, AttachmentTable } from '@powersync/web';
+// or from '@powersync/react-native' / '@powersync/node'
+
+export const AppSchema = new Schema({
+  users: new Table({
+    name: column.text,
+    photo_id: column.text,  // FK referencing attachment ID
+  }),
+  attachments: new AttachmentTable(),  // local-only, managed by queue
+});
+```
+
+`AttachmentTable` accepts an optional `viewName` (default: `'attachments'`). Use a custom `viewName` when migrating from the old `@powersync/attachments` package to avoid a SQLite name conflict with the legacy table.
+
+**Dart:**
+```dart
+import 'package:powersync/powersync.dart';
+import 'package:powersync_core/attachments/attachments.dart';
+
+final schema = Schema([
+  Table('users', [Column.text('name'), Column.text('photo_id')]),
+  AttachmentsQueueTable(),
+]);
+```
+
+**Kotlin / Swift** — use `createAttachmentsTable("attachments")` / `createAttachmentTable(name: "attachments")` respectively. See [SDK demos](https://docs.powersync.com/client-sdks/advanced/attachments.md#sdk--demo-reference) for full examples.
+
+## Storage Adapters
+
+The attachment queue requires two adapters:
+
+- **`localStorage`** — reads/writes files on the local device
+- **`remoteStorage`** — uploads/downloads files to/from cloud storage
+
+### Local Storage Adapters (JS/TS)
+
+```ts
+// Web (IndexedDB)
+import { IndexDBFileSystemStorageAdapter } from '@powersync/web';
+const localStorage = new IndexDBFileSystemStorageAdapter('my-app-files');
+
+// Node.js / Electron
+import { NodeFileSystemAdapter } from '@powersync/node';
+const localStorage = new NodeFileSystemAdapter('./user-attachments');
+
+// React Native — Expo (Expo 54+)
+import { ExpoFileSystemStorageAdapter } from '@powersync/attachments-storage-react-native';
+const localStorage = new ExpoFileSystemStorageAdapter();
+
+// React Native — bare
+import { ReactNativeFileSystemStorageAdapter } from '@powersync/attachments-storage-react-native';
+const localStorage = new ReactNativeFileSystemStorageAdapter();
+```
+
+### Remote Storage Adapter
+
+Implement an object with `uploadFile`, `downloadFile`, and `deleteFile`. Always use signed URLs generated by your backend — never expose storage credentials to the client.
+
+```ts
+import type { AttachmentRecord } from '@powersync/web';
+
+const remoteStorage = {
+  async uploadFile(fileData: ArrayBuffer, attachment: AttachmentRecord) {
+    const { uploadUrl } = await fetch('/api/attachments/upload-url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename: attachment.filename, contentType: attachment.mediaType }),
+    }).then(r => r.json());
+
+    await fetch(uploadUrl, {
+      method: 'PUT',
+      body: fileData,
+      headers: { 'Content-Type': attachment.mediaType ?? 'application/octet-stream' },
+    });
+  },
+
+  async downloadFile(attachment: AttachmentRecord): Promise<ArrayBuffer> {
+    const { downloadUrl } = await fetch(`/api/attachments/${attachment.id}/download-url`).then(r => r.json());
+    return fetch(downloadUrl).then(r => r.arrayBuffer());
+  },
+
+  async deleteFile(attachment: AttachmentRecord) {
+    await fetch(`/api/attachments/${attachment.id}`, { method: 'DELETE' });
+  },
+};
+```
+
+## Initialize the Attachment Queue
+
+```ts
+import { AttachmentQueue } from '@powersync/web';
+// or '@powersync/react-native' / '@powersync/node'
+
+const attachmentQueue = new AttachmentQueue({
+  db,           // PowerSyncDatabase instance
+  localStorage,
+  remoteStorage,
+
+  // Tell the queue which attachments your data model references.
+  // Called reactively whenever watched tables change.
+  watchAttachments: (onUpdate) => {
+    db.watch(
+      `SELECT photo_id FROM users WHERE photo_id IS NOT NULL`,
+      [],
+      {
+        onResult: async (result) => {
+          const attachments = result.rows?._array.map(row => ({
+            id: row.photo_id,
+            fileExtension: 'jpg',
+          })) ?? [];
+          await onUpdate(attachments);
+        },
+      }
+    );
+  },
+
+  syncIntervalMs: 30_000,       // retry interval (default: 30s)
+  downloadAttachments: true,    // auto-download referenced files (default: true)
+  archivedCacheLimit: 100,      // archived files to keep before cleanup (default: 100)
+});
+
+await attachmentQueue.startSync();
+```
+
+`watchAttachments` is critical: it tells the queue which files the app needs based on the current data model. The queue uses its output to decide what to download, upload, or archive. Each item must include `id` and `fileExtension`.
+
+## Upload a File
+
+Use `saveFile()`. The `updateHook` runs in the same database transaction as the attachment record creation, ensuring the FK in your data model and the attachment record are always written atomically.
+
+```ts
+async function uploadProfilePhoto(imageBlob: Blob, userId: string) {
+  const arrayBuffer = await imageBlob.arrayBuffer();
+
+  await attachmentQueue.saveFile({
+    data: arrayBuffer,
+    fileExtension: 'jpg',
+    mediaType: 'image/jpeg',
+    updateHook: async (tx, attachment) => {
+      // Runs in the same transaction — atomic
+      await tx.execute('UPDATE users SET photo_id = ? WHERE id = ?', [attachment.id, userId]);
+    },
+  });
+}
+```
+
+> **Do not write the FK separately** outside of `updateHook`. Writing it in a separate `db.execute()` call after `saveFile()` breaks atomicity and can leave the data model inconsistent if the app crashes between the two writes.
+
+## Delete a File
+
+**Explicit delete** — use `deleteFile()` with an `updateHook` to clear the FK atomically:
+
+```ts
+await attachmentQueue.deleteFile({
+  id: photoId,
+  updateHook: async (tx, attachment) => {
+    await tx.execute('UPDATE users SET photo_id = NULL WHERE id = ?', [userId]);
+  },
+});
+// Queue will: delete from remote storage → delete local file → remove attachment record
+```
+
+**Passive archive** — remove the FK reference from your data model without calling `deleteFile()`. The `watchAttachments` query will no longer return the ID, so the queue automatically transitions the record to `ARCHIVED`. Once `archivedCacheLimit` is reached, archived files are deleted in order.
+
+```ts
+// Just clear the reference; the queue handles cleanup
+await db.execute('UPDATE users SET photo_id = NULL WHERE id = ?', [userId]);
+```
+
+## Accessing a File
+
+Files are only available after the attachment record reaches `SYNCED` state. Read `local_uri` from the attachments table:
+
+```ts
+// React hook example — watches for the file to become available
+function useProfilePhoto(userId: string) {
+  return useQuery<{ local_uri: string; state: string }>(
+    `SELECT a.local_uri, a.state
+     FROM users u
+     LEFT JOIN attachments a ON a.id = u.photo_id
+     WHERE u.id = ?`,
+    [userId]
+  );
+}
+
+// In your component:
+const { data } = useProfilePhoto(userId);
+const uri = data?.[0]?.state === 'SYNCED' ? data[0].local_uri : null;
+```
+
+For non-React targets, use `db.watch()` with the same query pattern.
+
+## Watching Multiple Attachment Types
+
+**Single queue with `UNION ALL`** — simpler, but the query runs whenever any watched table changes:
+
+```ts
+watchAttachments: (onUpdate) => {
+  db.watch(
+    `SELECT photo_id AS id, 'jpg' AS file_extension FROM users WHERE photo_id IS NOT NULL
+     UNION ALL
+     SELECT document_id AS id, 'pdf' AS file_extension FROM documents WHERE document_id IS NOT NULL`,
+    [],
+    {
+      onResult: async (result) => {
+        const attachments = result.rows?._array.map(row => ({
+          id: row.id,
+          fileExtension: row.file_extension,
+        })) ?? [];
+        await onUpdate(attachments);
+      },
+    }
+  );
+},
+```
+
+**Multiple queues** — each queue watches its own table with a simpler query; more memory, but independent configuration per attachment type.
+
+## Error Handling
+
+Return `true` to retry on the next sync interval; return `false` to archive the attachment and stop retrying.
+
+```ts
+import type { AttachmentErrorHandler } from '@powersync/web';
+
+const errorHandler: AttachmentErrorHandler = {
+  async onDownloadError(attachment, error) {
+    if (error.message.includes('404')) return false; // file gone — don't retry
+    return true;
+  },
+  async onUploadError(attachment, error) {
+    return true; // always retry uploads
+  },
+  async onDeleteError(attachment, error) {
+    return true;
+  },
+};
+
+const attachmentQueue = new AttachmentQueue({ /* ... */ errorHandler });
+```
+
+## Key Rules to Apply Without Being Asked
+
+- **`updateHook` is mandatory for atomicity** — always link the attachment ID to your data model inside `updateHook`, never in a separate write after `saveFile()`.
+- **Signed URLs only** — the remote storage adapter must fetch signed URLs from your backend. Never embed storage credentials in the client app.
+- **React Native needs a separate local storage package** — install `@powersync/attachments-storage-react-native` and the appropriate file system peer (`expo-file-system` for Expo 54+, `@dr.pogodin/react-native-fs` for bare RN).
+- **`fileExtension` is required in `watchAttachments`** — each item returned by `watchAttachments` must include both `id` and `fileExtension`; the queue uses the extension to name local files.
+- **Check `state === 'SYNCED'` before using `local_uri`** — the record exists before the file is downloaded; accessing `local_uri` when state is `QUEUED_DOWNLOAD` will point to a file that doesn't exist yet.
+- **Migration from `@powersync/attachments`** — set a custom `viewName` on `AttachmentTable` (e.g. `'attachment_queue'`) to avoid a SQLite conflict with the legacy `attachments` table. Also update: `syncInterval` → `syncIntervalMs`, `cacheLimit` → `archivedCacheLimit`, `name` → `viewName` on `AttachmentTable`.

--- a/.claude/skills/powersync/references/custom-backend.md
+++ b/.claude/skills/powersync/references/custom-backend.md
@@ -1,0 +1,552 @@
+---
+name: custom-backend
+description: Building a custom backend for PowerSync — server-side API for uploadData, custom JWT auth, Postgres setup without Supabase, and end-to-end connector examples
+metadata:
+  tags: backend, custom, jwt, auth, express, fastify, postgres, uploadData, api, non-supabase
+---
+
+# Custom Backend for PowerSync
+
+Use this file when building a PowerSync integration **without Supabase** — a custom Postgres database, your own auth, and a backend API (Express, Fastify, Hono, etc.) that receives writes from the client's upload queue.
+
+| Resource | Description |
+|----------|-------------|
+| [App Backend Setup](https://docs.powersync.com/configuration/app-backend/setup.md) | Overview of setting up the app backend for PowerSync. |
+| [Client-Side Integration](https://docs.powersync.com/configuration/app-backend/client-side-integration.md) | How to implement a backend connector. |
+| [Writing Client-Side Changes](https://docs.powersync.com/usage/writing-client-side-changes-to-your-backend.md) | Detailed guide on the upload queue and backend write flow. |
+| [Custom Auth](https://docs.powersync.com/configuration/auth/custom.md) | JWT auth setup for non-Supabase backends. |
+| [Development Tokens](https://docs.powersync.com/configuration/auth/development-tokens.md) | Generate tokens for local development and testing. |
+
+## Architecture Recap
+
+```
+Client App                    Your Backend API              Postgres DB
+  |                                |                           |
+  |-- uploadData() POST ---------->|--- INSERT/UPDATE/DELETE -->|
+  |                                |<-- 2xx response -----------|
+  |                                |                           |
+  |                                                            |
+PowerSync Service <-------------- CDC / logical replication ---|
+  |
+  |-- streams synced data -------> Client App (local SQLite)
+```
+
+Key rule: **client writes never go through PowerSync**. The upload queue sends writes to YOUR backend API. PowerSync only handles the read/sync path.
+
+## 1. Postgres Database Setup
+
+Skip this section if using Supabase — see `references/supabase-auth.md` instead.
+
+### Enable Logical Replication
+
+```sql
+-- Check current setting
+SHOW wal_level;
+-- If not 'logical', set it (requires restart):
+ALTER SYSTEM SET wal_level = 'logical';
+-- Restart PostgreSQL after this change
+```
+
+Most managed Postgres providers (Neon, Railway, Render, etc.) have logical replication enabled or expose a setting for it. Check your provider's docs.
+
+### Create Replication User
+
+Generate a secure password — never use placeholder values.
+
+```sql
+-- Create dedicated user for PowerSync replication
+CREATE USER powersync_replication WITH REPLICATION PASSWORD 'YOUR_GENERATED_PASSWORD';
+
+-- Grant read access to synced tables
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO powersync_replication;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO powersync_replication;
+```
+
+### Create Publication
+
+```sql
+-- List specific tables (recommended)
+CREATE PUBLICATION powersync FOR TABLE users, posts, comments;
+
+-- Or all tables (simpler but less precise)
+CREATE PUBLICATION powersync FOR ALL TABLES;
+
+-- For each synced table, set REPLICA IDENTITY FULL (required for DELETE sync)
+ALTER TABLE users REPLICA IDENTITY FULL;
+ALTER TABLE posts REPLICA IDENTITY FULL;
+ALTER TABLE comments REPLICA IDENTITY FULL;
+```
+
+### Service Config Connection
+
+```yaml
+# powersync/service.yaml
+replication:
+  connections:
+    - type: postgresql
+      uri: !env PS_DATA_SOURCE_URI
+      # For local Postgres without SSL:
+      # sslmode: disable
+```
+
+## 2. Custom JWT Auth
+
+PowerSync verifies JWTs from client apps. Without Supabase, you must generate and serve your own JWTs and JWKS.
+
+### Supported Algorithms
+
+| Algorithm | Type | Recommendation |
+|-----------|------|----------------|
+| RS256, RS384, RS512 | Asymmetric (RSA) | Recommended for production |
+| ES256, ES384, ES512 | Asymmetric (ECDSA) | Recommended for production |
+| EdDSA (Ed25519, Ed448) | Asymmetric | Recommended for production |
+| HS256 | Symmetric | Development only |
+
+### Required JWT Claims
+
+| Claim | Required | Description |
+|-------|----------|-------------|
+| `sub` | Yes | User ID — returned by `auth.user_id()` in sync config queries |
+| `aud` | Yes | Must match the `audience` configured in PowerSync service config |
+| `iat` | Yes | Issued-at timestamp (seconds since epoch) |
+| `exp` | Yes | Expiry timestamp — must be at most 86400 seconds (24h) after `iat` |
+| `kid` | Yes (for JWKS) | Key ID — must match a key in the JWKS |
+
+### Generate RSA Key Pair
+
+```bash
+# Generate a 2048-bit RSA private key
+openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
+
+# Extract the public key
+openssl rsa -in private.pem -pubout -out public.pem
+```
+
+### Implement a JWKS Endpoint
+
+Your backend must serve a `/.well-known/jwks.json` endpoint. PowerSync fetches this every few minutes to get the public keys for token verification.
+
+```ts
+// Using jose library: npm install jose
+import { exportJWK, importPKCS8 } from 'jose';
+import { readFileSync } from 'fs';
+
+const privateKeyPem = readFileSync('./private.pem', 'utf-8');
+const KID = 'powersync-key-1'; // Stable key identifier
+
+let cachedJwk: any = null;
+
+export async function getJWKS() {
+  if (!cachedJwk) {
+    const privateKey = await importPKCS8(privateKeyPem, 'RS256');
+    const jwk = await exportJWK(privateKey);
+    // Only include the public key components
+    cachedJwk = {
+      kty: jwk.kty,
+      n: jwk.n,
+      e: jwk.e,
+      alg: 'RS256',
+      kid: KID,
+      use: 'sig',
+    };
+  }
+  return { keys: [cachedJwk] };
+}
+```
+
+### Generate JWTs (Token Endpoint)
+
+The token endpoint generates a PowerSync JWT for an already-authenticated user. It does **not** handle user login — your app authenticates users separately via sessions, OAuth, or whatever mechanism you use. The token endpoint simply takes a `user_id` and returns a signed JWT.
+
+```ts
+import { SignJWT, importPKCS8 } from 'jose';
+import { readFileSync } from 'fs';
+
+const privateKeyPem = readFileSync('./private.pem', 'utf-8');
+const KID = 'powersync-key-1';
+const POWERSYNC_URL = process.env.POWERSYNC_URL || 'http://localhost:8080';
+
+export async function generateToken(userId: string): Promise<string> {
+  const privateKey = await importPKCS8(privateKeyPem, 'RS256');
+
+  return new SignJWT({})
+    .setProtectedHeader({ alg: 'RS256', kid: KID })
+    .setSubject(userId)
+    .setIssuedAt()
+    .setIssuer('your-app')        // Must match issuer config if set
+    .setAudience(POWERSYNC_URL)   // Must match audience config
+    .setExpirationTime('5m')      // Short-lived; max 24h, PowerSync refreshes automatically
+    .sign(privateKey);
+}
+```
+
+### PowerSync Service Config for Custom Auth
+
+```yaml
+# powersync/service.yaml
+client_auth:
+  # Option 1: JWKS URI (recommended — supports key rotation)
+  jwks_uri: https://your-backend.com/.well-known/jwks.json
+  audience:
+    - powersync
+
+  # Option 2: Inline JWKS (no external endpoint needed)
+  # jwks:
+  #   keys:
+  #     - kty: RSA
+  #       n: "..."
+  #       e: "AQAB"
+  #       alg: RS256
+  #       kid: powersync-key-1
+  #       use: sig
+  # audience:
+  #   - powersync
+```
+
+For local development with `host.docker.internal`:
+
+```yaml
+client_auth:
+  jwks_uri: http://host.docker.internal:3001/.well-known/jwks.json
+  audience:
+    - powersync
+  block_local_jwks: false  # Required when JWKS URI resolves to a private IP
+```
+
+### Development Tokens (Self-Hosted)
+
+For quick development without setting up full auth, configure a signing key in `service.yaml` and use the CLI to generate tokens:
+
+```bash
+powersync generate token --user-id "test-user-123"
+```
+
+This requires `client_auth` to be configured with at least one key. See [Development Tokens](https://docs.powersync.com/configuration/auth/development-tokens.md).
+
+### Key Rotation
+
+When using a JWKS URI:
+
+1. Add the new key to the JWKS endpoint (keep the old key).
+2. Wait 5 minutes for PowerSync to refresh its key cache.
+3. Start signing tokens with the new key.
+4. Wait for all old tokens to expire (up to their `exp`).
+5. Remove the old key from the JWKS endpoint.
+
+## 3. Backend API for uploadData
+
+The client's `uploadData()` sends pending writes to your backend API. Your backend must:
+
+1. Accept the write operations.
+2. Apply them to Postgres **synchronously** (do not queue for later processing).
+3. Return 2xx — even for validation errors.
+
+### Request/Response Contract
+
+| Scenario | HTTP Status | Effect on Upload Queue |
+|----------|-------------|----------------------|
+| Success | 2xx | `transaction.complete()` advances the queue |
+| Validation error | 2xx (with error details in body) | Queue advances — surface errors via a synced table |
+| Transient error (DB down) | 5xx | PowerSync retries with backoff |
+| Auth error / permanent failure | 4xx | **Blocks the queue permanently** — never return 4xx for data errors |
+
+### CrudEntry Format (What the Client Sends)
+
+Each operation in the upload queue has this shape:
+
+```ts
+interface CrudEntry {
+  id: string;              // Row ID (UUID)
+  op: 'PUT' | 'PATCH' | 'DELETE';
+  table: string;           // Table name
+  opData?: Record<string, any>;  // Column values (undefined for DELETE)
+  transactionId?: number;  // Groups ops from the same writeTransaction()
+}
+```
+
+- `PUT` = full insert or replace (new row or complete overwrite)
+- `PATCH` = partial update (opData contains only changed columns)
+- `DELETE` = deletion (opData is undefined)
+
+### Example: Express Backend
+
+```ts
+import express from 'express';
+import pg from 'pg';
+
+const app = express();
+app.use(express.json());
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+
+// Token endpoint — client calls this in fetchCredentials()
+// This does NOT handle user authentication — your app authenticates users
+// separately (session, OAuth, etc.). This endpoint just generates a
+// PowerSync JWT for an already-authenticated user.
+app.get('/api/auth/token', async (req, res) => {
+  const userId = req.query.user_id as string;
+  if (!userId) return res.status(400).json({ error: 'user_id is required' });
+
+  // Optional: verify the caller is actually this user (check session, etc.)
+
+  const token = await generateToken(userId);
+  res.json({
+    token,
+    powersync_url: process.env.POWERSYNC_URL,
+  });
+});
+
+// JWKS endpoint — PowerSync fetches this to verify tokens
+app.get('/.well-known/jwks.json', async (_req, res) => {
+  const jwks = await getJWKS();
+  res.json(jwks);
+});
+
+// Upload endpoint — client's uploadData() calls this
+app.post('/api/powersync/upload', async (req, res) => {
+  const { operations } = req.body;
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    for (const op of operations) {
+      switch (op.op) {
+        case 'PUT': {
+          const columns = Object.keys(op.opData);
+          const values = Object.values(op.opData);
+          const placeholders = columns.map((_, i) => `$${i + 2}`).join(', ');
+          const updateSet = columns.map((col, i) => `${col} = $${i + 2}`).join(', ');
+          await client.query(
+            `INSERT INTO ${op.table} (id, ${columns.join(', ')})
+             VALUES ($1, ${placeholders})
+             ON CONFLICT (id) DO UPDATE SET ${updateSet}`,
+            [op.id, ...values]
+          );
+          break;
+        }
+        case 'PATCH': {
+          const columns = Object.keys(op.opData!);
+          const values = Object.values(op.opData!);
+          const setClause = columns.map((col, i) => `${col} = $${i + 2}`).join(', ');
+          await client.query(
+            `UPDATE ${op.table} SET ${setClause} WHERE id = $1`,
+            [op.id, ...values]
+          );
+          break;
+        }
+        case 'DELETE': {
+          await client.query(
+            `DELETE FROM ${op.table} WHERE id = $1`,
+            [op.id]
+          );
+          break;
+        }
+      }
+    }
+
+    await client.query('COMMIT');
+    res.json({ success: true });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('Upload error:', err);
+    // Return 2xx with error details — do NOT return 4xx
+    res.json({ success: false, error: (err as Error).message });
+  } finally {
+    client.release();
+  }
+});
+
+app.listen(3001, () => console.log('Backend running on :3001'));
+```
+
+**IMPORTANT:** The upload endpoint example above uses string interpolation for table names. In production, validate `op.table` against an allowlist of known tables to prevent SQL injection:
+
+```ts
+const ALLOWED_TABLES = new Set(['posts', 'comments', 'users']);
+if (!ALLOWED_TABLES.has(op.table)) {
+  return res.json({ success: false, error: `Unknown table: ${op.table}` });
+}
+```
+
+### Boolean Conversion
+
+PowerSync stores booleans as integers (0/1) in SQLite. If your Postgres schema uses native `boolean` columns, convert before writing:
+
+```ts
+// Convert 0/1 to true/false for boolean columns
+if (op.table === 'posts' && op.opData?.is_published !== undefined) {
+  op.opData.is_published = Boolean(op.opData.is_published);
+}
+```
+
+## 4. Client-Side Connector (Custom Backend)
+
+### fetchCredentials
+
+```ts
+import type { PowerSyncBackendConnector, PowerSyncCredentials } from '@powersync/web';
+
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;     // e.g. http://localhost:3001
+const POWERSYNC_URL = import.meta.env.VITE_POWERSYNC_URL;  // e.g. http://localhost:8080
+
+export class CustomConnector implements PowerSyncBackendConnector {
+  private userId: string;
+  private token: string | null = null;
+
+  constructor(userId: string) {
+    this.userId = userId;
+  }
+
+  async fetchCredentials(): Promise<PowerSyncCredentials> {
+    // Request a PowerSync JWT for the current user.
+    // Your app handles user authentication separately — this endpoint
+    // only generates PowerSync tokens for already-authenticated users.
+    const res = await fetch(
+      `${BACKEND_URL}/api/auth/token?user_id=${encodeURIComponent(this.userId)}`
+    );
+    if (!res.ok) throw new Error('Failed to get PowerSync token');
+
+    const { token, powersync_url } = await res.json();
+    this.token = token;
+
+    return {
+      endpoint: powersync_url || POWERSYNC_URL,
+      token,
+    };
+  }
+```
+
+### uploadData
+
+```ts
+  async uploadData(database: AbstractPowerSyncDatabase): Promise<void> {
+    const transaction = await database.getNextCrudTransaction();
+    if (!transaction) return;
+
+    try {
+      const operations = transaction.crud.map((op) => ({
+        id: op.id,
+        op: op.op,
+        table: op.table,
+        opData: op.opData,
+      }));
+
+      const res = await fetch(`${BACKEND_URL}/api/powersync/upload`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.token}`,
+        },
+        body: JSON.stringify({ operations }),
+      });
+
+      if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
+
+      const result = await res.json();
+      if (!result.success) {
+        // Log validation errors but still complete the transaction
+        // to prevent queue from stalling
+        console.warn('Upload had errors:', result.error);
+      }
+
+      // MUST call complete() — without this the queue stalls permanently
+      await transaction.complete();
+    } catch (ex) {
+      // Throw to retry later — PowerSync backs off automatically
+      throw ex;
+    }
+  }
+}
+```
+
+## 5. Complete Self-Hosted Docker Compose
+
+A full local development setup with custom Postgres, MongoDB (for PowerSync bucket storage), and the PowerSync service:
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app_password
+      POSTGRES_DB: myapp
+    command: ["postgres", "-c", "wal_level=logical"]
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+
+  mongo:
+    image: mongo:7
+    command: mongod --replSet rs0
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+  mongo-init:
+    image: mongo:7
+    depends_on:
+      - mongo
+    restart: "no"
+    entrypoint: >
+      mongosh --host mongo --eval "
+        try { rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: 'mongo:27017' }] }); }
+        catch(e) { if (e.codeName !== 'AlreadyInitialized') throw e; }
+      "
+
+  powersync:
+    image: journeyapps/powersync-service:latest
+    depends_on:
+      - mongo
+      - mongo-init
+    ports:
+      - "8080:8080"
+    environment:
+      PS_DATA_SOURCE_URI: "postgresql://app:app_password@postgres:5432/myapp"
+      PS_STORAGE_URI: "mongodb://mongo:27017/powersync_storage?replicaSet=rs0"
+      PS_JWKS_URI: "http://host.docker.internal:3001/.well-known/jwks.json"
+      PS_ADMIN_TOKEN: "dev-admin-token"
+      POWERSYNC_SYNC_CONFIG_B64: "<base64-encoded sync-config.yaml>"
+    volumes:
+      - ./powersync/service.yaml:/config/service.yaml
+    command: ["start", "-c", "/config/service.yaml"]
+
+volumes:
+  pg-data:
+  mongo-data:
+```
+
+Notes:
+- `PS_JWKS_URI` uses `host.docker.internal` to reach your backend API running on the host machine.
+- If Postgres is also in Docker (same compose), use the service name (`postgres:5432`) — no `host.docker.internal` needed, and no `sslmode: disable` needed.
+- If Postgres is on the host (e.g. local install, Supabase), use `host.docker.internal:<port>` and add `sslmode: disable` in the service.yaml if SSL is not configured.
+- Generate the base64 sync config: `base64 -i ./powersync/sync-config.yaml` (macOS) or `base64 -w0 ./powersync/sync-config.yaml` (Linux).
+
+## Common Pitfalls
+
+### 1. Returning 4xx from upload endpoint
+
+A 4xx response blocks the upload queue **permanently**. Always return 2xx, even for validation errors. Surface errors through a synced table or response body, never through HTTP status codes.
+
+### 2. Async processing of writes
+
+Do not accept the write and process it later (e.g., via a job queue). PowerSync's checkpoint system expects writes to be reflected in Postgres immediately so they can sync back to clients. If writes are delayed, clients see stale data or missing rows.
+
+### 3. Missing REPLICA IDENTITY FULL
+
+Without `ALTER TABLE ... REPLICA IDENTITY FULL`, PowerSync cannot sync DELETE operations to clients. The delete will apply in Postgres but clients keep the deleted row in local SQLite.
+
+### 4. Token expiry exceeding 24 hours
+
+PowerSync rejects tokens with `exp - iat > 86400` (24 hours). Use 1 hour for production, up to 24 hours for development.
+
+### 5. Missing `kid` in JWT header
+
+If the `kid` (Key ID) in the JWT header does not match any key in the JWKS, PowerSync returns `PSYNC_S2101: Could not find an appropriate key in the keystore`. Ensure the `kid` used in `setProtectedHeader()` matches the `kid` in your JWKS endpoint.
+
+### 6. Forgetting `block_local_jwks: false` for local development
+
+When the JWKS URI resolves to a private IP (`host.docker.internal`, `localhost`, `127.0.0.1`), PowerSync blocks the request by default. Set `block_local_jwks: false` in your service config for local development.

--- a/.claude/skills/powersync/references/onboarding-supabase-web.md
+++ b/.claude/skills/powersync/references/onboarding-supabase-web.md
@@ -1,0 +1,219 @@
+---
+name: onboarding-supabase-web
+description: Golden-path onboarding recipe for a React web app using Supabase auth with PowerSync Cloud
+metadata:
+  tags: onboarding, react, web, supabase, cloud, cli, dashboard, recipe
+---
+
+# React Web + Supabase + PowerSync Cloud
+
+Use this file for the benchmark-style onboarding path: existing web app, Supabase auth already wired, PowerSync added for offline-first reads and queued uploads.
+
+**Strongly prefer the [PowerSync CLI](https://docs.powersync.com/tools/cli.md) as the first option** for setup — creating/linking the instance, deploying service config, and deploying sync config. See `references/powersync-cli.md`. Fall back to the dashboard if the CLI is unavailable or the user explicitly prefers it.
+
+## Required Inputs
+
+Collect these before editing app code:
+
+- Whether the PowerSync Cloud instance already exists
+- PowerSync instance URL, if the instance already exists
+- Project ID and instance ID, if using CLI with an existing instance
+- Supabase Postgres connection string, if the PowerSync source DB connection is not already configured
+- `PS_ADMIN_TOKEN` or willingness to run `powersync login` (for CLI deployment)
+
+Only ask for the Postgres connection string when you are at the service configuration step.
+
+## Workflow
+
+Follow this sequence exactly. **Prefer the [PowerSync CLI](https://docs.powersync.com/tools/cli.md)** (see `references/powersync-cli.md`) as the first option to create/link the instance and to deploy service config and sync config. Try running the CLI commands directly before sending the user to the dashboard.
+
+1. Confirm the path is PowerSync Cloud + Supabase + web app.
+2. Generate the sync config and Supabase SQL based on the app's tables.
+3. **Run the Supabase publication SQL before deploying.** The publication must exist before PowerSync connects to the database — deploying without it causes replication errors. Present the exact SQL to the user and ask them to run it in the Supabase SQL Editor and confirm when done.
+4. **Deploy backend setup before writing app code:**
+   - Use `powersync deploy sync-config` and `powersync deploy service-config` to deploy directly via CLI.
+   - Do not defer deployment to a post-implementation summary — the app will not sync without a deployed sync config.
+5. Verify backend readiness.
+6. Only then implement app-side PowerSync integration.
+7. If the UI is stuck on `Syncing...`, re-check backend readiness before touching frontend code.
+
+### Sync Config Deployment
+
+The sync config tells the PowerSync service what data to replicate to each client. It **must** be deployed before the app will sync. Strongly prefer the [PowerSync CLI](https://docs.powersync.com/tools/cli.md) to deploy it (see `references/powersync-cli.md`):
+
+```bash
+powersync deploy sync-config
+```
+
+For service config changes (e.g. database connection, client auth):
+
+```bash
+powersync deploy service-config
+```
+
+Prefer the CLI for creating/linking the instance and for all deploys. If the CLI is not available or the user explicitly prefers the dashboard, instruct them to paste the sync config into the PowerSync dashboard Sync Config editor and deploy from there.
+
+For Supabase publication SQL, the agent cannot run this directly. Present the exact SQL to the user and ask them to confirm it is done before proceeding.
+
+## Backend Readiness Checklist
+
+Do not move on until all items below are true:
+
+- PowerSync instance exists
+- Source DB connection is configured
+- Sync config is deployed
+- Client auth is configured for Supabase
+- PowerSync instance URL is known
+- Supabase publication exists for the synced tables
+
+## New Cloud Instance
+
+### CLI path (Recommended)
+
+Prefer the [PowerSync CLI](https://docs.powersync.com/tools/cli.md) for every step below unless the user says otherwise. Full reference: `references/powersync-cli.md`. Prefer `PS_ADMIN_TOKEN` in autonomous or noninteractive environments.
+
+1. Authenticate:
+   ```bash
+   PS_ADMIN_TOKEN=your-token-here powersync fetch instances
+   ```
+   If no token is available, use `powersync login` and treat it as interactive.
+2. Scaffold:
+   ```bash
+   powersync init cloud
+   ```
+3. Edit `powersync/service.yaml` and `powersync/sync-config.yaml` using the minimum examples below.
+4. **Create and link the instance** (prefer CLI):
+   ```bash
+   powersync link cloud --create --project-id=<project-id>
+   ```
+5. **Run the Supabase publication SQL below.** The publication must exist before PowerSync connects to the database. Present the SQL to the user, ask them to run it in the Supabase SQL Editor, and confirm it is done before proceeding.
+6. **Deploy service config, then sync config** (prefer CLI):
+   ```bash
+   powersync deploy service-config
+   powersync deploy sync-config
+   ```
+7. Copy the instance URL.
+
+### Dashboard path
+
+Only use if the user explicitly prefers the dashboard or the CLI is unavailable.
+
+1. Create a project and a new PowerSync Cloud instance in the dashboard.
+2. **Run the Supabase publication SQL below.** The publication must exist before PowerSync connects to the database.
+3. In the instance, connect the Supabase database.
+4. In Sync Config, deploy the minimum sync config below.
+5. In Client Auth, enable **Use Supabase Auth**.
+6. If Supabase uses new signing keys, leave the JWT secret field empty.
+7. Copy the instance URL for app `fetchCredentials()`.
+
+## Existing Cloud Instance
+
+### Hard rule
+
+Never run `powersync pull instance` after editing local config. If you need to pull config, do it first and back up local files before making any manual edits.
+
+### CLI path (Recommended)
+
+1. Authenticate with `PS_ADMIN_TOKEN` if available, otherwise `powersync login`.
+2. Pull config before editing:
+   ```bash
+   powersync pull instance --project-id=<project-id> --instance-id=<instance-id>
+   ```
+3. Inspect the pulled files before making changes.
+4. Edit only the files that need changes.
+5. Prefer targeted deploys:
+   ```bash
+   powersync deploy service-config
+   powersync deploy sync-config
+   ```
+6. Do not pull again after editing unless you first back up the local files.
+
+## Minimum `service.yaml`
+
+Use this structure for PowerSync Cloud with Supabase:
+
+```yaml
+# powersync/service.yaml
+replication:
+  connections:
+    - type: postgresql
+      uri: !env PS_DATABASE_URI
+
+client_auth:
+  supabase: true
+```
+
+Rules:
+
+- The database connection must be under `replication.connections`.
+- Do not use a top-level `connections:` key.
+- If using legacy Supabase JWT signing keys, add `supabase_jwt_secret`.
+- `!env PS_DATABASE_URI` reads from the shell environment — it is **not** prompted by the CLI. Set the variable before deploying: `PS_DATABASE_URI="postgresql://..." powersync deploy service-config`. Get the Supabase Postgres URI from Supabase Dashboard → Project Settings → Database → Connection string (URI).
+
+## Minimum `sync-config.yaml`
+
+```yaml
+config:
+  edition: 3
+
+streams:
+  posts:
+    auto_subscribe: true
+    query: SELECT * FROM posts WHERE user_id = auth.user_id()
+```
+
+Rules:
+
+- Keep the top-level `config:` wrapper.
+- Use Sync Streams for new work.
+- Scope per-user data with `auth.user_id()` when appropriate.
+
+## Supabase SQL
+
+Run this in the Supabase SQL Editor after the tables exist:
+
+```sql
+CREATE PUBLICATION powersync FOR TABLE posts;
+ALTER TABLE posts REPLICA IDENTITY FULL;
+```
+
+If more tables should sync, add them to the publication or use `FOR ALL TABLES`.
+
+## Client Auth Setup
+
+For PowerSync Cloud + Supabase:
+
+1. Enable **Use Supabase Auth** in the instance Client Auth settings.
+2. If Supabase uses new signing keys, leave the JWT secret empty.
+3. If Supabase uses legacy signing keys, provide the Supabase JWT secret.
+4. Save and deploy.
+
+## Verification Before App Integration
+
+Verify all of these before changing app code:
+
+1. `service.yaml` or dashboard DB settings point at the correct Supabase database.
+2. Sync config is deployed and includes `config: edition: 3`.
+3. Client Auth is enabled for Supabase.
+4. The PowerSync instance URL is available.
+5. The Supabase publication exists for the synced tables.
+
+Only after that should you:
+
+- add the SDK packages
+- implement `fetchCredentials()`
+- implement `uploadData`
+- switch reads to local SQLite
+- test offline behavior
+
+## If the App Is Stuck on `Syncing...`
+
+Check these in order:
+
+1. Wrong PowerSync instance URL
+2. Missing source DB connection
+3. Missing or invalid sync config
+4. Missing Supabase client auth setup
+5. Missing Supabase publication
+
+Do not assume the bug is in React code until all five checks pass.

--- a/.claude/skills/powersync/references/powersync-cli.md
+++ b/.claude/skills/powersync/references/powersync-cli.md
@@ -1,0 +1,529 @@
+---
+name: powersync-cli
+description: PowerSync CLI — managing and deploying PowerSync instances from the command line for Cloud and self-hosted setups
+metadata:
+  tags: cli, powersync, cloud, self-hosted, deploy, sync-config, schema, token, devops, docker, docker-compose
+---
+
+# PowerSync CLI
+
+The PowerSync CLI manages Cloud and self-hosted PowerSync instances from the command line. It supports local config management, schema generation, development token generation, deployment, and more. See [this](https://docs.powersync.com/tools/cli.md) for any information not supplied in this document about the CLI.
+
+## Recommended Defaults for Agents
+
+Use these defaults unless the user explicitly wants something else:
+
+- Prefer `PS_ADMIN_TOKEN` in autonomous or noninteractive environments.
+- Treat `powersync login` as interactive and likely to interrupt the flow.
+- Prefer `powersync deploy service-config` or `powersync deploy sync-config` over `powersync deploy` when only one file changed.
+- For existing Cloud instances, pull config before manual edits and never pull again after editing unless local files were backed up first.
+
+## High-Probability Failure Modes
+
+- `No connection found in config` usually means the database connection was placed at the root instead of `replication.connections`.
+- Sync config validation or deploy failures often mean `powersync/sync-config.yaml` is missing the top-level `config: edition: 3` wrapper.
+- `powersync pull instance` silently overwrites local `service.yaml` and `sync-config.yaml`.
+
+## Recommended Cloud Sequence
+
+For the common Cloud path, use this order:
+
+1. Authenticate with `PS_ADMIN_TOKEN` if available, otherwise `powersync login`.
+2. Create or pull config.
+3. Edit `service.yaml`.
+4. Edit `sync-config.yaml`.
+5. Deploy service config.
+6. Deploy sync config.
+7. Verify status.
+
+## Installation
+```bash
+npm install -g powersync
+
+# or run via npx (0.9.0 is the first version with the new CLI)
+npx powersync@0.9.0
+```
+
+## How the CLI Resolves Instance Information
+
+The CLI needs to know which instance to operate against. It uses the first available source in this order:
+
+| Priority | Method | How |
+|----------|--------|-----|
+| 1 (highest) | Flags | `--instance-id`, `--project-id`, `--api-url`, etc. |
+| 2 | Environment variables | `INSTANCE_ID`, `PROJECT_ID`, `API_URL`, etc. |
+| 3 (lowest) | Link file | `powersync/cli.yaml` written by `powersync link` |
+
+For Cloud, `--org-id` / `ORG_ID` is optional — omit it when your token has access to exactly one org. If the token covers multiple orgs, it must be provided.
+
+## Authentication
+
+Cloud commands require a PowerSync personal access token (PAT). If the user does not have one, direct them to generate one at: https://dashboard.powersync.com/account/access-tokens
+
+Prefer `PS_ADMIN_TOKEN` when the environment is noninteractive or when the agent should avoid browser/device-login interruptions.
+
+The CLI checks in this order:
+
+1. `PS_ADMIN_TOKEN` environment variable
+2. Token stored via `powersync login` (macOS Keychain or config-file fallback)
+
+```bash
+# Store token for local use — opens browser to create a token or paste an existing one
+powersync login
+
+# CI / one-off — set env var
+export PS_ADMIN_TOKEN=your-token-here
+
+# Inline for a single command
+PS_ADMIN_TOKEN=your-token-here powersync fetch config --output=json
+
+# Remove stored token
+powersync logout
+```
+
+When secure storage is unavailable, `powersync login` asks whether to store the token in a plaintext config file after explicit confirmation. Decline and use `PS_ADMIN_TOKEN` instead.
+
+Self-hosted instances use `PS_ADMIN_TOKEN` as the API key (not accepted via flags — use the link file or env var).
+
+## Config Files
+
+Define your instance and sync config in YAML files so you can version them in git, review changes before deploying, and run `powersync validate` before `powersync deploy`. The CLI uses a config directory (default `powersync/`) containing:
+
+| File | Purpose |
+|------|---------|
+| `service.yaml` | Instance configuration: name, region, replication DB connection, client auth |
+| `sync-config.yaml` | Sync Streams (or Sync Rules) configuration |
+| `cli.yaml` | Link file (written by `powersync link`); ties this directory to an instance |
+
+All YAML files support the `!env` custom tag for secrets and environment-specific values:
+
+```yaml
+uri: !env PS_DATABASE_URI           # string (default)
+port: !env PS_PORT::number          # typed: number
+enabled: !env FEATURE_FLAG::boolean # typed: boolean
+```
+
+### IDE Support
+
+```bash
+powersync configure ide   # YAML schema validation, !env custom tag, autocomplete
+```
+
+### Config Studio (built-in editor)
+
+```bash
+powersync edit config     # Monaco editor for service.yaml and sync-config.yaml
+```
+
+Config Studio provides schema-aware validation, autocomplete, and inline sync config errors. Changes are written back to your config directory.
+
+### Cloud Secrets
+
+For Cloud `service.yaml`, supply DB credentials from an environment variable at deploy time:
+
+```yaml
+# First deploy — supply secret via env var
+password: secret: !env PS_DATABASE_PASSWORD
+
+# After first deploy — reuse stored secret without re-supplying
+password: secret_ref: default_password
+```
+
+## Cloud Usage
+
+### New Cloud Instance
+
+**Information the agent must collect from the user before proceeding:**
+- PowerSync account (if they don't have one, direct to https://dashboard.powersync.com to sign up)
+- A project on the dashboard (required before creating an instance — if they don't have one, they must create one at https://dashboard.powersync.com first)
+- Project ID (find on dashboard or via `powersync fetch instances` after login)
+- Org ID (only if their token covers multiple organizations)
+- Database connection details (type, host, port, database name, username, password)
+
+**Step-by-step:**
+
+```bash
+# 1. Authenticate
+powersync login                               # opens browser for PAT
+
+# 2. Scaffold config files
+powersync init cloud                          # creates powersync/ with service.yaml and sync-config.yaml
+```
+
+**After `powersync init cloud`:** Read the generated `powersync/service.yaml` and `powersync/sync-config.yaml`. These contain placeholder values. Prompt the user for their database connection details and edit the files before continuing.
+
+```bash
+# 3. Create instance and deploy
+powersync link cloud --create --project-id=<project-id>
+# Add --org-id=<org-id> only if token has multiple orgs
+powersync validate
+powersync deploy
+```
+
+#### Cloud service.yaml Example
+
+The database connection **must** be nested under `replication.connections` — not at the root level:
+
+```yaml
+# powersync/service.yaml — Cloud
+replication:
+  connections:
+    - type: postgresql
+      hostname: !env PS_DATABASE_HOST
+      port: 5432
+      database: !env PS_DATABASE_NAME
+      username: !env PS_DATABASE_USER
+      password:
+        secret: !env PS_DATABASE_PASSWORD   # stored as Cloud secret on first deploy
+      sslmode: verify-full
+```
+
+For the full `service.yaml` schema, see `references/powersync-service.md`.
+
+#### Cloud sync-config.yaml Example
+
+The `sync-config.yaml` **must** start with a `config: edition: 3` top-level wrapper:
+
+```yaml
+# powersync/sync-config.yaml — Cloud
+config:
+  edition: 3
+
+streams:
+  my_data:
+    auto_subscribe: true
+    query: SELECT * FROM my_table WHERE user_id = auth.user_id()
+```
+
+For the full sync config reference, see `references/sync-config.md`.
+
+### Existing Cloud Instance
+
+**Information the agent must collect from the user:**
+- Project ID
+- Instance ID
+- Org ID (only if token covers multiple orgs)
+
+The user can find these on the PowerSync Dashboard or by running `powersync fetch instances` after `powersync login`.
+
+```bash
+powersync login
+powersync pull instance --project-id=<project-id> --instance-id=<instance-id>
+# Add --org-id=<org-id> only if token has multiple orgs
+```
+
+This creates `powersync/`, writes `cli.yaml`, and downloads `service.yaml` and `sync-config.yaml`.
+
+If the directory is already linked, `powersync pull instance` (no IDs needed) refreshes local config from the cloud.
+
+**WARNING:** `powersync pull instance` **silently overwrites** your local `service.yaml` and `sync-config.yaml` with the remote version. Any hand-crafted or uncommitted local changes will be lost without warning or merge prompt. Always commit or back up local config files before running `pull instance`.
+
+After pulling, edit files as needed, then:
+```bash
+powersync validate
+powersync deploy
+```
+
+Prefer targeted deploys after edits:
+```bash
+powersync deploy service-config
+powersync deploy sync-config
+```
+
+### Deploy Commands
+
+```bash
+powersync deploy                # deploy both service config and sync config
+powersync deploy service-config # service config only (keeps cloud sync config unchanged)
+powersync deploy sync-config    # sync config only (keeps cloud service config unchanged)
+```
+
+Prefer targeted deploys when only one file changed.
+
+### One-Off Commands (No Local Config)
+
+```bash
+powersync login
+powersync fetch instances                          # see available instances and IDs
+powersync link cloud --instance-id=<id> --project-id=<id>
+powersync generate schema
+powersync generate token
+```
+
+## Self-Hosted Usage
+
+### Self-Hosted with CLI + Docker (Recommended for Local Development)
+
+The CLI manages a full Docker Compose stack for local development and testing.
+
+**Prerequisites:** Docker and Docker Compose V2 (2.20.3+).
+
+**Information the agent may need from the user:**
+- If using `--database external`: the source database URI (set as `PS_DATA_SOURCE_URI`)
+- If using `--storage external`: the storage database URI (set as `PS_STORAGE_SOURCE_URI`)
+- If using the default options: no user input needed — the CLI provisions local Postgres for both
+
+**Step-by-step:**
+
+```bash
+# 1. Scaffold config
+powersync init self-hosted                    # creates powersync/ with service.yaml template
+
+# 2. Configure Docker stack
+powersync docker configure
+# Use --database external to connect to an existing source database
+# Use --storage external to use an existing storage database
+
+# 3. Start the stack
+powersync docker start                        # docker compose up -d --wait
+```
+
+**After `powersync init self-hosted`:** Read the generated `powersync/service.yaml`. If the user is connecting to an external database, prompt them for the connection URI and update the file. The `powersync docker configure` command will merge Docker-specific settings into `service.yaml` and write `cli.yaml`.
+
+```bash
+# 4. Verify and use the instance
+powersync status
+powersync validate
+powersync generate schema --output=ts --output-path=./schema.ts
+powersync generate token --subject=user-test-1
+```
+
+### Self-Hosted — Linking to an Existing Instance
+
+For self-hosted instances already running (not managed by the CLI), the CLI can link to them for schema generation, token generation, and status checks.
+
+**Information the agent must collect from the user:**
+- API URL of the running PowerSync instance
+- API token (must match a token configured in the instance's `api.tokens` setting)
+
+```bash
+powersync init self-hosted                    # scaffold config template
+# Edit powersync/service.yaml (include api.tokens for API key auth)
+
+powersync link self-hosted --api-url=https://your-powersync.example.com
+# Set PS_ADMIN_TOKEN env var to match the instance's api.tokens value
+
+powersync status
+powersync generate schema
+powersync generate token
+```
+
+`--api-url` is the URL the running PowerSync instance is exposed from (configured by your deployment — Docker, Coolify, etc.).
+
+Supported self-hosted commands: `status`, `generate schema`, `generate token`, `validate`, `fetch instances`. The CLI does **not** create, deploy to, or pull config from a remote self-hosted server — you manage the server and its config yourself.
+
+## Supplying Instance Info Without Linking
+
+### Via Flags
+
+```bash
+# Cloud
+powersync stop --confirm=yes \
+  --instance-id=<id> \
+  --project-id=<id>
+# Add --org-id=<id> only if token has multiple orgs
+
+# Self-hosted (API key from PS_ADMIN_TOKEN or cli.yaml)
+powersync status --api-url=https://powersync.example.com
+```
+
+### Via Environment Variables
+
+```bash
+# Cloud
+export INSTANCE_ID=<id>
+export PROJECT_ID=<id>
+# export ORG_ID=<id>   # only if token has multiple orgs
+powersync stop --confirm=yes
+
+# Self-hosted
+export API_URL=https://powersync.example.com
+export PS_ADMIN_TOKEN=your-api-key
+powersync status --output=json
+
+# Inline
+INSTANCE_ID=<id> PROJECT_ID=<id> powersync stop --confirm=yes
+API_URL=https://... PS_ADMIN_TOKEN=... powersync status
+```
+
+## Multi-Environment Setup
+
+### Option A — Separate directories per environment
+
+```bash
+powersync deploy --directory=powersync          # production
+powersync deploy --directory=powersync-dev      # dev
+powersync deploy --directory=powersync-staging  # staging
+```
+
+Each directory has its own `cli.yaml` pointing at a different instance.
+
+### Option B — Single directory with `!env` substitution
+
+Use one `powersync/` folder and vary instance info via environment variables. Both `cli.yaml` and config files support `!env`.
+
+`cli.yaml` (Cloud):
+```yaml
+type: cloud
+instance_id: !env MY_INSTANCE_ID
+project_id: !env MY_PROJECT_ID
+org_id: !env MY_ORG_ID
+```
+
+`cli.yaml` (self-hosted):
+```yaml
+type: self-hosted
+api_url: !env API_URL
+api_key: !env PS_ADMIN_TOKEN
+```
+
+`service.yaml` (secrets and environment-specific values):
+```yaml
+# uri: !env PS_DATA_SOURCE_URI
+# password: !env PS_DATABASE_PASSWORD
+```
+
+## Local Config Directory
+
+The default config directory is `powersync/`. Override with `--directory`:
+
+```bash
+powersync deploy --directory=my-powersync
+```
+
+Contents of `powersync/`:
+- `cli.yaml` — link file (instance identifiers, written by `powersync link`)
+- `service.yaml` — service configuration (name, region, replication connection, auth)
+- `sync-config.yaml` — sync rules / sync streams config
+
+## Docker Commands Reference
+
+For the full Docker setup workflow, see [Self-Hosted with CLI + Docker](#self-hosted-with-cli--docker-recommended-for-local-development) above.
+
+### Stop and Reset
+
+```bash
+powersync docker stop                    # stop containers, keep them (can restart)
+powersync docker stop --remove           # stop and remove containers
+powersync docker stop --remove-volumes   # stop, remove containers and named volumes (implies --remove)
+powersync docker reset                   # full teardown then start (docker compose down + up --wait)
+```
+
+Use `--remove-volumes` when you need init scripts to re-run on the next start (e.g. "Publication 'powersync' does not exist" error). Then run `powersync docker reset` to bring the stack back up clean.
+
+### Docker Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `powersync docker configure` | Create `docker/` layout with chosen modules, merge config into `service.yaml`, write `cli.yaml`. Remove existing `docker/` first to re-run. |
+| `powersync docker start` | `docker compose up -d --wait`. Use after configure or after stop. |
+| `powersync docker reset` | `docker compose down` then `docker compose up -d --wait`. Use after config changes or to clear a bad state. |
+| `powersync docker stop` | Stop stack. Add `--remove` to remove containers, `--remove-volumes` to also remove volumes. |
+
+### Docker Flags
+
+| Flag | Applies to | Description |
+|------|-----------|-------------|
+| `--directory` | configure, start, reset | Config directory (default: `powersync/`). Compose dir is `<directory>/docker/`. |
+| `--database` | configure | `postgres` (default) or `external` |
+| `--storage` | configure | `postgres` (default) or `external` |
+| `--project-name` | stop | Docker Compose project name. If omitted, reads from `cli.yaml`. |
+| `--remove` | stop | Remove containers after stopping (`docker compose down`). |
+| `--remove-volumes` | stop | Remove containers and named volumes (`docker compose down -v`). Implies `--remove`. |
+
+`--database external`: set `PS_DATA_SOURCE_URI` in `powersync/docker/.env`.
+`--storage external`: set `PS_STORAGE_SOURCE_URI` in `powersync/docker/.env`.
+
+## Deploying from CI (e.g. GitHub Actions)
+
+Keep `service.yaml` and `sync-config.yaml` in the repo (with secrets via `!env` and CI secrets), then run `powersync deploy` or `powersync deploy sync-config`.
+
+Required CI environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `PS_ADMIN_TOKEN` | PowerSync personal access token |
+| `INSTANCE_ID` | Target instance (if not using a linked directory) |
+| `PROJECT_ID` | Target project (if not using a linked directory) |
+| `ORG_ID` | Required only if token has multiple organizations |
+| `API_URL` | Self-hosted: PowerSync API base URL |
+
+```bash
+# Example: deploy sync config on push
+PS_ADMIN_TOKEN=${{ secrets.PS_ADMIN_TOKEN }} \
+INSTANCE_ID=${{ vars.INSTANCE_ID }} \
+PROJECT_ID=${{ vars.PROJECT_ID }} \
+powersync deploy sync-config
+```
+
+## Common Commands
+
+| Command | Description |
+|---------|-------------|
+| `powersync login` | Store PAT for Cloud (interactive or paste token) |
+| `powersync logout` | Remove stored token |
+| `powersync init cloud` | Scaffold Cloud config directory |
+| `powersync init self-hosted` | Scaffold self-hosted config directory |
+| `powersync configure ide` | Configure IDE for YAML schema validation and `!env` support |
+| `powersync link cloud --project-id=<id>` | Link to an existing Cloud instance |
+| `powersync link cloud --create --project-id=<id>` | Create a new Cloud instance and link |
+| `powersync link self-hosted --api-url=<url>` | Link to a self-hosted instance by API URL |
+| `powersync pull instance --project-id=<id> --instance-id=<id>` | Download Cloud config into local files |
+| `powersync deploy` | Deploy full config to linked Cloud instance |
+| `powersync deploy service-config` | Deploy only service config |
+| `powersync deploy sync-config` | Deploy only sync config (optional `--sync-config-file-path`) |
+| `powersync validate` | Validate config and sync rules/streams |
+| `powersync edit config` | Open Config Studio (Monaco editor for service.yaml and sync-config.yaml) |
+| `powersync migrate sync-rules` | Migrate Sync Rules to Sync Streams |
+| `powersync fetch instances` | List Cloud and linked instances (optionally by project/org) |
+| `powersync fetch config` | Print linked Cloud instance config (YAML/JSON) |
+| `powersync status` | Instance diagnostics (connections, replication); Cloud and self-hosted |
+| `powersync generate schema --output=ts --output-path=schema.ts` | Generate client-side schema |
+| `powersync generate token --subject=user-123` | Generate a development JWT (see Development Tokens below) |
+| `powersync destroy --confirm=yes` | [Cloud only] Permanently destroy the linked instance |
+| `powersync stop --confirm=yes` | [Cloud only] Stop the linked instance (restart with deploy) |
+
+For full usage and flags, run `powersync --help` or `powersync <command> --help`.
+
+## Development Tokens
+
+`powersync generate token --subject=<user-id>` generates a short-lived JWT for local development and testing.
+
+**Cloud:** The instance manages signing keys automatically. `generate token` works immediately after `powersync deploy` with no additional `client_auth` configuration needed.
+
+**Self-hosted:** The instance must have `client_auth` configured in `service.yaml` with a real signing key (JWKS URI, inline JWKs, Supabase Auth, or shared secret) before `generate token` will work. There is no `dev: true` auth type — that does not exist in the config schema.
+
+```bash
+powersync generate token --subject=user-test-1
+# Copy the token output and use it as the JWT in fetchCredentials()
+```
+
+Dev tokens are for development only. In production, `fetchCredentials()` must return a real JWT from your auth provider.
+
+## Migrating from the Previous CLI (0.8.0 → 0.9.0)
+
+Version 0.9.0 is not backwards compatible with 0.8.0. To stay on the old CLI:
+
+```bash
+npm install -g @powersync/cli@0.8.0
+```
+
+Otherwise, upgrade to the latest `powersync` package and follow this mapping:
+
+| Previous CLI | New CLI |
+|-------------|---------|
+| `npx powersync init` (enter token, org, project) | `powersync login` (token only). Then `powersync init cloud` to scaffold, or `powersync pull instance --project-id=... --instance-id=...` to pull an existing instance. |
+| `powersync instance set --instanceId=<id>` | `powersync link cloud --instance-id=<id> --project-id=<id>` (writes `cli.yaml`). Use `--directory` for a specific folder. |
+| `powersync instance deploy` (interactive or long flag list) | Edit `powersync/service.yaml` and `powersync/sync-config.yaml`, then `powersync deploy`. Config is in files, not command args. |
+| `powersync instance config` | `powersync fetch config` (output as YAML or JSON with `--output`). |
+| Deploy only sync rules | `powersync deploy sync-config` |
+| `powersync instance schema` | `powersync generate schema --output=... --output-path=...` |
+| Org/project stored by init | Pass `--org-id` and `--project-id` when needed, or use `powersync link cloud` so they are stored in `powersync/cli.yaml`. For CI, use env vars: `PS_ADMIN_TOKEN`, `INSTANCE_ID`, `PROJECT_ID`, `ORG_ID`. |
+
+**Summary:** Authenticate with `powersync login` (or `PS_ADMIN_TOKEN` in CI). Use a config directory with `service.yaml` and `sync-config.yaml` as the source of truth. Link with `powersync link cloud` or `powersync pull instance`, then run `powersync deploy`. No more setting "current instance" separately from config — the directory and `cli.yaml` define the target.
+
+## Known Issues and Limitations
+
+- When secure storage is unavailable, `powersync login` may store the token in a plaintext config file after explicit confirmation.
+- Self-hosted: the CLI does not create or manage instances on your server, or deploy config to it. It only links to an existing API and runs a subset of commands (`status`, `generate schema/token`, `validate`). The sole exception is Docker — it starts a local PowerSync Service in containers for development, not a remote or production instance.
+- Some validation checks require a connected instance; validation of an unprovisioned instance may show errors that resolve after the first deployment.

--- a/.claude/skills/powersync/references/powersync-debug.md
+++ b/.claude/skills/powersync/references/powersync-debug.md
@@ -1,0 +1,217 @@
+---
+name: powersync-debug
+description: PowerSync debugging and troubleshooting — sync status, JWT verification, PSYNC error codes, replication lag, and diagnostics tools
+metadata:
+  tags: debugging, troubleshooting, sync-status, jwt, psync-errors, replication-lag, ps-crud, diagnostics
+---
+
+# PowerSync Debug
+
+These are debugging steps most frequently recommended by PowerSync, with an explanation of what problem each step helps identify and why it works.
+
+Make sure to understand the [PowerSync Architecture](references/powersync-overview.md) before debugging.
+
+## First Response When the UI Is Stuck on `Syncing...`
+
+Before asking for console logs or editing app code, verify these in order:
+
+1. The PowerSync endpoint URL returned by `fetchCredentials()` is correct.
+2. The PowerSync service has a valid source DB connection.
+3. Sync config was deployed and starts with `config: edition: 3`.
+4. Client auth is configured correctly.
+5. The Supabase publication exists for the synced tables.
+
+Only inspect frontend connector code or SDK state after all five checks pass.
+
+Before requesting browser console logs, ask the user to confirm:
+
+- the instance exists
+- the DB connection was configured
+- sync config was deployed
+- client auth was configured
+- the Supabase SQL was run
+
+## Check `SyncStatus` / `currentStatus` Before Investigating Further
+
+What it identifies: Whether the SDK is actually connected, syncing, or has hit an error, before diving into logs.
+
+Why: `SyncStatus` is the SDK's live view of its own state. It surfaces connection state, whether a first sync has completed, whether uploads are processing etc. Checking it first avoids chasing a perceived bug that is actually just "not yet connected."
+
+How:
+
+Each of the PowerSync Client SDKs have the SyncStatus class that can be used to access the client sync status.
+
+| SDK             | Link                                                                                                                                                                                                |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Flutter         | [SyncStatus Class](https://pub.dev/documentation/powersync/latest/powersync/SyncStatus-class.html)                                                                                                  |
+| Kotlin          | [SyncStatus Class](https://powersync-ja.github.io/powersync-kotlin/core/com.powersync.sync/-sync-status/index.html?query=data%20class%20SyncStatus%20:%20SyncStatusData)                            |
+| Swift           | [SyncStatusData](https://powersync-ja.github.io/powersync-swift/documentation/powersync/syncstatusdata)                                                                                            |
+| Web             | [SyncStatus Class](https://powersync-ja.github.io/powersync-js/web-sdk/classes/SyncStatus)                                                                                                          |
+| React Native    | [SyncStatus Class](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/SyncStatus)                                                                                                |
+| Node.js         | [SyncStatus Class](https://powersync-ja.github.io/powersync-js/node-sdk/classes/SyncStatus)                                                                                                         |
+| .NET (Alpha)    | [SyncStatus.cs](https://github.com/powersync-ja/powersync-dotnet/blob/2728eab0d13849686ff3f9a603040940744599e1/PowerSync/PowerSync.Common/DB/Crud/SyncStatus.cs)                                   |
+
+Key fields to check: `connected`, `downloading`, `uploading`, `lastSyncedAt`, `hasSynced`, `downloadError`, `uploadError`.
+
+## Enable `newClientImplementation: false` (Swift SDK only)
+
+What it identifies: Authentication failures, JWT errors, and endpoint misconfigurations that are silently swallowed by the default WebSocket client on Apple platforms.
+
+Why: The default WebSocket-based sync client on iOS/macOS restricts logging due to platform constraints. Switching to `newClientImplementation: false` uses the HTTP streaming client instead, which produces full request/response logs including headers, status codes, and error bodies. The actual 401 + `PSYNC_S2101` error that pointed to a JWT key mismatch was only visible after this switch.
+
+How: In the `connect` function for each of the PowerSync Client SDKs, disable the Rust Sync Client / disable `newClientImplementation`.
+
+Revert after debugging: The default WebSocket client is preferred for production.
+
+## Enable the Request Logger (Swift SDK)
+
+What it identifies: The exact HTTP request being made to the PowerSync Service to inspect the URL, method, headers, authorization token, and response status code.
+
+Why: Even with `newClientImplementation: false`, request details aren't logged by default. Adding a `SyncRequestLoggerConfiguration` gives you a full audit trail of every sync stream request, which lets you verify the `endpoint` URL is correct and the JWT is being sent.
+
+How:
+```swift
+try await db.connect(
+    connector: connector,
+    options: ConnectOptions(
+        newClientImplementation: false,
+        clientConfiguration: SyncClientConfiguration(
+            requestLogger: SyncRequestLoggerConfiguration(
+                requestLevel: .headers
+            ) { message in
+                print("[SyncRequest] \(message)")
+            }
+        )
+    )
+)
+```
+
+Look for: The `Authorization: Token <jwt>` header and the response status (`200`, `401`, `404`). A `401` with `PSYNC_S2101` in the response body means JWT key ID mismatch.
+
+## Use the Sync Diagnostics Client
+
+What it identifies: Whether the PowerSync Service is processing your sync rules correctly, what data is in each bucket for a given user, and whether parameter queries are resolving as expected.
+
+Why: Most "data not showing up on the client" issues are actually server-side: wrong Sync Rules / Sync Streams, parameter query not matching etc. The Diagnostics Client lets you verify this without touching client code. It runs entirely in the browser against your real instance.
+
+How: Go to [diagnostics-app.powersync.com](https://diagnostics-app.powersync.com/), connect to your PowerSync instance, and:
+1. Check the Client Parameters page to configure client parameters to test buckets that use parameter queries.
+2. Run queries directly in the SQL Console to confirm row counts.
+3. Check bucket and Sync Streams subscriptions contents to see exactly what data will be synced to a given user.
+4. Use the SQLite File Inspector to drag-and-drop a local `.db` file and inspect its contents directly in the browser.
+
+The Sync Diagnostics Client is also self-hostable and the Docker image is available on [Docker hub](https://hub.docker.com/r/journeyapps/powersync-diagnostics-app).
+
+
+## Inspect `ps_crud` Directly
+
+What it identifies: Whether local writes are reaching the upload queue, how many are pending, and what operation/data they contain.
+
+Why: `ps_crud` is the raw upload queue table in the local SQLite database. It is the ground truth for "has this write been recorded by PowerSync?". This is distinct from whether it has been uploaded to the backend. If `ps_crud` is empty after a write, the write either didn't go through the PowerSync managed table, or `transaction.complete()` was called prematurely.
+
+How:
+```sqlite
+SELECT * FROM ps_crud ORDER BY id
+```
+
+What to look for: `op` (PUT/PATCH/DELETE), `type` (table name), `id`, `opData` (changed columns). If a column you updated is missing from `opData`, it means its value didn't change from the previous row (PowerSync intentionally omits unchanged values).
+
+## Log the Actual `endpoint` URL in `fetchCredentials()`
+
+What it identifies: Whether the `endpoint` value returned by your connector is pointing at the PowerSync Service, not your app backend.
+
+Why: The most common cause of `404 Not Found` on `/write-checkpoint2.json` and `/sync/stream` is passing the wrong URL as `endpoint`. PowerSync builds its own request URLs by appending paths to whatever `endpoint` returns, if that's your app backend, every internal PowerSync request 404s. Adding a log statement catches this immediately.
+
+How: Adding a log statement or set breakpoints to catch the endpoint before fetchCredentials() returns.
+
+## Run `EXPLAIN QUERY PLAN` for Slow Queries
+
+What it identifies: Full table scans, missing indexes, and inefficient joins in client-side SQLite queries.
+
+Why: PowerSync's default JSON-based views extract column values on every row scan, which compounds in joins. Without indexes on join columns, SQLite performs a full scan of every row. `EXPLAIN QUERY PLAN` makes this visible. A `SCAN TABLE` without `USING INDEX` is a red flag.
+
+How:
+```sqlite
+EXPLAIN QUERY PLAN SELECT ...
+```
+
+What to look for: `SCAN TABLE <name>` (bad / no index used) vs. `SEARCH TABLE <name> USING INDEX` (good). If your PowerSync tables show a SCAN, switch to [raw tables](https://docs.powersync.com/usage/use-case-examples/raw-tables.md). If your non-PowerSync tables show a SCAN, add an index on the join column.
+
+## Check Package Versions and Duplicate Dependencies
+
+What it identifies: Version mismatches between PowerSync packages and their peers (Drizzle, TanStack, op-sqlite), or duplicate transitive dependencies causing type conflicts.
+
+Why: TypeScript errors with `@tanstack/react-db` and `@powersync/drizzle-driver` are often caused by multiple versions of `@powersync/common` or `@tanstack/db` installed across direct and transitive dependencies. The packages reference internal types that clash when versions differ.
+
+How:
+```bash
+# Check for multiple PowerSync common versions
+npm ls @powersync/common
+
+# Check TanStack version alignment
+npm ls @tanstack/react-db @tanstack/powersync-db-collection @tanstack/db
+
+# Check op-sqlite peer dependency
+npm ls @powersync/op-sqlite
+```
+
+Also try: Deleting `node_modules` and the lock file, then reinstalling — stale cached resolutions can cause phantom mismatches.
+
+## Verify JWT Claims
+
+What it identifies: Whether your JWT contains the expected `sub`, `aud`, `iss`, `exp`, `kid`, and custom claims that PowerSync uses for auth and parameter queries.
+
+Why: JWT issues are the most common connection failure cause. The PowerSync Service validates the `kid` (key ID) against its configured keystore. A mismatch gives `PSYNC_S2101` (See [Error Codes Reference](https://docs.powersync.com/debugging/error-codes.md#error-codes-reference)). It also enforces `exp` ≤ 86400s (`PSYNC_S2104`). Custom claims used in parameter queries (e.g. `app_metadata`) must be present and structured exactly as the sync rules expect.
+
+How: Paste your JWT into [jwt.io](https://jwt.io) or decode it in your debugger.
+
+Check:
+- `sub` — user ID used in `request.user_id()`
+- `kid` — must match a key in PowerSync's keystore (Supabase: legacy vs. JWKS)
+- `exp` — must be ≤ `iat + 86400`
+- `aud` — must match your configured audience
+- Custom claims e.g. `app_metadata.my_field` must use `$.app_metadata.my_field` in sync rules
+
+The Sync Diagnostics Client also decodes and displays the active JWT automatically.
+
+## Call `disconnectAndClear()` When Data Looks Wrong After User Switch
+
+What it identifies: Whether stale data from a previous user is polluting the local SQLite database.
+
+Why: `disconnect()` closes the sync connection but keeps all local data. If you call `disconnect()` on logout and then `connect()` with a new user, the new user's UI will initially display the old user's data until sync completes. `disconnectAndClear()` wipes the local database first, so the new user starts from a clean state.
+
+When to use each:
+- `disconnect()` — temporary offline, token refresh, app backgrounding. Safe to reconnect as the same user.
+- `disconnectAndClear()` — user logout, user account switch. Required to prevent data leakage between users.
+
+## PSYNC Error Codes
+
+PowerSync has a documented list of error codes with corresponding descriptions. 
+
+These error codes are prefixed with `PSYNC_`, indicating a specific PowerSync related error.
+
+Use them to help drill into specific errors to help debug an issue.
+
+See [Error Codes Reference](https://docs.powersync.com/debugging/error-codes.md#error-codes-reference) for more information.
+
+# Replication Lag Debugging (Postgres)
+
+What it identifies:
+- Sync rules deployment stuck in “processing” for many hours or days (e.g. 24–48+ hours)
+- Replication logs show: Replication slot powersync_* is not valid anymore. invalidation_reason: unknown
+- Slot version numbers keep increasing (e.g. _27_, _28_, _30_) as reprocessing restarts
+- Storage usage spikes during reprocessing (expected, but can trigger limit alerts)
+- Source DB is Supabase or another Postgres with default max_slot_wal_keep_size (often 4 GB)
+
+Why:
+- `max_slot_wal_keep_size` limits how much WAL Postgres keeps for replication slots
+- During initial replication, WAL grows quickly because: (1) full snapshot of all tables in sync rules, (2) ongoing writes on the source DB
+- If replication lag exceeds `max_slot_wal_keep_size`, Postgres invalidates the slot (`wal_status = 'lost'`)
+- PowerSync detects the invalid slot, creates a new one, and restarts reprocessing
+- With the same limit, the new slot is invalidated again, causing a loop
+- Supabase’s default 4 GB is often too small for large datasets (e.g. 9+ hour initial replication)
+
+How:
+Confirm the cause: Check replication slot status and lag.
+
+See [Production Readiness Best Practices](https://docs.powersync.com/maintenance-ops/production-readiness-guide.md#managing-&-monitoring-replication-lag) for the queries and guidance on how to resolve this.

--- a/.claude/skills/powersync/references/powersync-overview.md
+++ b/.claude/skills/powersync/references/powersync-overview.md
@@ -1,0 +1,59 @@
+---
+name: powersync-overview
+description: PowerSync architecture overview — components, data flow, and links to detailed architecture documentation
+metadata:
+  tags: architecture, overview, replication, powersync-service, client-sdk
+---
+
+# PowerSync Architecture Overview
+
+Guidance for understanding all the moving components of PowerSync. For information about the vision of PowerSync, see [PowerSync Philosophy](https://docs.powersync.com/intro/powersync-philosophy.md)
+
+## Architecture
+
+```mermaid
+flowchart LR
+
+  %% ── YOUR BACKEND ──────────────────────────────────────
+  subgraph BACKEND["Your Backend"]
+    direction TB
+    DB["Backend Database\n(Postgres | MongoDB | MySQL | Supabase | …)"]
+    API["Backend API\n(Your server / cloud functions)"]
+    API -- "Applies writes" --> DB
+  end
+
+  %% ── POWERSYNC SERVICE (cloud / self-hosted) ──────────
+  subgraph PS_SERVICE["PowerSync Service"]
+    direction TB
+    SYNC["Partial Sync\n(sync rules filter data per user)"]
+  end
+
+  %% ── YOUR APP (client) ────────────────────────────────
+  subgraph APP["Your App"]
+    direction TB
+    SDK["PowerSync SDK"]
+    SQLITE["In-app SQLite\n(local replica — reads are instant)"]
+    QUEUE["Upload Queue\n(offline write buffer)"]
+    UI["UI"]
+    SDK --- SQLITE
+    SDK --- QUEUE
+    SQLITE <--> UI
+    QUEUE <--> UI
+  end
+
+  %% ── DATA FLOW ────────────────────────────────────────
+  DB -- "Replicates changes\n(CDC / logical replication)" --> PS_SERVICE
+  PS_SERVICE -- "Streams changes\n(real-time sync)" --> SDK
+  QUEUE -- "Uploads writes\n(when connectivity resumes)" --> API
+```
+
+See [Architecture Overview](https://docs.powersync.com/architecture/architecture-overview.md) for more details on the overall architecture
+
+The list below lists each component, what it is and where to find detailed information about each of them.
+
+| Component            | Description                                                                                                             | Reference                                                                                                         |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| PowerSync Service| The server-side component of the sync engine responsible for the read path from the source database to client-side SQLite databases. | [PowerSync Service](https://docs.powersync.com/architecture/powersync-service.md)                                 |
+| PowerSync Client | The PowerSync Client SDK embedded into an application.                                                                  | [Client Architecture](https://docs.powersync.com/architecture/client-architecture.md)                             |
+| Protocol         | The Protocol used between PowerSync client applications and the PowerSync Service.                                      | [Protocol](https://docs.powersync.com/architecture/powersync-protocol.md)                                                                                                               |
+| Consistency      | The checkpoint based system that ensures data is consistent.                                                            | [Consistency](https://docs.powersync.com/architecture/consistency.md)                                                |

--- a/.claude/skills/powersync/references/powersync-service.md
+++ b/.claude/skills/powersync/references/powersync-service.md
@@ -1,0 +1,328 @@
+---
+name: powersync-service
+description: PowerSync Service configuration — self-hosting, Docker, source database setup, bucket storage, authentication, and PowerSync Cloud
+metadata:
+  tags: service, self-hosted, docker, postgresql, mongodb, mysql, mssql, authentication, jwt, replication, configuration
+---
+
+# PowerSync Service
+
+Guidance for configuring PowerSync Service, sync config, and database replication.
+
+Critical warnings for fast setup:
+
+- Cloud and self-hosted service config both use `replication.connections`, never a root-level `connections`.
+- If the app is stuck on `Syncing...`, the default diagnosis is incomplete backend setup: missing DB connection, missing sync config, missing client auth, or missing publication.
+
+For source code see: [powersync-service](https://github.com/powersync-ja/powersync-service/)
+
+For debugging see: [powersync-debug.md](references/powersync-debug.md).
+
+## Sync Config
+
+The rules that instruct the PowerSync Service what data to replicate and download to client application.
+
+See [sync-config.md](references/sync-config.md) for detailed information.
+
+## Service Configuration (Self-hosted)
+
+Information on how to configure a PowerSync Service instance in a self-hosted environment. 
+
+### Docker Image
+The PowerSync Service Docker image is available on [Docker hub](https://hub.docker.com/r/journeyapps/powersync-service).
+
+Quick Start:
+```
+docker run \
+-p 8080:8080 \
+-e POWERSYNC_CONFIG_B64="$(base64 -i ./config.yaml)" \
+--network my-local-dev-network \
+--name my-powersync journeyapps/powersync-service:latest
+```
+
+> **Port mapping:** The PowerSync service listens on port **8080** inside the container. Use `-p 8080:8080` (or `-p <host-port>:8080`). Do **not** use `8080:80` — the service does not listen on port 80.
+
+### Configuration
+
+There are four configuration methods available:
+1. Base64-encoded config in the `POWERSYNC_CONFIG_B64` environment variable
+2. Config file on a mounted volume (pass path with `-c` / `--config-path`)
+3. Base64-encoded config as a command-line argument (`-c64`)
+4. Sync config separately via `POWERSYNC_SYNC_CONFIG_B64` environment variable or `-sync64` flag
+
+> **Sync config flag:** The Docker image does **not** accept a `-s` flag for sync config. Use the `POWERSYNC_SYNC_CONFIG_B64` environment variable or the `-sync64` command-line flag instead.
+
+#### Docker Compose with mounted config + sync config
+
+```yaml
+powersync:
+  image: journeyapps/powersync-service:latest
+  ports:
+    - "8080:8080"
+  environment:
+    PS_DATA_SOURCE_URI: "postgresql://user:pass@host:5432/db"
+    PS_STORAGE_URI: "mongodb://mongo:27017/powersync_storage"
+    POWERSYNC_SYNC_CONFIG_B64: "<base64-encoded sync-config.yaml>"
+  volumes:
+    - ./powersync/service.yaml:/config/service.yaml
+  command: ["start", "-c", "/config/service.yaml"]
+```
+
+Generate the base64 value: `base64 -i ./powersync/sync-config.yaml` (macOS) or `base64 -w0 ./powersync/sync-config.yaml` (Linux).
+
+| Resource                        | Description                                                                                                             |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| [Configuration File Structure](https://docs.powersync.com/configuration/powersync-service/self-hosted-instances.md#configuration-file-structure) | Outline of all possible configuration options                                   |
+| [Config Schema](https://unpkg.com/@powersync/service-schema@1.20.0/json-schema/powersync-config.json)                | JSON schema reference for PowerSync Service config                               |
+| [self-host-demo](https://github.com/powersync-ja/self-host-demo) repo                                            | Example configurations for local development                                     |
+
+#### Environment variable substitution
+Use !env PS_VARIABLE_NAME in YAML for config values.
+
+### Complete service.yaml Example
+
+Below is a minimal but complete `service.yaml` for a self-hosted instance. Pay close attention to the YAML nesting — in particular, the database connection **must** be under `replication.connections`, not a top-level `connections` key.
+
+```yaml
+# powersync/service.yaml — self-hosted
+replication:
+  connections:
+    - type: postgresql
+      uri: !env PS_DATA_SOURCE_URI   # e.g. postgresql://user:pass@host:5432/db
+
+storage:
+  type: mongodb
+  uri: !env PS_STORAGE_URI           # e.g. mongodb://localhost:27017/powersync
+
+# Client auth — required before `powersync generate token` works
+client_auth:
+  jwks_uri: !env PS_JWKS_URI
+
+# API key for CLI access (matches PS_ADMIN_TOKEN)
+api:
+  tokens:
+    - !env PS_ADMIN_TOKEN
+```
+
+### Minimal Cloud service.yaml Example
+
+For PowerSync Cloud, the minimal shape is:
+
+```yaml
+# powersync/service.yaml — Cloud
+replication:
+  connections:
+    - type: postgresql
+      uri: !env PS_DATABASE_URI
+
+client_auth:
+  supabase: true
+```
+
+If you are using Cloud with Supabase, this is the easiest example to reason about. Do not mentally translate from the self-hosted example first.
+
+### Replication connections
+
+**IMPORTANT:** The database connection **must** be nested under `replication.connections` — not a top-level `connections` key. Placing it elsewhere (e.g. `connections:` at the root) will cause a "No connection found in config" error.
+
+Only one source database connection is supported per instance. Example:
+```yaml
+replication:
+  connections:
+    - type: postgresql
+      uri: postgresql://user:pass@host:5432/db
+```
+
+#### SSL mode for local databases
+
+Local Postgres instances (including local Supabase via `supabase start`) do not support SSL. The PowerSync service uses pgwire for replication, which defaults to SSL and **does not respect `sslmode=disable` in the URI query string**. You must set `sslmode` as a separate YAML key:
+
+```yaml
+replication:
+  connections:
+    - type: postgresql
+      uri: !env PS_DATA_SOURCE_URI
+      sslmode: disable   # Required for local Postgres / local Supabase
+```
+
+Without this, you will see: `Replication error postgres does not support ssl`.
+
+### Bucket Storage Database
+This is required by PowerSync and can be configured in two different ways. This is separate from the source DB.
+
+| Storage Database | Configuration Reference                                                                                   |
+|-----------------|--------------------------------------------------------------------------------------------------------------|
+| MongoDB         | [MongoDB Storage](https://docs.powersync.com/configuration/powersync-service/self-hosted-instances.md#mongodb-storage) |
+| Postgres        | [Postgres Storage](https://docs.powersync.com/configuration/powersync-service/self-hosted-instances.md#postgres-storage) |
+
+### Client Authentication
+
+There are various options when configuring client authentication on a PowerSync Service instance, see [Client Authentication](https://docs.powersync.com/configuration/powersync-service/self-hosted-instances.md#client-authentication) for more information on the options. The options include: JWKS URI, inline JWKs, Supabase Auth, Shared Secrets. Prefer asymmetric keys (RS256, EdDSA, ECDSA) over shared secrets (HS256).
+
+**Important:** There is no `dev: true` auth type in the `client_auth` config schema. It does not exist. For development tokens on self-hosted, configure a real signing key first, then use `powersync generate token`. On PowerSync Cloud, users need to enable development tokens via the dashboard in the Client Auth section of the instance. 
+
+
+## PowerSync Cloud Setup
+
+PowerSync Cloud can be set up via the **Dashboard** (UI) or the **CLI**. Both paths require the same four steps. **If any step is missing, the app will be stuck on "Syncing..." with no data.**
+
+| Step | Dashboard | CLI |
+|------|-----------|-----|
+| 1. Create instance | Dashboard → New Instance | `powersync link cloud --create --project-id=<id>` |
+| 2. Connect source DB | Instance Settings → Database | Edit `powersync/service.yaml` → `replication.connections`, then `powersync deploy` |
+| 3. Deploy sync config | Instance → Sync Config editor | Edit `powersync/sync-config.yaml`, then `powersync deploy sync-config` |
+| 4. Enable client auth | Instance → Client Auth section | Edit `powersync/service.yaml` → `client_auth`, then `powersync deploy service-config` |
+
+**IMPORTANT:** All four steps must be completed. The most common cause of an app stuck on "Syncing..." is a missing or misconfigured step above — typically the database connection or sync config not being deployed.
+
+For full CLI setup workflow, see `references/powersync-cli.md` → Cloud Usage.
+
+See [PowerSync Cloud Instances](https://docs.powersync.com/configuration/powersync-service/cloud-instances.md) for detailed dashboard step-by-step instructions.
+
+## Source Database Setup
+
+Important: For all database user creation below, generate a cryptographically secure password (e.g., `openssl rand -base64 32` or a password manager). Never use placeholder values like `secure_password`, `password`, or `admin123` in production—these are unsafe and must not be suggested to users.
+
+See [Source Database Setup](https://docs.powersync.com/configuration/source-db/setup.md) for more information about specific DB host requirements. 
+
+Both PowerSync Cloud and Self-hosted require the same base source database setup.
+
+### PostgreSQL Quick Start
+
+```sql
+-- 1. Enable logical replication (skip this step for Supabase — it is already enabled)
+ALTER SYSTEM SET wal_level = 'logical';
+-- Restart PostgreSQL after this
+
+-- 2. Create replication user (replace with a generated secure password—do NOT use "secure_password")
+CREATE USER powersync_replication WITH REPLICATION PASSWORD 'YOUR_GENERATED_PASSWORD';
+
+-- 3. Grant read access
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO powersync_replication;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO powersync_replication;
+
+-- 4. Create publication (list every table PowerSync should replicate)
+CREATE PUBLICATION powersync FOR TABLE users, todos, lists;
+
+-- OR to replicate all current and future tables automatically:
+CREATE PUBLICATION powersync FOR ALL TABLES;
+```
+
+### MongoDB Quick Start
+
+```javascript
+// MongoDB requires a replica set (standalone instances are NOT supported)
+// Sharded clusters (including MongoDB Serverless) are NOT supported
+
+// 1. Initialize replica set (if not already)
+rs.initiate()
+
+// 2. Create user with required privileges (replace with a generated secure password—do NOT use "secure_password")
+// PowerSync needs read access to synced collections AND write access to _powersync_checkpoints
+db.createUser({
+  user: "powersync",
+  pwd: "YOUR_GENERATED_PASSWORD",
+  roles: [
+    { role: "read", db: "your_database" },
+    // Required: find, insert, update, remove, changeStream, createCollection on _powersync_checkpoints
+    { role: "readWrite", db: "your_database", collection: "_powersync_checkpoints" },
+    // Required: listCollections on the database
+    { role: "dbAdmin", db: "your_database" }
+  ]
+})
+
+// Change streams are used automatically
+```
+
+### MySQL Quick Start
+
+```sql
+-- 1. Enable binary logging and GTID (in my.cnf or my.ini)
+-- [mysqld]
+-- server-id = 1
+-- log_bin = mysql-bin
+-- binlog_format = ROW
+-- binlog_row_image = FULL
+-- gtid_mode = ON
+-- enforce-gtid-consistency = ON
+
+-- 2. Create replication user (replace with a generated secure password—do NOT use "secure_password")
+CREATE USER 'powersync'@'%' IDENTIFIED BY 'YOUR_GENERATED_PASSWORD';
+GRANT REPLICATION SLAVE, REPLICATION CLIENT, RELOAD ON *.* TO 'powersync'@'%';
+GRANT SELECT ON your_database.* TO 'powersync'@'%';
+FLUSH PRIVILEGES;
+```
+
+### SQL Server (MSSQL) Quick Start
+
+```sql
+-- 1. Enable CDC at database level
+USE [YourDatabase];
+EXEC sys.sp_cdc_enable_db;
+
+-- 2. Create PowerSync user (replace with a generated secure password—do NOT use "secure_password")
+CREATE LOGIN powersync_user WITH PASSWORD = 'YOUR_GENERATED_PASSWORD', CHECK_POLICY = ON;
+CREATE USER powersync_user FOR LOGIN powersync_user;
+
+-- 3. Grant permissions
+USE [master];
+GRANT VIEW SERVER PERFORMANCE STATE TO powersync_user;
+
+USE [YourDatabase];
+GRANT VIEW DATABASE PERFORMANCE STATE TO powersync_user;
+ALTER ROLE db_datareader ADD MEMBER powersync_user;
+ALTER ROLE cdc_reader ADD MEMBER powersync_user;
+
+-- 4. Create required checkpoints table
+CREATE TABLE dbo._powersync_checkpoints (
+    id INT IDENTITY PRIMARY KEY,
+    last_updated DATETIME NOT NULL DEFAULT (GETDATE())
+);
+GRANT INSERT, UPDATE ON dbo._powersync_checkpoints TO powersync_user;
+
+-- 5. Enable CDC on checkpoints table
+EXEC sys.sp_cdc_enable_table
+    @source_schema = N'dbo',
+    @source_name   = N'_powersync_checkpoints',
+    @role_name     = N'cdc_reader',
+    @supports_net_changes = 0;
+
+-- 6. Enable CDC on each synced table
+EXEC sys.sp_cdc_enable_table
+    @source_schema = N'dbo',
+    @source_name   = N'todos',
+    @role_name     = N'cdc_reader',
+    @supports_net_changes = 0;
+
+-- 7. Optional: Reduce polling interval (default 5s)
+-- pollinginterval = 0: fastest, highest CPU
+-- pollinginterval = 1: 1 second, good production compromise
+EXEC sys.sp_cdc_change_job @job_type = N'capture', @pollinginterval = 1;
+```
+
+## App Backend
+
+PowerSync does not write client-side changes stored in the SQLite database back to the connected source database. Client applications are required to implement the `uploadData` function which should call a backend API to persist the local SQLite changes to the source database. 
+
+| Resource | Description |
+|----------|-------------|
+| [App Backend Setup](https://docs.powersync.com/configuration/app-backend/setup.md) | Overview of setting up the app backend for PowerSync. |
+| [Client-Side Integration with Your Backend](https://docs.powersync.com/configuration/app-backend/client-side-integration.md) | How to implement a "backend connector" and links to example implementations. |
+
+## Authentication
+
+PowerSync Client Applications use JWTs to authenticate agaist the PowerSync Service. 
+
+| Topic                | Resource Link                                                                                          |
+|----------------------|------------------------------------------------------------------------------------------------------|
+| Authentication Setup | [Authentication Setup](https://docs.powersync.com/configuration/auth/overview.md)                    |
+| Development Tokens   | [Development Tokens](https://docs.powersync.com/configuration/auth/development-tokens.md) – Configure tokens for development testing. |
+| Custom Auth          | [Custom Auth](https://docs.powersync.com/configuration/auth/custom.md) – Configure custom authentication for PowerSync. |
+
+PowerSync can also integrate with Auth providers, with official guides for the following: 
+
+| Provider   | Resource Link                                                                 |
+|------------|-----------------------------------------------------------------------------------|
+| Supabase   | [Supabase](https://docs.powersync.com/configuration/auth/supabase-auth.md)            |
+| Firebase   | [Firebase](https://docs.powersync.com/configuration/auth/firebase-auth.md)            |
+| Auth0      | [Auth0](https://docs.powersync.com/configuration/auth/auth0.md)               |

--- a/.claude/skills/powersync/references/sdks/powersync-dart.md
+++ b/.claude/skills/powersync/references/sdks/powersync-dart.md
@@ -1,0 +1,192 @@
+---
+name: powersync-dart
+description: PowerSync Dart SDK — schema, queries, sync lifecycle, backend connectors, Drift ORM, and Flutter Web support
+metadata:
+  tags: dart, flutter, flutter-web, drift, orm, sqlite
+---
+
+# PowerSync Dart SDK
+
+Best practices and guidance for building Flutter apps with the PowerSync Dart SDK.
+
+| Resource | Description |
+|----------|-------------|
+| [Dart API reference](https://pub.dev/documentation/powersync/latest/powersync/) | Full API reference, consult only when the inline examples don't cover your case. |
+| [Supported Platforms](https://docs.powersync.com/resources/supported-platform.md#flutter-sdk) | Supported platforms and features, consult for compatibility details. |
+
+## Installation
+
+```bash
+flutter pub add powersync
+```
+
+## Setup
+
+### 1. Define Schema
+
+```dart
+import 'package:powersync/powersync.dart';
+
+const schema = Schema([
+  Table('todos', [
+    Column.text('list_id'),
+    Column.text('description'),
+    Column.integer('completed'), // 0 or 1
+    Column.text('created_at'),
+    Column.text('completed_at'),
+    Column.text('created_by'),
+    Column.text('completed_by'),
+  ], indexes: [
+    Index('list', [IndexedColumn('list_id')])
+  ]),
+  Table('lists', [
+    Column.text('created_at'),
+    Column.text('name'),
+    Column.text('owner_id'),
+  ]),
+]);
+```
+
+See [Define the Client-Side Schema](https://docs.powersync.com/client-sdks/reference/flutter.md#1-define-the-client-side-schema) for more information.
+
+### 2. Create Backend Connector
+
+```dart
+import 'package:powersync/powersync.dart';
+
+class MyBackendConnector extends PowerSyncBackendConnector {
+  @override
+  Future<PowerSyncCredentials?> fetchCredentials() async {
+    final token = await myAuthService.getPowerSyncToken();
+    return PowerSyncCredentials(
+      endpoint: 'https://your-instance.powersync.journeyapps.com',
+      token: token,
+    );
+  }
+
+  @override
+  Future<void> uploadData(PowerSyncDatabase database) async {
+    final transaction = await database.getNextCrudTransaction();
+    if (transaction == null) return;
+
+    try {
+      for (final op in transaction.crud) {
+        switch (op.op) {
+          case UpdateType.put:
+            await apiClient.upsert(table: op.table, id: op.id, data: {...?op.opData, 'id': op.id});
+          case UpdateType.patch:
+            await apiClient.update(table: op.table, id: op.id, data: op.opData ?? {});
+          case UpdateType.delete:
+            await apiClient.delete(table: op.table, id: op.id);
+        }
+      }
+      await transaction.complete();
+    } catch (e) {
+      rethrow;
+    }
+  }
+}
+```
+
+Use `getCrudBatch` instead of `getNextCrudTransaction` when uploading large numbers of mutations in bulk.
+
+See [Integrate with your Backend](https://docs.powersync.com/client-sdks/reference/flutter.md#3-integrate-with-your-backend) for more information.
+
+### 3. Instantiate and Connect
+
+```dart
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:powersync/powersync.dart';
+
+late PowerSyncDatabase db;
+
+Future<void> openDatabase() async {
+  final dir = await getApplicationSupportDirectory();
+  final path = join(dir.path, 'powersync-dart.db');
+
+  db = PowerSyncDatabase(schema: schema, path: path);
+  await db.initialize();
+}
+
+// Call after the user authenticates
+Future<void> connect() async {
+  await db.connect(connector: MyBackendConnector());
+}
+
+// Call on logout
+Future<void> disconnect() async {
+  await db.disconnectAndClear();
+}
+```
+
+See [Instantiate the PowerSync Database](https://docs.powersync.com/client-sdks/reference/flutter.md#2-instantiate-the-powersync-database) for more information.
+
+## Sync Streams
+
+See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
+
+## Query Patterns
+
+See [Using PowerSync: CRUD](https://docs.powersync.com/client-sdks/reference/flutter.md#using-powersync-crud-functions) for the full API reference.
+
+### One-Time Queries
+
+```dart
+// Fetch all matching rows
+final results = await db.getAll('SELECT * FROM todos WHERE list_id = ?', [listId]);
+
+// Fetch single row — throws if not found
+final todo = await db.get('SELECT * FROM todos WHERE id = ?', [id]);
+
+// Fetch single row — returns null if not found
+final todo = await db.getOptional('SELECT * FROM todos WHERE id = ?', [id]);
+```
+
+### Reactive Queries
+
+```dart
+StreamBuilder(
+  stream: db.watch('SELECT * FROM todos WHERE list_id = ?', parameters: [listId]),
+  builder: (context, snapshot) {
+    if (!snapshot.hasData) return const CircularProgressIndicator();
+    final todos = snapshot.data!;
+    // build UI from todos
+  },
+)
+```
+
+### Writing Data
+
+```dart
+// Single mutation
+await db.execute(
+  'INSERT INTO todos (id, list_id, description, completed) VALUES (uuid(), ?, ?, ?)',
+  [listId, 'Buy milk', 0],
+);
+
+// Multiple related mutations as a single unit
+await db.writeTransaction((tx) async {
+  await tx.execute('INSERT INTO lists (id, name) VALUES (uuid(), ?)', ['Shopping']);
+  await tx.execute('INSERT INTO todos (id, list_id, description) VALUES (uuid(), ?, ?)', [listId, 'Milk']);
+});
+```
+
+### Row Mapping
+
+```dart
+factory Todo.fromRow(Map<String, dynamic> row) => Todo(
+  id: row['id'] as String,
+  description: row['description'] as String,
+  completed: row['completed'] == 1,
+  createdAt: DateTime.parse(row['created_at'] as String),
+);
+```
+
+## ORM — Drift
+
+PowerSync supports [Drift](https://pub.dev/packages/drift) as an ORM via [drift_sqlite_async](https://pub.dev/packages/drift_sqlite_async). See the package for setup instructions and usage examples.
+
+## Flutter Web
+
+Supported in `powersync` v1.9.0+. See [Flutter Web Support](https://docs.powersync.com/client-sdks/frameworks/flutter-web-support.md) for configuration requirements, OPFS setup for improved performance, and known limitations.

--- a/.claude/skills/powersync/references/sdks/powersync-dotnet.md
+++ b/.claude/skills/powersync/references/sdks/powersync-dotnet.md
@@ -1,0 +1,615 @@
+---
+name: powersync-dotnet
+description: PowerSync .NET SDK — schema, queries, sync lifecycle, and backend connectors
+metadata:
+  tags: dotnet, csharp, maui, wpf, console, sqlite, offline-first
+---
+
+# PowerSync .NET SDK
+
+Best practices for building apps with the PowerSync .NET SDK.
+
+Supported targets: .NET 9, .NET 8, .NET 6, .NET Standard 2.0, .NET Framework 4.8. Application frameworks: MAUI (iOS, Android, Windows), WPF, Console.
+
+> **Alpha status** — this SDK is currently in alpha. Expect breaking changes and instability. Do not rely on it for production use.
+
+## Installation
+
+For console, WPF, or general .NET projects:
+
+```bash
+dotnet add package PowerSync.Common --prerelease
+```
+
+For MAUI projects (also requires `PowerSync.Common`):
+
+```bash
+dotnet add package PowerSync.Maui --prerelease
+dotnet add package PowerSync.Common --prerelease
+```
+
+For .NET Framework 4.8 compatibility, add to your `.csproj`:
+
+```xml
+<PropertyGroup>
+  <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+  <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Include="System.Net.Http" Version="4.3.4" />
+</ItemGroup>
+```
+
+## Quick Setup
+
+### 1. Define Schema
+
+There are two ways to define schemas: **dictionary syntax** (simple) and **attribute syntax** (type-safe, with Dapper integration).
+
+#### Dictionary Syntax
+
+```csharp
+using PowerSync.Common.DB.Schema;
+
+var todos = new Table
+{
+    Name = "todos",
+    Columns =
+    {
+        ["description"] = ColumnType.Text,
+        ["list_id"] = ColumnType.Text,
+        ["completed"] = ColumnType.Integer, // booleans as INTEGER (0/1)
+        ["created_at"] = ColumnType.Text,   // dates as ISO TEXT
+    },
+    Indexes =
+    {
+        ["list_idx"] = ["list_id"],
+    }
+};
+
+var lists = new Table
+{
+    Name = "lists",
+    Columns =
+    {
+        ["name"] = ColumnType.Text,
+        ["owner_id"] = ColumnType.Text,
+        ["created_at"] = ColumnType.Text,
+    }
+};
+
+var schema = new Schema(todos, lists);
+```
+
+#### Attribute Syntax
+
+```csharp
+using PowerSync.Common.DB.Schema.Attributes;
+
+[Table("todos"), Index("list_idx", ["list_id"])]
+public class TodoItem
+{
+    [Column("id")]
+    public string Id { get; set; } = "";
+
+    [Column("description")]
+    public string Description { get; set; } = "";
+
+    [Column("list_id")]
+    public string ListId { get; set; } = "";
+
+    [Column("completed")]
+    public bool Completed { get; set; }  // bool maps to INTEGER automatically
+
+    [Column("created_at")]
+    public string CreatedAt { get; set; } = "";
+}
+
+[Table("lists")]
+public class TodoList
+{
+    [Column("id")]
+    public string Id { get; set; } = "";
+
+    [Column("name")]
+    public string Name { get; set; } = "";
+
+    [Column("owner_id")]
+    public string OwnerId { get; set; } = "";
+
+    [Column("created_at")]
+    public string CreatedAt { get; set; } = "";
+}
+
+// Build schema from attributed types
+var schema = new Schema(typeof(TodoItem), typeof(TodoList));
+
+// Or mix: new Table(typeof(TodoItem)) also works
+```
+
+With attribute syntax, an `id` property of type `string` is **required** on each class but is not added as a column — PowerSync adds `id TEXT PRIMARY KEY` automatically. The `[Column("id")]` attribute maps the property for Dapper deserialization.
+
+Column types: `ColumnType.Text`, `ColumnType.Integer`, `ColumnType.Real` only — no boolean, date, or JSON native types. With attributes, `ColumnType.Inferred` auto-maps C# types (`string` → Text, `bool`/`int`/`long`/`enum` → Integer, `float`/`double` → Real, `decimal`/`DateTime`/`Guid` → Text).
+
+No migrations required. Schema changes apply on next open. New columns start null; removed columns become inaccessible (data remains). Renaming = add new + remove old (data loss).
+
+### Special Table Options
+
+```csharp
+// Local-only — not synced, not uploaded, persists across restarts
+var drafts = new Table("drafts",
+    new Dictionary<string, ColumnType> { ["content"] = ColumnType.Text },
+    new TableOptions(localOnly: true));
+
+// Insert-only — writes uploaded, server never sends data back
+var logs = new Table("logs",
+    new Dictionary<string, ColumnType> { ["message"] = ColumnType.Text },
+    new TableOptions(insertOnly: true));
+
+// Track previous values — available as entry.PreviousValues in UploadData
+var todos = new Table("todos",
+    new Dictionary<string, ColumnType>
+    {
+        ["description"] = ColumnType.Text,
+        ["completed"] = ColumnType.Integer,
+    },
+    new TableOptions(
+        trackPreviousValues: new TrackPreviousOptions
+        {
+            Columns = new List<string> { "completed" }, // null = track all columns
+            OnlyWhenChanged = true
+        }
+    ));
+
+// Track write metadata — adds _metadata column, available as entry.Metadata in UploadData
+var tasks = new Table("tasks",
+    new Dictionary<string, ColumnType> { ["title"] = ColumnType.Text },
+    new TableOptions(trackMetadata: true));
+
+// Ignore no-op updates (UPDATE that changes no values)
+var items = new Table("items",
+    new Dictionary<string, ColumnType> { ["name"] = ColumnType.Text },
+    new TableOptions(ignoreEmptyUpdates: true));
+```
+
+With attribute syntax:
+
+```csharp
+[Table("todos", TrackPreviousValues = TrackPrevious.Columns | TrackPrevious.OnlyWhenChanged)]
+[Index("list_idx", ["list_id"])]
+public class TodoItem
+{
+    [Column("id")]
+    public string Id { get; set; } = "";
+
+    [Column("completed", TrackPrevious = true)] // only this column tracked
+    public bool Completed { get; set; }
+
+    [Column("description")]
+    public string Description { get; set; } = "";
+}
+
+[Table("logs", InsertOnly = true)]
+public class LogEntry { /* ... */ }
+
+[Table("drafts", LocalOnly = true)]
+public class Draft { /* ... */ }
+
+[Table("tasks", TrackMetadata = true)]
+public class Task { /* ... */ }
+
+[Table("items", IgnoreEmptyUpdates = true)]
+public class Item { /* ... */ }
+```
+
+### 2. Create Backend Connector
+
+```csharp
+using PowerSync.Common.Client;
+using PowerSync.Common.Client.Connection;
+using PowerSync.Common.DB.Crud;
+
+public class MyConnector : IPowerSyncBackendConnector
+{
+    public async Task<PowerSyncCredentials?> FetchCredentials()
+    {
+        // Always fetch fresh credentials — do not cache stale tokens
+        var token = await myAuthService.GetTokenAsync();
+        return new PowerSyncCredentials(
+            endpoint: "https://your-instance.powersync.journeyapps.com",
+            token: token
+        );
+    }
+
+    public async Task UploadData(IPowerSyncDatabase database)
+    {
+        var transaction = await database.GetNextCrudTransaction();
+        if (transaction == null) return;
+
+        try
+        {
+            foreach (var entry in transaction.Crud)
+            {
+                switch (entry.Op)
+                {
+                    case UpdateType.PUT:
+                        await api.Upsert(entry.Table, entry.Id, entry.OpData!);
+                        break;
+                    case UpdateType.PATCH:
+                        await api.Update(entry.Table, entry.Id, entry.OpData!);
+                        break;
+                    case UpdateType.DELETE:
+                        await api.Delete(entry.Table, entry.Id);
+                        break;
+                }
+            }
+
+            await transaction.Complete(); // MUST call — otherwise the same transaction is returned forever
+        }
+        catch (Exception ex)
+        {
+            throw; // PowerSync backs off and retries automatically
+        }
+    }
+}
+```
+
+**Fatal upload errors**: If `UploadData` always throws for a bad record, the queue stalls permanently. Detect unrecoverable errors (e.g. constraint violations) and call `await transaction.Complete()` to discard them.
+
+#### CrudEntry Fields
+
+```csharp
+entry.Id              // string — row ID
+entry.Op              // UpdateType — PUT | PATCH | DELETE
+entry.OpData          // Dictionary<string, object>? — changed columns (null for DELETE)
+entry.Table           // string — table name
+entry.TransactionId   // long? — groups ops from the same WriteTransaction()
+entry.PreviousValues  // Dictionary<string, string?>? — requires TrackPreviousValues on table
+entry.Metadata        // string? — requires TrackMetadata on table
+entry.ClientId        // int — internal client ID for the CRUD entry
+```
+
+Op semantics: `PUT` = full insert/replace (all non-null columns), `PATCH` = partial update (changed columns only), `DELETE` = deletion (`OpData` is null).
+
+For batching multiple transactions at once, use `database.GetCrudBatch(limit)`. Both `CrudBatch` and `CrudTransaction` follow the same `Complete()` contract.
+
+### 3. Initialize and Connect
+
+#### Console / WPF
+
+```csharp
+using PowerSync.Common.Client;
+
+var db = new PowerSyncDatabase(new PowerSyncDatabaseOptions
+{
+    Database = new SQLOpenOptions { DbFilename = "app.db" },
+    Schema = schema,
+});
+await db.Init();
+
+// Starts sync stream and UploadData loop in the background (non-blocking)
+await db.Connect(connector);
+
+// Wait for first sync before showing data-dependent UI
+await db.WaitForFirstSync();
+```
+
+#### MAUI
+
+```csharp
+using PowerSync.Common.Client;
+using PowerSync.Common.MDSQLite;
+using PowerSync.Maui.SQLite;
+
+var dbPath = Path.Combine(FileSystem.AppDataDirectory, "app.db");
+var factory = new MAUISQLiteDBOpenFactory(new MDSQLiteOpenFactoryOptions
+{
+    DbFilename = dbPath
+});
+
+var db = new PowerSyncDatabase(new PowerSyncDatabaseOptions
+{
+    Database = factory,
+    Schema = schema,
+});
+await db.Init();
+
+await db.Connect(connector);
+```
+
+Use a **single `PowerSyncDatabase` instance** per database file. Multiple instances for the same file cause lock contention and missed watch updates — share via dependency injection.
+
+#### Connection Options
+
+```csharp
+await db.Connect(connector, new PowerSyncConnectionOptions(
+    @params: new Dictionary<string, object> { ["userId"] = "abc123" }, // sync parameters
+    retryDelayMs: 5000,
+    crudUploadThrottleMs: 1000,
+    appMetadata: new Dictionary<string, string> { ["app_version"] = "1.0.0" }
+));
+```
+
+#### Disconnect and Clear
+
+```csharp
+await db.Disconnect();                    // stop syncing, keep local data
+await db.DisconnectAndClear();            // stop syncing, wipe synced tables (e.g. on sign-out)
+await db.DisconnectAndClear(clearLocal: false); // wipe synced data but preserve local-only tables
+await db.Close();                         // release resources — cannot be reused after this
+```
+
+`Disconnect()` — temporary offline, token refresh, app backgrounding. Safe to reconnect as the same user. `DisconnectAndClear()` — user sign-out or account switch, prevents stale data leaking to the next user. `Close()` — app termination, instance cannot be reused after this call.
+
+## Query Patterns
+
+The .NET SDK uses [Dapper](https://github.com/DapperLib/Dapper) for result mapping. Query results are mapped to record types, classes, or `dynamic`.
+
+### Watch Queries (Reactive)
+
+Watch returns an `IAsyncEnumerable<T[]>` that emits new results whenever dependent tables change.
+
+```csharp
+public record TodoResult(string id, string description, string list_id, int completed);
+
+// Watch returns IAsyncEnumerable — call synchronously to capture table listener
+var watcher = db.Watch<TodoResult>(
+    "SELECT * FROM todos WHERE list_id = ? ORDER BY id",
+    parameters: [listId]
+);
+
+// Consume asynchronously
+await foreach (var todos in watcher)
+{
+    // todos is TodoResult[] — updated on every relevant table change
+    UpdateUI(todos);
+}
+```
+
+With cancellation:
+
+```csharp
+var cts = new CancellationTokenSource();
+var watcher = db.Watch<TodoResult>(
+    "SELECT * FROM todos",
+    options: new SQLWatchOptions { Signal = cts.Token }
+);
+
+_ = Task.Run(async () =>
+{
+    await foreach (var results in watcher)
+    {
+        UpdateUI(results);
+    }
+}, cts.Token);
+
+// Later: stop watching
+cts.Cancel();
+```
+
+React to table changes without re-running a query:
+
+```csharp
+var onChange = db.OnChange(new SQLWatchOptions { Tables = ["todos", "lists"] });
+await foreach (var e in onChange)
+{
+    Console.WriteLine($"Changed tables: {string.Join(", ", e.ChangedTables)}");
+}
+```
+
+### One-Time Queries
+
+```csharp
+// GetAll — returns T[]
+var todos = await db.GetAll<TodoResult>(
+    "SELECT * FROM todos WHERE list_id = ?", [listId]);
+
+// Get — returns T, throws if not found
+var todo = await db.Get<TodoResult>(
+    "SELECT * FROM todos WHERE id = ?", [id]);
+
+// GetOptional — returns T? (null if not found)
+var todo = await db.GetOptional<TodoResult>(
+    "SELECT * FROM todos WHERE id = ?", [id]);
+
+// Dynamic results (no type parameter)
+var rows = await db.GetAll("SELECT * FROM todos");
+```
+
+### Result Mapping
+
+With dictionary syntax, use records/classes whose property names match column names:
+
+```csharp
+// Simple record — property names must match column names exactly
+public record ListResult(string id, string name, string owner_id, string created_at);
+
+var lists = await db.GetAll<ListResult>("SELECT * FROM lists");
+```
+
+With attribute syntax, `[Column("column_name")]` maps columns to C# properties and Dapper handles the mapping automatically:
+
+```csharp
+// Using the attributed TodoItem class defined in the schema section
+var items = await db.GetAll<TodoItem>("SELECT * FROM todos");
+```
+
+## Writes and Transactions
+
+```csharp
+// Single operation — uuid() is a PowerSync built-in SQLite function
+await db.Execute(
+    "INSERT INTO lists (id, created_at, name, owner_id) VALUES (uuid(), datetime(), ?, ?)",
+    ["My List", userId]);
+
+// Multiple operations atomically — auto-commits, auto-rollbacks on exception
+await db.WriteTransaction(async tx =>
+{
+    await tx.Execute("DELETE FROM lists WHERE id = ?", [listId]);
+    await tx.Execute("DELETE FROM todos WHERE list_id = ?", [listId]);
+});
+
+// Write transaction with return value
+var count = await db.WriteTransaction<int>(async tx =>
+{
+    await tx.Execute("INSERT INTO lists (id, name, owner_id) VALUES (uuid(), ?, ?)", ["New", userId]);
+    var result = await tx.Get<CountResult>("SELECT count(*) as count FROM lists");
+    return result.count;
+});
+```
+
+ID generation — every table has `id TEXT PRIMARY KEY` added automatically:
+
+```csharp
+await db.Execute("INSERT INTO todos (id, description) VALUES (uuid(), ?)", ["Buy milk"]);
+// or generate in C#:
+await db.Execute("INSERT INTO todos (id, description) VALUES (?, ?)", [Guid.NewGuid().ToString(), "Buy milk"]);
+```
+
+### Batch Execution
+
+```csharp
+// Execute the same statement with multiple parameter sets
+await db.ExecuteBatch(
+    "INSERT INTO todos (id, description, list_id) VALUES (uuid(), ?, ?)",
+    [
+        ["Buy milk", listId],
+        ["Buy eggs", listId],
+        ["Buy bread", listId],
+    ]);
+```
+
+## Sync Status
+
+```csharp
+SyncStatus status = db.CurrentStatus;
+
+status.Connected            // bool — sync stream is active
+status.Connecting           // bool
+status.DataFlowStatus.Downloading  // bool
+status.DataFlowStatus.Uploading    // bool
+status.HasSynced            // bool? — null = DB still opening; true = at least one full sync completed
+status.LastSyncedAt         // DateTime?
+status.DownloadProgress()   // SyncProgress? — non-null only while downloading
+status.DataFlowStatus.UploadError    // Exception?
+status.DataFlowStatus.DownloadError  // Exception?
+```
+
+Observe status changes via event stream:
+
+```csharp
+await foreach (var update in db.ListenAsync(cancellationToken))
+{
+    if (update.StatusChanged != null)
+    {
+        var s = update.StatusChanged;
+        Console.WriteLine($"Connected: {s.Connected}, HasSynced: {s.HasSynced}");
+    }
+}
+```
+
+`HasSynced` persists across app restarts once set.
+
+### Sync Priorities
+
+Buckets can be assigned priorities (lower number = higher priority) on the server. Higher-priority data syncs first. See [Prioritized Sync](https://docs.powersync.com/usage/use-case-examples/prioritized-sync.md).
+
+```csharp
+await db.WaitForFirstSync(new PowerSyncDatabase.PrioritySyncRequest { Priority = 1 });
+
+var entry = db.CurrentStatus.StatusForPriority(1);
+entry.HasSynced     // bool?
+entry.LastSyncedAt  // DateTime?
+
+var progress = db.CurrentStatus.DownloadProgress()?.UntilPriority(1);
+progress?.DownloadedFraction    // double 0.0–1.0
+progress?.DownloadedOperations  // int
+progress?.TotalOperations       // int
+```
+
+## Sync Streams
+
+Sync Streams are the recommended way to define what data syncs to each client. See [Sync Config](references/sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs) and [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md) for full examples.
+
+> Sync Streams are currently in alpha in the .NET SDK.
+
+If `auto_subscribe` is not set to `true` in the sync config, subscribe to streams from client code:
+
+```csharp
+using PowerSync.Common.Client.Sync.Stream;
+
+// Create a stream handle
+ISyncStream stream = db.SyncStream(
+    name: "my_orders",
+    parameters: new Dictionary<string, object> { ["userId"] = currentUserId }
+);
+
+// Subscribe to the stream
+ISyncStreamSubscription subscription = await stream.Subscribe(new SyncStreamSubscribeOptions
+{
+    Ttl = TimeSpan.FromHours(1),                // optional — keep data alive after unsubscribe
+    Priority = new StreamPriority(1),           // optional — lower number = higher priority
+});
+
+// Wait for this specific stream to complete its first sync
+await subscription.WaitForFirstSync();
+
+// Check stream status
+SyncStreamStatus? streamStatus = db.CurrentStatus.ForStream(subscription);
+streamStatus?.Subscription.HasSynced        // bool
+streamStatus?.Subscription.LastSyncedAt     // DateTime?
+streamStatus?.Subscription.Active           // bool
+streamStatus?.Subscription.IsDefault        // bool
+streamStatus?.Subscription.ExpiresAt        // DateTime?
+streamStatus?.Progress?.DownloadedFraction  // double
+
+// Unsubscribe when done — TTL starts running after this
+subscription.Unsubscribe();
+
+// Or unsubscribe all subscriptions for a stream
+await stream.UnsubscribeAll();
+```
+
+Same stream name with different parameters creates separate subscriptions. Subscribing while offline is supported — subscriptions are tracked locally and sent on next connect.
+
+## Logging
+
+The SDK accepts an `ILogger` via `PowerSyncDatabaseOptions`:
+
+```csharp
+using Microsoft.Extensions.Logging;
+
+ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.AddConsole();
+    builder.SetMinimumLevel(LogLevel.Debug);
+});
+var logger = loggerFactory.CreateLogger("PowerSync");
+
+var db = new PowerSyncDatabase(new PowerSyncDatabaseOptions
+{
+    Database = new SQLOpenOptions { DbFilename = "app.db" },
+    Schema = schema,
+    Logger = logger,
+});
+```
+
+## Schema Updates
+
+Update the schema at runtime (must be disconnected):
+
+```csharp
+await db.Disconnect();
+await db.UpdateSchema(newSchema);
+await db.Connect(connector);
+```
+
+## Additional Resources
+
+Only read these if the content above does not provide enough context for the task.
+
+- [NuGet packages](https://www.nuget.org/profiles/PowerSync) — published packages
+- [Full SDK reference](https://docs.powersync.com/client-sdk-references/dotnet.md) — full SDK documentation
+- [CommandLine](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/CommandLine) — CLI app with real-time data sync example
+- [WPF](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/WPF) — Windows desktop to-do list app example
+- [MAUITodo](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/MAUITodo) — Cross-platform mobile and desktop to-do list example

--- a/.claude/skills/powersync/references/sdks/powersync-js-node.md
+++ b/.claude/skills/powersync/references/sdks/powersync-js-node.md
@@ -1,0 +1,192 @@
+---
+name: powersync-js-node
+description: PowerSync Node.js and Electron integration — CLI setup, background sync, ETL pipelines, and Electron renderer/main process split
+metadata:
+  tags: nodejs, electron, cli, javascript, typescript, better-sqlite3, offline-first
+---
+
+# PowerSync Node.js & Electron
+
+Node.js-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when building Node.js CLI tools, background sync processes, ETL pipelines, or Electron desktop apps.
+
+| Resource | Description |
+|----------|-------------|
+| [Node.js SDK Reference](https://docs.powersync.com/client-sdks/reference/node.md) | Full SDK documentation for Node.js, consult for details beyond the inline examples. |
+| [Node SDK API Reference](https://powersync-ja.github.io/powersync-js/node-sdk) | Full API reference for `@powersync/node`, consult only when the inline examples don't cover your case. |
+
+## Node.js
+
+### 1. Install
+
+```bash
+npm install @powersync/node
+npm install better-sqlite3   # required peer dependency
+```
+
+TypeScript types for `better-sqlite3`:
+
+```bash
+npm install --save-dev @types/better-sqlite3
+```
+
+### Key Differences from the Web SDK
+
+| Aspect | `@powersync/web` | `@powersync/node` |
+|--------|-----------------|-------------------|
+| SQLite runtime | WebAssembly (wa-sqlite) | Native (`better-sqlite3`) |
+| Web Workers | Yes — DB runs in a worker by default | No — runs synchronously in the main thread |
+| Multi-tab sync | Yes — shared sync worker across browser tabs | No |
+| UI framework hooks | `@powersync/react`, `@powersync/vue` | None — use imperative API |
+| Environment | Browser | Node.js 18+ |
+
+### 2. Setup
+
+```ts
+import { PowerSyncDatabase } from '@powersync/node';
+import { AppSchema } from './AppSchema';
+import { PowerSyncConnector } from './PowerSyncConnector';
+
+const db = new PowerSyncDatabase({
+  schema: AppSchema,
+  database: {
+    dbFilename: 'app.db'
+  }
+});
+
+const connector = new PowerSyncConnector();
+await db.connect(connector);
+```
+
+`connect()` behaves the same as the web SDK — it starts the sync stream in the background. Use `db.waitForFirstSync()` to wait for data before proceeding.
+
+### Querying
+
+No UI hooks are available in Node.js. Use the imperative API from `references/sdks/powersync-js.md` directly:
+
+```ts
+// One-time queries
+const lists = await db.getAll('SELECT * FROM lists WHERE owner_id = ?', [userId]);
+const list = await db.getOptional('SELECT * FROM lists WHERE id = ?', [id]);
+
+// Watch for changes (async generator)
+for await (const result of db.watchWithAsyncGenerator('SELECT * FROM lists')) {
+  console.log('Lists updated:', result.rows._array);
+}
+
+// Writes
+await db.execute('INSERT INTO lists (id, name) VALUES (uuid(), ?)', ['My List']);
+await db.writeTransaction(async (tx) => {
+  await tx.execute('DELETE FROM lists WHERE id = ?', [listId]);
+  await tx.execute('DELETE FROM todos WHERE list_id = ?', [listId]);
+});
+```
+
+### Use Cases
+
+- CLI tools: Sync data from a PowerSync service for offline-capable scripts
+- Background sync jobs: Keep a local SQLite database up to date with server data for reporting or ETL
+- Server-side scripts: Read/write to a local PowerSync-managed SQLite database without a browser
+
+### Sync Status
+
+The same `db.currentStatus` and `db.registerListener` API applies:
+
+```ts
+db.registerListener({
+  statusChanged: (status) => {
+    console.log('Connected:', status.connected, '| Last synced:', status.lastSyncedAt);
+  }
+});
+```
+
+---
+
+## Electron
+
+Electron apps have two distinct environments — the renderer process (a Chromium browser window) and the main process (Node.js). PowerSync has a different SDK for each.
+
+### Architecture
+
+```
+Electron App
+├── Renderer Process (Chromium)
+│   └── Use @powersync/web + @powersync/react or @powersync/vue
+│       → See references/sdks/powersync-js-react.md or references/sdks/powersync-js-vue.md
+│
+└── Main Process (Node.js)
+    └── Use @powersync/node + better-sqlite3
+        → Use imperative API — no UI hooks available
+```
+
+### Renderer Process
+
+The renderer process is a full browser environment. Set it up exactly like any other web app:
+
+```bash
+npm install @powersync/web @journeyapps/wa-sqlite @powersync/react
+```
+
+Use `PowerSyncContext.Provider` and `useQuery`/`useStatus` hooks as documented in `references/sdks/powersync-js-react.md`. The Web-Specific Options section in `references/sdks/powersync-js.md` (VFS options, multi-tab, `debugMode`) also applies to the renderer process.
+
+### Main Process
+
+The main process runs Node.js with no DOM. Use `@powersync/node`:
+
+```bash
+npm install @powersync/node better-sqlite3
+```
+
+```ts
+// main/db.ts
+import { PowerSyncDatabase } from '@powersync/node';
+import { AppSchema } from './AppSchema';
+import { PowerSyncConnector } from './PowerSyncConnector';
+
+export const db = new PowerSyncDatabase({
+  schema: AppSchema,
+  database: { dbFilename: 'app.db' }
+});
+
+export async function initDb() {
+  const connector = new PowerSyncConnector();
+  await db.connect(connector);
+  await db.waitForFirstSync();
+}
+```
+
+### IPC Pattern
+
+If you sync data in the main process and need to expose it to the renderer, use Electron's IPC:
+
+```ts
+// main/ipcHandlers.ts
+import { ipcMain } from 'electron';
+import { db } from './db';
+
+ipcMain.handle('powersync:query', async (_event, sql: string, params: any[]) => {
+  return db.getAll(sql, params);
+});
+```
+
+```ts
+// renderer — via preload bridge
+const lists = await window.electron.invoke('powersync:query', 'SELECT * FROM lists', []);
+```
+
+However, the more common pattern is to use `@powersync/web` in the renderer and maintain a separate sync connection there — this keeps the data layer entirely in the renderer process and avoids IPC overhead.
+
+## Common Pitfalls
+
+### Using `@powersync/web` in Node.js
+
+`@powersync/web` requires browser APIs (`SharedWorker`, `indexedDB`, WebAssembly with browser globals) that are not available in Node.js. Always use `@powersync/node` for the main process or any non-browser Node.js environment.
+
+### Missing `better-sqlite3` native build
+
+`better-sqlite3` is a native module that must be compiled for the target platform. In Electron, it must be rebuilt for Electron's Node.js version using `electron-rebuild` or `@electron/rebuild`:
+
+```bash
+npx @electron/rebuild -f -w better-sqlite3
+```
+
+Run this after any Electron version upgrade.

--- a/.claude/skills/powersync/references/sdks/powersync-js-react-native.md
+++ b/.claude/skills/powersync/references/sdks/powersync-js-react-native.md
@@ -1,0 +1,164 @@
+---
+name: powersync-js-react-native
+description: PowerSync React Native, Expo, and Expo Go integration — native SQLite adapters, managed workflow setup, and Expo Go sql-js fallback
+metadata:
+  tags: react-native, expo, expo-go, mobile, op-sqlite, javascript, typescript, offline-first
+---
+
+# PowerSync React Native, Expo & Expo Go
+
+React Native-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when building React Native apps, Expo apps (managed or bare workflow), or Expo Go sandboxes.
+
+The React hooks API (`useQuery`, `useStatus`, `usePowerSync`, `useSuspenseQuery`) from `@powersync/react-native` is identical to `@powersync/react` — see `references/sdks/powersync-js.md` for full hook patterns and `references/sdks/powersync-js-react.md` for `useSuspenseQuery` and sync stream hooks.
+
+| Resource | Description |
+|----------|-------------|
+| [React Native & Expo SDK](https://docs.powersync.com/client-sdks/reference/react-native-and-expo.md) | Full SDK documentation for React Native, consult for details beyond the inline examples. |
+| [React Native SDK API Reference](https://powersync-ja.github.io/powersync-js/react-native-sdk) | Full API reference for `@powersync/react-native`, consult only when the inline examples don't cover your case. |
+| [Expo Go Support](https://docs.powersync.com/client-sdks/frameworks/expo-go-support.md) | Expo Go adapter guide, consult for details beyond the inline examples. |
+
+## 1. Install
+
+### Standard React Native (Recommended)
+
+```bash
+npm install @powersync/react-native
+```
+
+Then install a native SQLite adapter (required peer dependency):
+
+```bash
+# OP-SQLite — recommended: built-in encryption, React Native New Architecture support
+npm install @powersync/op-sqlite
+
+# OR: React Native Quick SQLite — original adapter
+npm install @journeyapps/react-native-quick-sqlite
+```
+
+After installing native dependencies, rebuild your native app:
+
+```bash
+npx expo prebuild   # Expo managed/bare
+# or
+npx react-native run-ios / run-android
+```
+
+## 2. Provider Setup
+
+The provider pattern is identical to React web. Import from `@powersync/react-native`:
+
+```tsx
+import { PowerSyncContext } from '@powersync/react-native';
+
+export function App() {
+  return (
+    <PowerSyncContext.Provider value={db}>
+      <YourApp />
+    </PowerSyncContext.Provider>
+  );
+}
+```
+
+## 3. Database Initialization
+
+```ts
+import { PowerSyncDatabase } from '@powersync/react-native';
+import { AppSchema } from './AppSchema';
+
+export const db = new PowerSyncDatabase({
+  schema: AppSchema,
+  database: {
+    dbFilename: 'app.db'
+  }
+});
+```
+
+By default, `@powersync/react-native` uses OP-SQLite if installed, falling back to React Native Quick SQLite. No additional configuration is needed to select the adapter — the SDK detects which peer is present.
+
+## Expo
+
+### Managed Workflow
+
+PowerSync works with Expo managed workflow. Native adapters (recommended) require a development build because they use native modules. If you need to run in Expo Go, use the JavaScript-only adapter instead. See the Expo Go section below.
+
+```bash
+npx expo install @powersync/react-native @powersync/op-sqlite
+npx expo prebuild
+npx expo run:ios   # or run:android
+```
+
+Use [EAS Build](https://docs.expo.dev/build/introduction/) for CI/CD builds.
+
+### Bare Workflow
+
+Same as standard React Native above. Run `npx react-native run-ios` / `run-android` after installing native dependencies.
+
+## Expo Go
+
+Expo Go is a sandbox that does not support native modules. To run PowerSync in Expo Go, use the JavaScript-only adapter `@powersync/adapter-sql-js`.
+
+> Alpha: `@powersync/adapter-sql-js` is in alpha. Do not use in production.
+
+### Limitations
+
+- No SQLite consistency guarantees — every write triggers a full rewrite of the entire database file; the app may end up with missing data or a corrupted file if killed mid-write
+- Significantly slower than native adapters
+- Default mode is in-memory; persistence requires a custom `persister` option
+
+### Install
+
+```bash
+npm install @powersync/react-native @powersync/adapter-sql-js
+```
+
+### Usage
+
+```tsx
+import { SQLJSOpenFactory } from '@powersync/adapter-sql-js';
+import { PowerSyncDatabase, Schema } from '@powersync/react-native';
+
+export const powerSync = new PowerSyncDatabase({
+  schema: new Schema({}), // define your schema here
+  database: new SQLJSOpenFactory({
+    dbFilename: 'app.db',
+  }),
+});
+```
+
+### Switching Between Expo Go and Native Adapters
+
+Use `Constants.executionEnvironment` to select the adapter at runtime, allowing the same codebase to run in both Expo Go and development/production builds:
+
+```tsx
+import { SQLJSOpenFactory } from '@powersync/adapter-sql-js';
+import { PowerSyncDatabase } from '@powersync/react-native';
+import Constants from 'expo-constants';
+
+const isExpoGo = Constants.executionEnvironment === 'storeClient';
+
+export const powerSync = new PowerSyncDatabase({
+  schema: AppSchema,
+  database: isExpoGo
+    ? new SQLJSOpenFactory({ dbFilename: 'app.db' })
+    : { dbFilename: 'sqlite.db' }, // uses native adapter
+});
+```
+
+### Moving Beyond Expo Go
+
+When moving to development builds or production, switch to a native adapter:
+
+- OP-SQLite (`@powersync/op-sqlite`) — recommended; encryption support, New Architecture compatible
+- React Native Quick SQLite (`@journeyapps/react-native-quick-sqlite`) — original adapter
+
+These require native compilation and cannot run inside Expo Go's prebuilt container.
+
+## Common Pitfalls
+
+### Forgetting to rebuild after installing native deps
+
+Any change to native dependencies requires a rebuild. Running `npx expo start` without rebuilding will use the old native bundle and the new package won't be linked.
+
+### Using Expo Go without the sql-js adapter
+
+Expo Go does not support native modules. Attempting to use `@powersync/react-native` with the default OP-SQLite adapter in Expo Go will throw a native module not found error. Use `@powersync/adapter-sql-js` for Expo Go.

--- a/.claude/skills/powersync/references/sdks/powersync-js-react.md
+++ b/.claude/skills/powersync/references/sdks/powersync-js-react.md
@@ -1,0 +1,314 @@
+---
+name: powersync-js-react
+description: PowerSync React and Next.js integration — PowerSyncContext, useSuspenseQuery, useQuery, sync stream hooks, and Next.js/Vite setup
+metadata:
+  tags: react, nextjs, vite, hooks, useSuspenseQuery, useQuery, PowerSyncContext, javascript, typescript
+---
+
+# PowerSync React & Next.js
+
+React-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when building React web apps, Next.js apps, or when using the React hooks from `@powersync/react` or `@powersync/react-native`.
+
+| Resource | Description |
+|----------|-------------|
+| [React Integration Guide](https://docs.powersync.com/client-sdks/frameworks/react.md) | Full React setup guide, consult for details beyond the inline examples. |
+| [Next.js Integration Guide](https://docs.powersync.com/client-sdks/frameworks/next-js.md) | Full Next.js setup guide, consult for details beyond the inline examples. |
+| [React SDK API Reference](https://powersync-ja.github.io/powersync-js/react-sdk) | Full API reference for `@powersync/react`, consult only when the inline examples don't cover your case. |
+
+## Provider Setup
+
+```tsx
+import { PowerSyncContext } from '@powersync/react'; // or @powersync/react-native
+
+export function App() {
+  return (
+    <PowerSyncContext.Provider value={db}>
+      <YourApp />
+    </PowerSyncContext.Provider>
+  );
+}
+```
+
+All hooks (`useQuery`, `useSuspenseQuery`, `useStatus`) read from this context via `usePowerSync()`. If the provider is missing, `useQuery` returns `{ isLoading: false, error: Error('PowerSync not configured.') }`, and `useSuspenseQuery` throws.
+
+## useSuspenseQuery
+
+```ts
+useSuspenseQuery<RowType>(
+  query: string | CompilableQuery<RowType>,
+  parameters?: any[],
+  options?: { rowComparator?, reportFetching?, throttleMs?, runQueryOnce? }
+): { data, isFetching }  // no isLoading — always has data when it returns
+```
+
+Must be used inside a `<Suspense>` boundary. Throws an error boundary-catchable error if the query errors. Always pair with an `<ErrorBoundary>`:
+
+```tsx
+<ErrorBoundary fallback={<ErrorUI />}>
+  <Suspense fallback={<Loading />}>
+    <DataComponent />  {/* calls useSuspenseQuery */}
+  </Suspense>
+</ErrorBoundary>
+```
+
+`useSuspenseQuery` uses a `QueryStore` (one per `PowerSyncDatabase` instance, stored in a `WeakMap`). The store caches `WatchedQuery` instances keyed by:
+
+```
+"${sql} -- ${JSON.stringify(params)} -- ${JSON.stringify(options)}"
+```
+
+A query is evicted (closed) when all listeners are removed. `useSuspenseQuery` and `useQuery` with the same SQL/params/options share the same underlying `WatchedQuery`.
+
+## Sync Stream Hooks
+
+React hooks for subscribing to named Sync Streams. Requires the PowerSync service to be configured with Sync Streams (edition 3 config). See [Sync Streams Overview](https://docs.powersync.com/sync/streams/overview.md) and [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md#react-hooks) for more information.
+
+```tsx
+import { useSyncStream, useSuspenseSyncStream } from '@powersync/react';
+
+// Non-suspense — returns null while subscription is being established
+function ListsScreen() {
+  const streamStatus = useSyncStream({
+    name: 'lists',
+    parameters: { userId: currentUser.id },
+    priority: 1,  // optional, 0-3
+    ttl: 3600,    // optional, seconds to keep alive after unsubscribe
+  });
+
+  if (!streamStatus) return <Loading />;  // subscription not yet ready
+  if (!streamStatus.subscription.hasSynced) return <Loading />;
+
+  return <ListsComponent />;
+}
+
+// Suspense version — never returns null, suspends instead
+function ListsScreen() {
+  const streamStatus = useSuspenseSyncStream({
+    name: 'lists',
+    parameters: { userId: currentUser.id },
+  });
+  // streamStatus.subscription.hasSynced is guaranteed true here
+  return <ListsComponent />;
+}
+```
+
+Automatic cleanup: Both hooks unsubscribe when the component unmounts. The TTL keeps data active for the specified duration after unsubscribe.
+
+### SyncStreamStatus Fields
+
+```ts
+interface SyncStreamStatus {
+  subscription: {
+    name: string;
+    parameters: Record<string, any> | null;
+    active: boolean;         // currently receiving data
+    isDefault: boolean;      // was configured as a default stream on the server
+    hasExplicitSubscription: boolean;
+    expiresAt: Date | null;  // when TTL expires
+    hasSynced: boolean;      // has completed at least one full sync
+    lastSyncedAt: Date | null;
+  };
+  progress: {
+    downloadedFraction: number;  // 0.0-1.0
+    downloadedOperations: number;
+    totalOperations: number;
+  } | null;
+  priority: number | null;
+}
+```
+
+## Next.js Setup
+
+PowerSync is tailored for client-side applications. Next.js evaluates code in a Node.js runtime during SSR — the PowerSync Web SDK requires browser APIs not available in Node.js. It performs no-ops in Node.js rather than throwing errors, but no data is available during SSR. Always isolate PowerSync to client-side code.
+
+### Install
+
+```bash
+npm install @powersync/web @journeyapps/wa-sqlite @powersync/react
+```
+
+### Copy Worker Assets (Turbopack)
+
+Turbopack doesn't support dynamic imports of workers yet. Add a `postinstall` script to copy pre-bundled worker files to your public directory:
+
+```json
+{
+  "scripts": {
+    "postinstall": "powersync-web copy-assets -o public"
+  }
+}
+```
+
+Run it once after install, then add to `.gitignore`:
+
+```
+public/@powersync/*
+```
+
+### `next.config.ts` — Turbopack (Next.js 16+)
+
+```typescript
+module.exports = {
+  images: {
+    disableStaticImages: true
+  },
+  turbopack: {}
+};
+```
+
+### `next.config.ts` — Webpack (legacy, pre-Next.js 16)
+
+```typescript
+module.exports = {
+  webpack: (config, { isServer }) => {
+    config.experiments = {
+      ...config.experiments,
+      asyncWebAssembly: true,
+      topLevelAwait: true,
+    };
+
+    if (!isServer) {
+      config.module.rules.push({
+        test: /\.wasm$/,
+        type: 'asset/resource',
+      });
+    }
+
+    return config;
+  }
+};
+```
+
+### SystemProvider
+
+Create a client-only provider component. The `disableSSRWarning: true` flag suppresses the Node.js no-op warning. The pre-bundled worker paths reference the files copied by `powersync-web copy-assets`.
+
+```tsx
+// components/providers/SystemProvider.tsx
+'use client';
+
+import { AppSchema } from '@/lib/powersync/AppSchema';
+import { BackendConnector } from '@/lib/powersync/BackendConnector';
+import { PowerSyncContext } from '@powersync/react';
+import { PowerSyncDatabase, WASQLiteOpenFactory, createBaseLogger, LogLevel } from '@powersync/web';
+import React, { Suspense } from 'react';
+
+const factory = new WASQLiteOpenFactory({
+  dbFilename: 'powersync.db',
+  // Pre-bundled worker — required for Turbopack
+  worker: '/@powersync/worker/WASQLiteDB.umd.js'
+});
+
+export const db = new PowerSyncDatabase({
+  database: factory,
+  schema: AppSchema,
+  flags: {
+    disableSSRWarning: true
+  },
+  sync: {
+    worker: '/@powersync/worker/SharedSyncImplementation.umd.js'
+  }
+});
+
+const connector = new BackendConnector();
+db.connect(connector);
+
+export const SystemProvider = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Suspense>
+      <PowerSyncContext.Provider value={db}>{children}</PowerSyncContext.Provider>
+    </Suspense>
+  );
+};
+```
+
+### Update `layout.tsx`
+
+```tsx
+// app/layout.tsx
+'use client';
+
+import { SystemProvider } from '@/app/components/providers/SystemProvider';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <SystemProvider>{children}</SystemProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+### Using PowerSync in Pages
+
+```tsx
+// app/page.tsx
+'use client';
+
+import { useQuery, useStatus, usePowerSync } from '@powersync/react';
+
+export default function Page() {
+  const powersync = usePowerSync();
+  const status = useStatus();
+  const { data: lists, isLoading } = useQuery('SELECT * FROM lists');
+
+  return (
+    <ul>
+      {lists.map(list => <li key={list.id}>{list.name}</li>)}
+    </ul>
+  );
+}
+```
+
+All components that use PowerSync hooks must have `'use client'` at the top. PowerSync hooks are not compatible with React Server Components.
+
+## Vite Setup
+
+Vite requires `vite-plugin-wasm` + `vite-plugin-top-level-await` to handle the WASM SQLite engine.
+
+```bash
+npm install -D vite-plugin-wasm vite-plugin-top-level-await
+```
+
+```ts
+// vite.config.ts
+import wasm from 'vite-plugin-wasm'
+import topLevelAwait from 'vite-plugin-top-level-await'
+
+export default defineConfig({
+  plugins: [react(), wasm(), topLevelAwait()],
+  optimizeDeps: {
+    exclude: ['@journeyapps/wa-sqlite', '@powersync/web'],
+  },
+  worker: {
+    format: 'es',
+    plugins: () => [wasm(), topLevelAwait()],
+  },
+})
+```
+
+> **Do NOT** add `optimizeDeps: { include: ['@powersync/web > js-logger'] }` — this dependency path does not exist in current SDK versions and causes build warnings. The `exclude` configuration above is sufficient.
+
+## Common Pitfalls
+
+### Suspense requires ErrorBoundary
+
+`useSuspenseQuery` throws query errors upward — they go to the nearest `<ErrorBoundary>`, not `<Suspense>`. Without an ErrorBoundary, query errors crash the component tree silently.
+
+```tsx
+<ErrorBoundary fallback={<ErrorUI />}>
+  <Suspense fallback={<Loading />}>
+    <DataComponent />
+  </Suspense>
+</ErrorBoundary>
+```
+
+### Next.js: forgetting `'use client'`
+
+Any component that calls `usePowerSync`, `useQuery`, `useStatus`, or `useSuspenseQuery` must be a Client Component. Forgetting `'use client'` causes a build error or a runtime error about hooks in Server Components.
+
+### Next.js: awaiting `db.connect()` at module scope
+
+`connect()` is fire-and-forget. Calling `await db.connect(connector)` at module scope in a Next.js file will block the module evaluation. Call `db.connect(connector)` without `await` in your provider, then use `db.waitForFirstSync()` if you need to gate rendering on data availability.

--- a/.claude/skills/powersync/references/sdks/powersync-js-tanstack.md
+++ b/.claude/skills/powersync/references/sdks/powersync-js-tanstack.md
@@ -1,0 +1,197 @@
+---
+name: powersync-js-tanstack
+description: PowerSync TanStack integrations — TanStack Query caching, TanStack DB collections, optimistic mutations, and schema validation
+metadata:
+  tags: tanstack, tanstack-query, tanstack-db, react, javascript, typescript, offline-first
+---
+
+# PowerSync TanStack Integrations
+
+TanStack-specific integrations for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when using TanStack Query (React) or TanStack DB (multi-framework) with PowerSync.
+
+| Resource | Description |
+|----------|-------------|
+| [TanStack Query & TanStack DB](https://docs.powersync.com/client-sdks/frameworks/tanstack.md) | Full TanStack integrations guide, consult for details beyond the inline examples. |
+| [TanStack React Query API Reference](https://powersync-ja.github.io/powersync-js/tanstack-react-query-sdk) | Full API reference for `@powersync/tanstack-react-query`, consult only when the inline examples don't cover your case. |
+| [PowerSync Collection — TanStack DB Docs](https://tanstack.com/db/latest/docs/collections/powersync-collection) | Full TanStack DB collection reference. |
+| [TanStack DB API Reference](https://tanstack.com/db/latest/docs/reference/powersync-db-collection/index) | TanStack DB collection API reference. |
+
+---
+
+## TanStack Query
+
+`@powersync/tanstack-react-query` wraps TanStack Query's `useQuery` and `useSuspenseQuery` hooks, bringing TanStack's advanced async state management to PowerSync web and React Native applications.
+
+Use TanStack Query when you need:
+- Query caching by key — subsequent instances of the same query don't refire
+- Flicker mitigation on navigation — stale cached data shows instantly while fresh data loads
+- Pagination support via TanStack's built-in paginated query patterns
+- React Suspense with navigation blocking via `v7_startTransition`
+
+Use `@powersync/react` hooks (from `references/sdks/powersync-js-react.md`) when:
+- You don't need TanStack's query cache
+- You want a simpler API with fewer dependencies
+
+### Install
+
+```bash
+npm install @powersync/tanstack-react-query
+```
+
+TanStack Query also requires its core peer:
+
+```bash
+npm install @tanstack/react-query
+```
+
+### Usage
+
+```tsx
+import { useQuery, useSuspenseQuery } from '@powersync/tanstack-react-query';
+
+// Basic reactive query with TanStack loading/error states
+function ListsScreen() {
+  const { data: lists, isLoading, error } = useQuery({
+    queryKey: ['lists'],
+    query: 'SELECT * FROM lists ORDER BY created_at DESC'
+  });
+
+  if (isLoading) return <Loading />;
+  if (error) return <Error message={error.message} />;
+  return <ul>{lists.map(l => <li key={l.id}>{l.name}</li>)}</ul>;
+}
+
+// Suspense version — use with a <Suspense> boundary
+function ListsScreen() {
+  const { data: lists } = useSuspenseQuery({
+    queryKey: ['lists'],
+    query: 'SELECT * FROM lists ORDER BY created_at DESC'
+  });
+  return <ul>{lists.map(l => <li key={l.id}>{l.name}</li>)}</ul>;
+}
+```
+
+For full usage examples and configuration options, see the [package README](https://www.npmjs.com/package/@powersync/tanstack-react-query).
+
+### Flicker Mitigation
+
+When navigating to or refreshing a page, a brief UI flicker (10–50ms) can occur as queries rerun. TanStack Query addresses this:
+
+- First load: use `isLoading` / a Suspense fallback
+- Subsequent loads: TanStack's query cache serves stale data instantly, then updates in the background — no flicker
+- Block navigation: combine `useSuspenseQuery` with `<Suspense>` and React Router's [`v7_startTransition`](https://reactrouter.com/en/main/upgrading/future#v7_starttransition) flag to ensure page B is fully loaded before navigating away from page A
+
+---
+
+## TanStack DB
+
+> Alpha: The PowerSync TanStack DB collection is currently in an [Alpha](https://docs.powersync.com/resources/feature-status.md) release.
+
+`@tanstack/powersync-db-collection` lets you use TanStack DB collections backed by PowerSync. In-memory collections stay in sync with PowerSync's SQLite database, providing offline-first reactive data with optimistic mutations.
+
+TanStack DB is different from TanStack Query: TanStack DB uses differential data flow for in-memory queries that update incrementally, rather than re-running full SQL queries. It's more suitable for complex, highly interactive UIs that need cross-collection joins and optimistic updates.
+
+Use TanStack DB when:
+- Mutations need to feel synchronous — TanStack DB applies optimistic state in-memory immediately; PowerSync's `execute()` is async, which is fast but not instantaneous
+- Your app renders many simultaneous live queries — PowerSync live queries each hold a SQLite connection from a bounded pool; if many views watch queries at once, that pool becomes a snappiness bottleneck; TanStack DB's in-memory queries bypass it entirely
+- You have complex dependent queries that benefit from differential invalidation — PowerSync re-runs the full SQL query and diffs results on every table change; TanStack DB invalidates only the queries whose specific inputs changed
+- You need to join a PowerSync (offline) collection with a non-PowerSync TanStack DB collection (e.g. an online store)
+
+Use plain PowerSync (`.watch()` / `usePowerSyncQuery`) when:
+- Async SQLite write latency is acceptable for your use case
+- Your app has a modest number of simultaneous live queries
+- Your queries are simple and don't benefit from differential invalidation
+- You are not mixing offline and online collections
+
+### Install
+
+```bash
+# Web
+npm install @tanstack/powersync-db-collection @powersync/web @journeyapps/wa-sqlite
+
+# React Native
+npm install @tanstack/powersync-db-collection @powersync/react-native
+```
+
+Also install a TanStack DB framework adapter for your UI framework:
+
+```bash
+npm install @tanstack/react-db    # React
+npm install @tanstack/vue-db      # Vue
+npm install @tanstack/solid-db    # Solid
+npm install @tanstack/svelte-db   # Svelte
+npm install @tanstack/angular-db  # Angular
+```
+
+### Quick Start
+
+```ts
+import { Schema, Table, column } from '@powersync/web';
+import { PowerSyncDatabase } from '@powersync/web';
+import { createCollection } from '@tanstack/react-db';
+import { powerSyncCollectionOptions } from '@tanstack/powersync-db-collection';
+
+const APP_SCHEMA = new Schema({
+  documents: new Table({
+    name: column.text,
+    author: column.text,
+    created_at: column.text,
+    archived: column.integer
+  })
+});
+
+const db = new PowerSyncDatabase({
+  database: { dbFilename: 'app.sqlite' },
+  schema: APP_SCHEMA
+});
+
+// Optional: db.connect(connector) for backend sync
+
+// Create a collection — types are inferred from the table definition
+const documentsCollection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents
+  })
+);
+```
+
+### Features
+
+- Differential in-memory queries — live queries update incrementally instead of re-running entire SQL queries; stays fast even for complex queries across multiple collections
+- Reactive data flow — components re-render only when their specific data changes
+- Optimistic mutations — mutations apply to local state immediately; TanStack DB keeps optimistic state on top of synced data and rolls back automatically if the server request fails
+- Cross-collection queries — live queries can join across collections, including mixing PowerSync collections with other TanStack DB collections
+- Schema validation and rich types — use Zod (or any schema library) to validate mutations and transform SQLite types into rich JavaScript types (`Date`, boolean, JSON); supports separate deserialization schemas for synced vs. written data
+- Metadata tracking — attach custom metadata to insert/update/delete operations; PowerSync persists it and exposes it in `CrudEntry.metadata` during `uploadData`
+- Advanced transactions — batch multiple operations with `PowerSyncTransactor` and `createTransaction`; control commit timing and wait for persistence
+
+### Configuration Options
+
+`powerSyncCollectionOptions` accepts:
+- `database` — the `PowerSyncDatabase` instance
+- `table` — a table from your `Schema.props`
+- `schema` — optional Zod (or compatible) schema for mutation validation
+- `deserializationSchema` — optional separate schema for deserializing synced data
+- `serializer` — optional custom serializer
+- `onDeserializationError` — callback for deserialization errors
+- `syncBatchSize` — number of rows to process per sync batch
+
+See [PowerSync Collection — Configuration Options](https://tanstack.com/db/latest/docs/collections/powersync-collection#4-create-a-tanstack-db-collection) for full details.
+
+## Common Pitfalls
+
+### Version misalignment between TanStack packages
+
+Type conflicts between `@powersync/common`, `@tanstack/db`, and `@tanstack/powersync-db-collection` often occur when multiple versions of the same package are installed as transitive dependencies. Check alignment:
+
+```bash
+npm ls @powersync/common
+npm ls @tanstack/react-db @tanstack/powersync-db-collection @tanstack/db
+```
+
+If multiple versions appear, delete `node_modules` and the lock file, then reinstall. See also `references/powersync-debug.md` for the full debugging guidance.
+
+### Don't mix TanStack DB collections and direct `db.execute()` without accounting for optimistic state
+
+TanStack DB collections maintain their own in-memory optimistic state on top of the SQLite database. If you write to SQLite directly via `db.execute()` while a collection has pending optimistic mutations for the same rows, the collection's view of the data may temporarily diverge until the optimistic state is reconciled. Prefer writing through the collection's mutation API when the collection is active.

--- a/.claude/skills/powersync/references/sdks/powersync-js-vue.md
+++ b/.claude/skills/powersync/references/sdks/powersync-js-vue.md
@@ -1,0 +1,323 @@
+---
+name: powersync-js-vue
+description: PowerSync Vue and Nuxt integration — composables, plugin setup, Kysely ORM, and diagnostics panel
+metadata:
+  tags: vue, nuxt, composables, useQuery, javascript, typescript, offline-first
+---
+
+# PowerSync Vue & Nuxt
+
+Vue-specific integration for the PowerSync JavaScript SDK. Use this reference alongside `references/sdks/powersync-js.md` when building Vue apps or Nuxt apps.
+
+| Resource | Description |
+|----------|-------------|
+| [Vue Composables Reference](https://docs.powersync.com/client-sdks/frameworks/vue.md) | Full Vue composables guide, consult for details beyond the inline examples. |
+| [Vue SDK API Reference](https://powersync-ja.github.io/powersync-js/vue-sdk) | Full API reference for `@powersync/vue`, consult only when the inline examples don't cover your case. |
+| [Nuxt Integration Guide](https://docs.powersync.com/client-sdks/frameworks/nuxt.md) | Full Nuxt setup guide. |
+| [Nuxt Module API Reference](https://powersync-ja.github.io/powersync-js/nuxt-sdk) | API reference for `@powersync/nuxt`. |
+
+## Vue
+
+### 1. Install
+
+```bash
+# npm (v7+ installs peer dependencies automatically)
+npm install @powersync/vue
+
+# pnpm (must install peer dependencies explicitly)
+pnpm add @powersync/vue @powersync/web @journeyapps/wa-sqlite
+```
+
+### 2. Plugin Setup
+
+```ts
+import { createPowerSyncPlugin } from '@powersync/vue';
+import { PowerSyncDatabase } from '@powersync/web';
+import { AppSchema } from './AppSchema';
+import { PowerSyncConnector } from './PowerSyncConnector';
+import { createApp } from 'vue';
+import App from './App.vue';
+
+const db = new PowerSyncDatabase({
+  database: { dbFilename: 'app.db' },
+  schema: AppSchema
+});
+
+const connector = new PowerSyncConnector();
+db.connect(connector);
+
+const app = createApp(App);
+app.use(createPowerSyncPlugin({ database: db }));
+app.mount('#app');
+```
+
+### Composables
+
+In a standalone Vue app, composables are imported from `@powersync/vue`. In Nuxt, all composables are auto-imported — no import statement is needed.
+
+#### `useQuery`
+
+Reactive query — re-renders the component automatically when underlying data changes.
+
+```ts
+import { useQuery } from '@powersync/vue'; // omit import in Nuxt
+
+const { data: lists, isLoading, isFetching, error } = useQuery(
+  'SELECT * FROM lists ORDER BY created_at DESC'
+);
+```
+
+With parameters (parameters are reactive — can be a `ref` or `computed`):
+
+```ts
+const { data: todos } = useQuery(
+  'SELECT * FROM todos WHERE list_id = ?',
+  [listId]
+);
+```
+
+Return shape: `{ data: Ref<RowType[]>, isLoading: Ref<boolean>, isFetching: Ref<boolean>, error: Ref<Error | undefined> }`.
+
+For advanced watch query features including incremental updates and differential results, see [Live Queries / Watch Queries](https://docs.powersync.com/client-sdks/watch-queries.md).
+
+#### `useStatus`
+
+Reactive connectivity status. Same shape as the React `useStatus` hook — see `references/sdks/powersync-js.md` for the full status field reference.
+
+```ts
+import { useStatus } from '@powersync/vue'; // omit import in Nuxt
+
+const status = useStatus();
+// status.connected, status.hasSynced, status.lastSyncedAt, etc.
+```
+
+#### `usePowerSync`
+
+Access the `PowerSyncDatabase` instance directly for imperative operations.
+
+```ts
+import { usePowerSync } from '@powersync/vue'; // omit import in Nuxt
+import { v4 as uuid } from 'uuid';
+
+const powersync = usePowerSync();
+
+await powersync.value.execute(
+  'INSERT INTO lists (id, created_at, name, owner_id) VALUES (?, ?, ?, ?)',
+  [uuid(), new Date().toISOString(), 'My List', currentUserId]
+);
+```
+
+`usePowerSync()` returns a `Ref<AbstractPowerSyncDatabase>` — access the database via `.value`.
+
+### Setup Context Requirement
+
+`usePowerSync`, `useQuery`, and `useStatus` all rely on Vue's `inject()` internally and must be called at the top level of a `<script setup>` block (or the synchronous `setup()` function). They must not be called inside nested functions, async functions, event handlers, or lifecycle hooks.
+
+```vue
+<script setup>
+import { usePowerSync } from '@powersync/vue';
+
+// ✅ Correct — called at the top level of setup
+const powerSync = usePowerSync();
+
+const handleClick = async () => {
+  // ✅ Use the ref returned from the top-level call
+  const result = await powerSync.value.getAll('SELECT * FROM lists');
+  console.log(result);
+};
+
+// ❌ Wrong — usePowerSync() called inside a nested function
+const handleClickBad = async () => {
+  const result = await usePowerSync().value.getAll('SELECT * FROM lists');
+};
+</script>
+```
+
+Calling these composables outside of a setup context throws an error. If you need to access the PowerSync database outside a component (e.g. in a store or utility module), export the database instance directly instead of using the composable.
+
+### Example Component
+
+```vue
+<script setup lang="ts">
+import { usePowerSync, useQuery, useStatus } from '@powersync/vue';
+
+const powersync = usePowerSync();
+const { data: lists, isLoading } = useQuery('SELECT * FROM lists ORDER BY created_at DESC');
+const status = useStatus();
+</script>
+
+<template>
+  <div>
+    <p>Status: {{ status.connected ? 'Connected' : 'Offline' }}</p>
+    <p v-if="isLoading">Loading...</p>
+    <ul v-else>
+      <li v-for="list in lists" :key="list.id">{{ list.name }}</li>
+    </ul>
+  </div>
+</template>
+```
+
+---
+
+## Nuxt
+
+> Alpha: `@powersync/nuxt` is currently in Alpha. APIs and behavior may change.
+
+`@powersync/nuxt` is a Nuxt module that wraps `@powersync/vue` and re-exports all its composables. It also adds a Nuxt Devtools integration with a PowerSync diagnostics panel.
+
+PowerSync is tailored for client-side applications. Nuxt evaluates plugins server-side unless you use the `.client.ts` suffix. The PowerSync Web SDK requires browser APIs not available in Node.js — it performs no-ops in Node.js rather than throwing errors, but no data is available during SSR. Always create your PowerSync plugin as `plugins/powersync.client.ts`.
+
+### 1. Install
+
+```bash
+# npm (v7+ installs peer dependencies automatically)
+npm install @powersync/nuxt
+
+# pnpm (must install peer dependencies explicitly)
+pnpm add @powersync/nuxt @powersync/vue @powersync/web
+```
+
+### 2. `nuxt.config.ts`
+
+Add `@powersync/nuxt` to the `modules` array and include the required Vite configuration:
+
+```typescript
+export default defineNuxtConfig({
+  modules: ['@powersync/nuxt'],
+  vite: {
+    optimizeDeps: {
+      exclude: ['@powersync/web']
+    },
+    worker: {
+      format: 'es'
+    }
+  }
+});
+```
+
+### 3. Create the Plugin
+
+Create `plugins/powersync.client.ts`. The `.client.ts` suffix ensures this only runs in the browser.
+
+```typescript
+import { NuxtPowerSyncDatabase, createPowerSyncPlugin } from '@powersync/nuxt';
+import { AppSchema } from '~/powersync/AppSchema';
+import { PowerSyncConnector } from '~/powersync/PowerSyncConnector';
+
+export default defineNuxtPlugin({
+  async setup(nuxtApp) {
+    const db = new NuxtPowerSyncDatabase({
+      database: {
+        dbFilename: 'my-app.sqlite'
+      },
+      schema: AppSchema
+    });
+
+    const connector = new PowerSyncConnector();
+
+    await db.init();
+    await db.connect(connector);
+
+    const plugin = createPowerSyncPlugin({ database: db });
+    nuxtApp.vueApp.use(plugin);
+  }
+});
+```
+
+### Using Composables
+
+All `@powersync/vue` composables (`usePowerSync`, `useQuery`, `useStatus`) are auto-imported in Nuxt — no import statement is needed in components or composables.
+
+```vue
+<script setup lang="ts">
+// No imports needed — composables are auto-imported by @powersync/nuxt
+
+const powersync = usePowerSync();
+const { data: lists, isLoading } = useQuery('SELECT * FROM lists ORDER BY created_at DESC');
+const status = useStatus();
+</script>
+```
+
+The same [setup context requirement](#setup-context-requirement) as standalone Vue applies — call composables at the top level of `<script setup>`, not inside nested or async functions.
+
+### Kysely ORM (Optional)
+
+The module optionally exposes a `usePowerSyncKysely()` composable for type-safe query building.
+
+Install the driver:
+
+```bash
+npm install @powersync/kysely-driver
+```
+
+Enable it in `nuxt.config.ts`:
+
+```typescript
+export default defineNuxtConfig({
+  modules: ['@powersync/nuxt'],
+  powersync: {
+    kysely: true
+  },
+  vite: {
+    optimizeDeps: {
+      exclude: ['@powersync/web']
+    },
+    worker: {
+      format: 'es'
+    }
+  }
+});
+```
+
+Use in components — `usePowerSyncKysely` is auto-imported. Import only your schema's `Database` type for full type safety:
+
+```typescript
+import { type Database } from '~/powersync/AppSchema';
+
+const db = usePowerSyncKysely<Database>();
+
+const lists = await db.selectFrom('lists').selectAll().execute();
+```
+
+### Diagnostics Panel
+
+`@powersync/nuxt` includes a PowerSync diagnostics panel that shows sync status, local data, bucket contents, config, and logs. Must be explicitly enabled.
+
+Enable in `nuxt.config.ts`:
+
+```typescript
+export default defineNuxtConfig({
+  modules: ['@powersync/nuxt'],
+  powersync: {
+    useDiagnostics: true
+  },
+  vite: {
+    optimizeDeps: {
+      exclude: ['@powersync/web']
+    },
+    worker: {
+      format: 'es'
+    }
+  }
+});
+```
+
+When `useDiagnostics: true` is set, `NuxtPowerSyncDatabase` automatically extends the schema with the diagnostics schema, sets up recording and logging, and stores the connector internally. No changes to the plugin file are needed.
+
+Access the inspector:
+- Nuxt Devtools: open browser Devtools and look for the PowerSync tab
+- Direct URL: navigate to `http://localhost:3000/__powersync-inspector`
+
+### Known Issues
+
+#### Tailwind CSS conflict
+
+PowerSync Inspector uses `unocss` as a transitive dependency, which conflicts with Tailwind CSS. If you use Tailwind, add the following to `nuxt.config.ts`:
+
+```typescript
+export default defineNuxtConfig({
+  unocss: {
+    autoImport: false
+  }
+});
+```

--- a/.claude/skills/powersync/references/sdks/powersync-js.md
+++ b/.claude/skills/powersync/references/sdks/powersync-js.md
@@ -1,0 +1,1036 @@
+---
+name: powersync-js
+description: PowerSync JavaScript/TypeScript SDK — schema, backend connector, queries, transactions, sync status, raw tables, Drizzle/Kysely ORM, and debugging
+metadata:
+  tags: javascript, typescript, web, sqlite, offline-first, drizzle, kysely
+---
+
+# PowerSync JavaScript/TypeScript SDK
+
+Core patterns and guidance shared across all PowerSync JavaScript/TypeScript targets. Use this reference for any JS/TS project — it covers schema design, the backend connector, database initialization, transactions, imperative queries, sync status, raw tables, and debugging. Always load this file as the foundation, then load the applicable framework-specific file alongside it.
+
+| Resource | Description |
+|----------|-------------|
+| [JS/TS Reference](https://docs.powersync.com/client-sdks/reference/javascript-web.md) | Full SDK documentation for Web, consult for details beyond the inline examples. |
+| [Web SDK API Reference](https://powersync-ja.github.io/powersync-js/web-sdk) | Full API reference for `@powersync/web`, consult only when the inline examples don't cover your case. |
+| [React Native Reference](https://docs.powersync.com/client-sdks/reference/react-native.md) | Full SDK documentation for React Native, consult for details beyond the inline examples. |
+| [React Native SDK API Reference](https://powersync-ja.github.io/powersync-js/react-native-sdk) | Full API reference for `@powersync/react-native`, consult only when the inline examples don't cover your case. |
+| [Capacitor Reference](https://docs.powersync.com/client-sdks/reference/capacitor.md) | Full SDK documentation for Capacitor, consult for details beyond the inline examples. |
+| [Capacitor SDK API Reference](https://powersync-ja.github.io/powersync-js/capacitor-sdk) | Full API reference for `@powersync/capacitor`, consult only when the inline examples don't cover your case. |
+| [Node.js Reference](https://docs.powersync.com/client-sdks/reference/node.md) | Full SDK documentation for Node.js, consult for details beyond the inline examples. |
+| [Node.js SDK API Reference](https://powersync-ja.github.io/powersync-js/node-sdk) | Full API reference for `@powersync/node`, consult only when the inline examples don't cover your case. |
+| [Supported Platforms - JS SDK](https://docs.powersync.com/resources/supported-platform.md#javascript-web-sdk) | Supported platforms and features, consult for compatibility details. |
+
+Framework-specific files (load alongside this file):
+
+| File | Use when... |
+|------|-------------|
+| `references/sdks/powersync-js-react.md` | React web app or Next.js |
+| `references/sdks/powersync-js-react-native.md` | React Native, Expo, or Expo Go |
+| `references/sdks/powersync-js-vue.md` | Vue or Nuxt |
+| `references/sdks/powersync-js-node.md` | Node.js CLI/server or Electron |
+| `references/sdks/powersync-js-tanstack.md` | TanStack Query or TanStack DB (any framework) |
+
+## Package Coverage
+
+| Need | Package |
+|------|---------|
+| Web browser | `@powersync/web` |
+| React Native | `@powersync/react-native` |
+| Node.js/CLI | `@powersync/node` |
+| Capacitor | `@powersync/capacitor` |
+| React hooks | `@powersync/react` |
+| Vue composables | `@powersync/vue` |
+| Nuxt module | `@powersync/nuxt` |
+| TanStack Query (React) | `@powersync/tanstack-react-query` |
+| TanStack DB (multi-framework) | `@tanstack/powersync-db-collection` |
+| ORM | `@powersync/drizzle-driver` or `@powersync/kysely-driver` |
+
+## Quick Setup
+
+### 1. Install
+
+```bash
+# Web
+npm install @powersync/web
+npm install @journeyapps/wa-sqlite # Needed (peer-dependency)
+
+# React Native
+npm install @powersync/react-native
+npm install @powersync/powersync-op-sqlite  # Needed (peer-dependency)
+
+# Node.js
+npm install @powersync/node
+npm install better-sqlite3 # Needed (peer-dependency)
+
+# React integration
+npm install @powersync/react
+
+# Vue
+npm install @powersync/vue
+
+# Nuxt (includes @powersync/vue — npm v7+ installs peers automatically)
+npm install @powersync/nuxt
+
+# TanStack Query (React)
+npm install @powersync/tanstack-react-query
+
+# TanStack DB
+npm install @tanstack/powersync-db-collection
+```
+
+Always install packages by running these commands rather than writing versions into `package.json` manually. Using `"latest"` as a version string in `package.json` is incorrect — it bypasses the lockfile and can pull in breaking changes at any install.
+
+See the framework-specific files for full setup instructions per target.
+
+### 2. Define Schema
+
+```ts
+import { column, Schema, Table } from '@powersync/web'; // or @powersync/react-native / @powersync/common
+
+const todos = new Table(
+  {
+    // Do NOT define 'id' — PowerSync creates it automatically as TEXT PRIMARY KEY
+    list_id: column.text,
+    created_at: column.text,   // Store dates as ISO strings — no date type
+    description: column.text,
+    completed: column.integer, // Store booleans as 0/1 — no boolean type
+  },
+  {
+    indexes: { list: ['list_id'] }, // Optional SQLite index
+  }
+);
+
+export const AppSchema = new Schema({ todos, lists });
+export type Database = (typeof AppSchema)['types'];
+export type Todo = Database['todos']; // Auto-generated row type
+```
+
+Column types: only `column.text`, `column.integer`, `column.real`. No boolean, no date, no JSON native type — store those as text/integer.
+
+No migrations — schema changes apply automatically on next open. Removed columns become inaccessible (data still in DB). New columns start null. Renaming = adding new + removing old (data loss). See [Define the Client-Side Schema](https://docs.powersync.com/client-sdks/reference/javascript-web.md#1-define-the-client-side-schema) for more information.
+
+### Special Table Types
+
+See [Local-Only Tables](https://docs.powersync.com/usage/use-case-examples/local-only-tables.md) and [Insert-Only Tables](https://docs.powersync.com/usage/use-case-examples/insert-only-tables.md) for more information.
+
+```ts
+// Local-only — not synced from server, not uploaded, persists across restarts
+const drafts = new Table({ title: column.text }, { localOnly: true });
+
+// Insert-only — writes are uploaded but server never sends deletes
+const logs = new Table({ message: column.text }, { insertOnly: true });
+
+// Track previous values — available as op.previousValues in uploadData
+const todos = new Table(
+  { description: column.text, completed: column.integer },
+  {
+    trackPreviousValues: true,
+    // or: trackPreviousValues: { columns: ['completed'] }
+    // or: trackPreviousValues: { columns: ['completed'], onlyWhenChanged: true }
+  }
+);
+
+// Track metadata attached to individual writes
+const tasks = new Table(
+  { title: column.text },
+  { trackMetadata: true }  // Adds _metadata column, available as op.metadata in uploadData
+);
+```
+
+### 3. Create Backend Connector
+
+See [Integrate with your Backend](https://docs.powersync.com/client-sdks/reference/javascript-web.md#3-integrate-with-your-backend) and [Client-Side Integration](https://docs.powersync.com/configuration/app-backend/client-side-integration.md) for more information.
+
+**IMPORTANT:** `PowerSyncBackendConnector`, `PowerSyncCredentials`, and `AbstractPowerSyncDatabase` are **type-only exports**. Always use `import type` for these — importing them as values (without `type`) causes runtime errors in bundlers like Vite. Only `UpdateType` is a runtime value (enum) and uses a regular import.
+
+```ts
+import type { PowerSyncBackendConnector, PowerSyncCredentials } from '@powersync/web'
+async fetchCredentials(): Promise<PowerSyncCredentials> {
+  return {
+    endpoint: 'https://your-instance.powersync.journeyapps.com',
+    token: await getJwtFromAuthService(),
+    expiresAt: new Date(Date.now() + 3600_000), // optional hint for refresh timing
+  };
+}
+```
+
+`fetchCredentials` is called automatically every few minutes when the sync stream reconnects. Must always return fresh credentials — do not return stale cached tokens.
+
+`PowerSyncCredentials` interface: `{ endpoint: string; token: string; expiresAt?: Date }`. See [Authentication Setup](https://docs.powersync.com/configuration/auth/overview.md) for configuring JWT authentication.
+
+### uploadData
+
+Called automatically whenever local writes are pending. Must be synchronous with the actual backend write — do not queue operations for async processing elsewhere. If it throws, PowerSync backs off and retries automatically. See [Writing Client-Side Changes to your Backend](https://docs.powersync.com/usage/writing-client-side-changes-to-your-backend.md) for more information.
+
+```ts
+import { UpdateType } from '@powersync/web'
+import type { AbstractPowerSyncDatabase, PowerSyncBackendConnector, PowerSyncCredentials } from '@powersync/web'
+
+async uploadData(database: AbstractPowerSyncDatabase): Promise<void> {
+  const transaction = await database.getNextCrudTransaction();
+  if (!transaction) return;
+
+  try {
+    for (const op of transaction.crud) {
+      switch (op.op) {
+        case UpdateType.PUT:
+          await api.create(op.table, { id: op.id, ...op.opData });
+          break;
+        case UpdateType.PATCH:
+          await api.update(op.table, op.id, op.opData);
+          break;
+        case UpdateType.DELETE:
+          await api.delete(op.table, op.id);
+          break;
+      }
+    }
+    // MUST call complete() to advance the queue to the next transaction
+    await transaction.complete();
+  } catch (ex) {
+    // Throw to retry later — PowerSync will back off and retry
+    throw ex;
+  }
+}
+```
+
+If `transaction.complete()` is never called, `getNextCrudTransaction()` returns the same transaction forever — the upload queue stalls permanently.
+
+Note: When uploading to backends with native boolean columns (e.g. PostgreSQL via Supabase or MongoDB), op.opData will contain 0/1. Convert before writing.
+
+#### HTTP Status Code Handling
+
+- Return 2xx from backend even for validation errors — a 4xx blocks the upload queue permanently
+- 5xx → PowerSync retries automatically with backoff
+- Surface validation errors by writing them to a local-only table and showing in the UI — never let them block the queue
+
+#### getCrudBatch vs getNextCrudTransaction
+
+Two ways to consume the upload queue:
+
+```ts
+// getNextCrudTransaction — exactly one transaction's worth, all entries share transactionId
+const tx = await db.getNextCrudTransaction();
+if (tx) {
+  for (const op of tx.crud) { /* op.transactionId is the same for all */ }
+  await tx.complete();
+}
+
+// getCrudBatch — up to N entries, may span multiple transactions
+const batch = await db.getCrudBatch(100);
+if (batch) {
+  for (const op of batch.crud) { /* may have different transactionIds */ }
+  await batch.complete();
+  // batch.haveMore === true means there are more entries waiting
+}
+```
+
+`getNextCrudTransaction` is used in most connector examples — simpler, guarantees atomicity per write transaction. `getCrudBatch` is useful when you want to batch across transaction boundaries for backend throughput.
+
+#### CrudEntry Fields
+
+```ts
+interface CrudEntry {
+  clientId: number;                     // Auto-incrementing local ID
+  id: string;                           // Row ID
+  op: UpdateType;                       // PUT | PATCH | DELETE
+  opData?: Record<string, any>;         // Changed columns — undefined for DELETE
+  previousValues?: Record<string, any>; // Previous values — requires trackPreviousValues on table
+  table: string;                        // Table name
+  transactionId?: number;               // Groups ops from the same writeTransaction()
+  metadata?: string;                    // Custom metadata — requires trackMetadata on table
+}
+```
+
+Op types (`UpdateType` enum):
+- `PUT` — full insert or replace (new row, or complete overwrite)
+- `PATCH` — partial update (`opData` contains only the changed columns)
+- `DELETE` — deletion (`opData` is undefined)
+
+`previousValues` is populated for PATCH and DELETE ops when the table has `trackPreviousValues: true`. Useful for implementing last-write-wins conflict resolution on the backend.
+
+### 4. Initialize Database and Connect
+
+See [Instantiate the PowerSync Database](https://docs.powersync.com/client-sdks/reference/javascript-web.md#2-instantiate-the-powersync-database) for more information.
+
+```ts
+// 1. Instantiate — schema applied at construction, no migrations
+const db = new PowerSyncDatabase({ schema, database: { dbFilename: 'app.db' } });
+
+// 2. Connect — starts sync stream and uploadData loop in background
+db.connect(connector);
+
+// 3. Optionally wait for first sync before rendering data
+await db.waitForFirstSync();
+```
+
+`connect()` does not block — sync happens in the background. Do NOT `await connect()` thinking data is ready after it returns.
+
+### 5. Provider / Plugin Setup
+
+Framework-specific setup (React `PowerSyncContext.Provider`, Vue plugin, Nuxt plugin) is covered in the framework files. See `references/sdks/powersync-js-react.md`, `references/sdks/powersync-js-vue.md`, etc.
+
+### Web-Specific Options
+
+```ts
+const db = new PowerSyncDatabase({
+  schema,
+  database: {
+    dbFilename: 'app.db',
+    debugMode: true        // Logs all SQL to Chrome DevTools Performance timeline
+  },
+  flags: {
+    useWebWorker: true,    // Default true — runs DB in a web worker
+    enableMultiTabs: true  // Default true — shares sync worker across tabs
+  }
+});
+```
+
+Multi-tab behavior: By default the web SDK uses a shared sync worker so all tabs share sync state. Only the most recently opened tab runs `fetchCredentials` and `uploadData`. Disable with `enableMultiTabs: false` if causing issues — but then only the oldest tab syncs.
+
+#### VFS Options
+
+| VFS Option                | Description         | Reference URL                                                                                           |
+|---------------------------|---------------------|---------------------------------------------------------------------------------------------------------|
+| IDBBatchAtomicVFS         | Default             | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#1-idbbatchatomicvfs-default)     |
+| OPFSCoopSyncVFS           | Recommended         | [Link](https://docs.powersync.com/client-sdks/reference/javascript-web.md#2-opfs-based-alternatives)       |
+
+```ts
+// Recommended — more reliable across browsers including Safari
+import { WASQLiteOpenFactory, WASQLiteVFS } from '@powersync/web'
+
+const db = new PowerSyncDatabase({
+  schema,
+  database: new WASQLiteOpenFactory({
+    dbFilename: 'app.db',
+    vfs: WASQLiteVFS.OPFSCoopSyncVFS, // default: IDBBatchAtomicVFS
+  }),
+})
+```
+
+Safari: Requires `OPFSCoopSyncVFS` for stable multi-tab, or set `useWebWorker: false`. See [Web SDK Reference](https://docs.powersync.com/client-sdks/reference/javascript-web.md) for full configuration options.
+
+## Query Patterns
+
+See [Using PowerSync: CRUD functions](https://docs.powersync.com/client-sdks/reference/javascript-web.md#using-powersync-crud-functions) for the full API reference.
+
+### useQuery
+
+```ts
+useQuery<RowType>(
+  query: string | CompilableQuery<RowType>,
+  parameters?: any[],
+  options?: {
+    rowComparator?: { keyBy, compareBy },
+    reportFetching?: boolean,
+    throttleMs?: number,
+    runQueryOnce?: boolean,
+    streams?: QuerySyncStreamOptions[],
+  }
+): { data, isLoading, isFetching, error }
+```
+
+Parameters are compared by `JSON.stringify` value, not by reference — so `[userId]` across renders are considered equal even as different array instances.
+
+Pitfall: Avoid passing objects that serialize differently between renders (e.g. objects with changing key order).
+
+#### rowComparator — Differential Mode
+
+Without `rowComparator`: every change to any watched table re-runs the query and returns a new array reference — all children re-render regardless of whether their row changed.
+
+With `rowComparator`: uses differential watch internally. Only rows that actually changed get new object references. Unchanged rows keep the same object reference, so `React.memo` can skip re-rendering them.
+
+```tsx
+const { data: lists } = useQuery('SELECT * FROM lists', [], {
+  rowComparator: {
+    keyBy: (row) => row.id,
+    compareBy: (row) => JSON.stringify(row)
+  }
+});
+
+const ListItem = React.memo(({ list }) => <Text>{list.name}</Text>);
+// Only re-renders when list.name or other fields actually change
+```
+
+#### runQueryOnce
+
+Runs the query once after sync completes — no live watch. Useful for aggregations or reports.
+
+```ts
+const { data } = useQuery('SELECT COUNT(*) as total FROM lists', [], { runQueryOnce: true });
+```
+
+#### streams option
+
+Gates the query on specific named sync streams having synced before executing.
+
+```ts
+const { data } = useQuery('SELECT * FROM lists', [], {
+  streams: [{ name: 'lists', parameters: { userId }, waitForStream: true }]
+});
+// Returns isLoading: true until the 'lists' stream has synced
+```
+
+### Compiling Queries (CompilableQuery)
+
+Both hooks accept a `CompilableQuery` object in addition to a plain SQL string. This is useful when using [Drizzle](https://docs.powersync.com/client-sdks/orms/javascript-web/drizzle.md) or [Kysely](https://docs.powersync.com/client-sdks/orms/javascript-web/kysely.md) integrations:
+
+```ts
+// With Drizzle
+const query = db.select().from(lists).where(eq(lists.ownerId, userId));
+const { data } = useQuery(query);
+
+// With Kysely
+const query = db.selectFrom('lists').selectAll().where('owner_id', '=', userId);
+const { data } = useQuery(query);
+```
+
+### One-Time Queries (Imperative)
+
+```ts
+// Get all
+const todos = await db.getAll('SELECT * FROM todos WHERE list_id = ?', [listId]);
+
+// Get one (throws if not found)
+const todo = await db.get('SELECT * FROM todos WHERE id = ?', [id]);
+
+// Get optional (returns null if not found)
+const todo = await db.getOptional('SELECT * FROM todos WHERE id = ?', [id]);
+```
+
+### Watch Queries (Imperative)
+
+Outside of React, use the async generator API directly:
+
+```ts
+for await (const result of db.watchWithAsyncGenerator('SELECT * FROM lists')) {
+  console.log(result.rows._array);
+}
+
+// Or with a differential watch (only emits on actual changes)
+const watchedQuery = db.customQuery({
+  compile: () => ({ sql: 'SELECT * FROM lists', parameters: [] }),
+  execute: () => db.getAll('SELECT * FROM lists')
+}).watch({ reportFetching: true });
+
+const dispose = watchedQuery.registerListener({
+  onData: (data) => console.log(data),
+  onError: (err) => console.error(err)
+});
+
+// Later:
+dispose();
+```
+
+## Writes & Transactions
+
+### Single Operation
+
+```ts
+await db.execute(
+  'INSERT INTO lists (id, created_at, name, owner_id) VALUES (uuid(), datetime(), ?, ?)',
+  ['My List', userId]
+);
+```
+
+### writeTransaction — Multiple Related Operations
+
+Use when multiple operations must be atomic. Auto-commits on success, auto-rollbacks if an exception is thrown.
+
+```ts
+await db.writeTransaction(async (tx) => {
+  await tx.execute('DELETE FROM lists WHERE id = ?', [listId]);
+  await tx.execute('DELETE FROM todos WHERE list_id = ?', [listId]);
+  // No need to call commit() — it's automatic
+});
+```
+
+When to use `writeTransaction`:
+- Multiple operations that must succeed or fail together
+- Cascading deletes, multi-table updates
+- Any situation where partial completion would leave data inconsistent
+
+When NOT to use:
+- Single operations — `db.execute()` is simpler and faster
+- Read-only queries — use `readTransaction` or `getAll`/`get`
+
+### readTransaction
+
+```ts
+const result = await db.readTransaction(async (tx) => {
+  const lists = await tx.getAll('SELECT * FROM lists');
+  const count = await tx.get('SELECT COUNT(*) as n FROM todos');
+  return { lists, count };
+});
+```
+
+### ID Generation
+
+PowerSync auto-creates an `id TEXT` column on every table — do not declare it in the schema. Generate UUIDs client-side:
+
+```ts
+// SQLite uuid() function is available
+await db.execute('INSERT INTO todos (id, description) VALUES (uuid(), ?)', ['Buy milk']);
+
+// Or generate in JS
+import { v4 as uuidv4 } from 'uuid';
+await db.execute('INSERT INTO todos (id, description) VALUES (?, ?)', [uuidv4(), 'Buy milk']);
+```
+
+### Lock Behavior
+
+- Only ONE write transaction executes at a time (global write mutex)
+- Default lock timeout: 120 seconds — increase only if operations genuinely take longer
+- `writeTransaction()` takes the lock for the entire callback duration
+- Multiple rapid writes are more efficient when batched inside a single `writeTransaction`
+
+## Sync Status, Priorities & Sync Streams
+
+### useStatus Hook
+
+```ts
+const status = useStatus();
+// {
+//   connected: boolean,
+//   connecting: boolean,
+//   lastSyncedAt: Date | null,
+//   hasSynced: boolean,          // true after first full sync, persists across restarts
+//   isSyncing: boolean,
+//   downloadProgress: DownloadProgress | null,
+//   dataFlowStatus: {
+//     uploading: boolean,
+//     downloading: boolean,
+//     uploadError: Error | undefined,    // set on upload failure, cleared on next success
+//     downloadError: Error | undefined,  // set on download/connect failure, cleared on next success
+//     downloadProgress: ...
+//   }
+// }
+```
+
+#### uploadError and downloadError
+
+`status.dataFlowStatus.uploadError` and `status.dataFlowStatus.downloadError` are the primary way to surface sync failures to users or logging systems.
+
+- `uploadError` — set when an exception occurs during the CRUD upload loop. Cleared automatically on the next successful upload.
+- `downloadError` — set when an exception occurs during the streaming sync (including connection failures). Cleared on the next successful data download or checkpoint completion.
+
+```tsx
+const status = useStatus();
+
+if (status.dataFlowStatus?.uploadError) {
+  return <Banner>Failed to save changes: {status.dataFlowStatus.uploadError.message}</Banner>;
+}
+if (status.dataFlowStatus?.downloadError) {
+  return <Banner>Sync error: {status.dataFlowStatus.downloadError.message}</Banner>;
+}
+```
+
+Register a status listener imperatively (useful for logging, not just UI):
+
+```ts
+db.registerListener({
+  statusChanged: (status) => {
+    if (status.dataFlowStatus?.downloadError) {
+      logger.error('PowerSync download failed', {
+        error: status.dataFlowStatus.downloadError,
+        lastSyncedAt: status.lastSyncedAt,
+        connected: status.connected,
+      });
+    }
+    if (status.dataFlowStatus?.uploadError) {
+      logger.error('PowerSync upload failed', {
+        error: status.dataFlowStatus.uploadError,
+        lastSyncedAt: status.lastSyncedAt,
+        connected: status.connected,
+      });
+    }
+  }
+});
+```
+
+### waitForFirstSync
+
+`db.waitForFirstSync()` resolves when all data has been downloaded at least once. After that, `db.currentStatus.hasSynced` is `true` and persists across app restarts (stored in the local DB).
+
+```ts
+// Standard usage — gate app rendering behind first sync
+db.connect(connector);
+await db.waitForFirstSync();
+// Now safe to render data-dependent screens
+
+// With abort signal (e.g. timeout after 10s)
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 10_000);
+await db.waitForFirstSync(controller.signal);
+```
+
+### Sync Priorities
+
+Streams (or buckets in legacy Sync Rules) can be assigned priorities (0-3). Lower numbers = higher priority. Higher-priority data syncs first, allowing partial data to appear before the full sync completes. See [Prioritized Sync](https://docs.powersync.com/usage/use-case-examples/prioritized-sync.md) for more information.
+
+Priority 0 is special: it syncs regardless of pending uploads — use carefully as it can cause temporary inconsistencies.
+
+Consistency caveat: Full PowerSync consistency guarantees (including deletes) only apply once ALL buckets at all priorities have synced. Higher-priority partial syncs may have stale deletes until lower-priority buckets complete.
+
+#### waitForFirstSync with Priority
+
+```ts
+// Wait only for priority-1 buckets (faster — show UI sooner)
+await db.waitForFirstSync({ priority: 1 });
+
+// With abort signal + priority
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 10_000);
+await db.waitForFirstSync({ signal: controller.signal, priority: 1 });
+```
+
+#### Download Progress UI
+
+```tsx
+const status = useStatus();
+const progress = status.downloadProgress;
+
+// Overall progress
+if (progress) {
+  return <ProgressBar value={progress.downloadedFraction} />;
+  // progress.downloadedOperations / progress.totalOperations also available
+}
+
+// Progress up to a specific priority only
+const priorityProgress = progress?.untilPriority(1);
+if (priorityProgress) {
+  return <ProgressBar value={priorityProgress.downloadedFraction} />;
+}
+```
+
+#### Per-Priority Status
+
+```ts
+// Check if a specific priority has synced
+const p1Status = db.currentStatus.statusForPriority(1);
+// p1Status.hasSynced, p1Status.lastSyncedAt
+
+// List all priority statuses seen
+const entries = db.currentStatus.priorityStatusEntries();
+// [{ priority: 1, hasSynced: true, lastSyncedAt: Date }, ...]
+```
+
+### Sync Streams
+
+Sync Streams are the recommended way to define what data syncs to each client. They provide on-demand subscriptions with parameters and TTL-based expiry. See [sync-config.md](references/sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs).
+
+Requires the service to be configured with Sync Streams (edition 3 config). See [Sync Streams Overview](https://docs.powersync.com/sync/streams/overview.md) and [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md) for more information.
+
+The `streams` option in `useQuery` (see below) and the imperative API work across all JS/TS frameworks. Framework-specific Sync Stream hooks are covered in the respective framework files where available — for example, `useSyncStream` and `useSuspenseSyncStream` in `references/sdks/powersync-js-react.md`.
+
+#### Streams in useQuery
+
+Gate a query on a specific stream having synced, without managing the subscription manually:
+
+```ts
+const { data: lists } = useQuery('SELECT * FROM lists', [], {
+  streams: [
+    {
+      name: 'lists',
+      parameters: { userId },
+      waitForStream: true,  // hold isLoading: true until this stream syncs
+      priority: 1,
+      ttl: 3600,
+    }
+  ]
+});
+```
+
+#### Imperative API
+
+```ts
+// Subscribe directly
+const subscription = await db.syncStream('lists', { userId }).subscribe({
+  priority: 1,
+  ttl: 3600
+});
+
+// Wait for this specific stream to sync
+await subscription.waitForFirstSync();
+
+// Check status
+const streamStatus = db.currentStatus.forStream(subscription);
+console.log(streamStatus.subscription.hasSynced);
+
+// Unsubscribe when done
+subscription.unsubscribe();
+```
+
+#### Stream Gotchas
+
+- Parameters as identity: same stream name with different parameters = separate subscriptions
+- Partial checkpoints: only the Rust sync client supports partial checkpoints (priority-level consistency)
+- Default streams: server may configure streams as default — these subscribe automatically without a client call
+- TTL eviction: after TTL expires with no active subscriber, the stream's data may be removed from the local DB
+
+## Raw Tables
+
+Raw tables let PowerSync sync data directly into native SQLite tables you define, instead of storing data as JSON in `ps_data__<table>` and exposing it via views. This gives full SQLite control and better query performance. See [Raw Tables](https://docs.powersync.com/usage/use-case-examples/raw-tables.md) for more information.
+
+Requires: The Rust sync client (now the default). Will not work with the legacy JavaScript client.
+
+Status: Experimental — not covered by semver stability guarantees.
+
+### When to Use Raw Tables
+
+- Complex queries that benefit from native column types (e.g. `SUM`, `GROUP BY` on typed columns)
+- Tables with many rows where JSON extraction overhead is significant
+- Need for SQLite constraints (foreign keys, `NOT NULL`, `GENERATED` columns)
+- Custom indexes on expressions or generated columns
+
+### Defining a Raw Table
+
+```ts
+import { Schema, RawTable } from '@powersync/common';
+
+const schema = new Schema({
+  // Regular PowerSync-managed tables here
+});
+
+schema.withRawTables({
+  // The key name ('todo_lists') matches the table name in the backend database
+  // as sent by the PowerSync service — NOT necessarily the local SQLite table name
+  todo_lists: {
+    put: {
+      sql: 'INSERT OR REPLACE INTO todo_lists (id, created_by, title, content) VALUES (?, ?, ?, ?)',
+      params: ['Id', { Column: 'created_by' }, { Column: 'title' }, { Column: 'content' }]
+    },
+    delete: {
+      sql: 'DELETE FROM todo_lists WHERE id = ?',
+      params: ['Id']
+    }
+  }
+});
+```
+
+Parameter types:
+- `'Id'` — replaced with the object ID from the sync service
+- `{ Column: 'fieldName' }` — replaced with the value of that column from the synced row data
+- For `delete` statements, only `'Id'` is supported
+
+You must also create the actual SQLite table separately (e.g. in app init):
+
+```ts
+await db.execute(`
+  CREATE TABLE IF NOT EXISTS todo_lists (
+    id TEXT NOT NULL PRIMARY KEY,
+    created_by TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT
+  ) STRICT
+`);
+```
+
+### Triggers for Local Writes
+
+Raw tables require manual triggers to capture local writes into PowerSync's upload queue (`powersync_crud` virtual table):
+
+```sql
+CREATE TRIGGER todo_lists_insert
+  AFTER INSERT ON todo_lists FOR EACH ROW
+  BEGIN
+    INSERT INTO powersync_crud (op, id, type, data)
+    VALUES ('PUT', NEW.id, 'todo_lists', json_object(
+      'created_by', NEW.created_by,
+      'title', NEW.title,
+      'content', NEW.content
+    ));
+  END;
+
+CREATE TRIGGER todo_lists_update
+  AFTER UPDATE ON todo_lists FOR EACH ROW
+  BEGIN
+    SELECT CASE
+      WHEN (OLD.id != NEW.id) THEN RAISE(FAIL, 'Cannot update id')
+    END;
+    INSERT INTO powersync_crud (op, id, type, data)
+    VALUES ('PATCH', NEW.id, 'todo_lists', json_object(
+      'created_by', NEW.created_by,
+      'title', NEW.title,
+      'content', NEW.content
+    ));
+  END;
+
+CREATE TRIGGER todo_lists_delete
+  AFTER DELETE ON todo_lists FOR EACH ROW
+  BEGIN
+    INSERT INTO powersync_crud (op, id, type)
+    VALUES ('DELETE', OLD.id, 'todo_lists');
+  END;
+```
+
+The `powersync_crud` virtual table fields:
+- `op` — `'PUT'`, `'PATCH'`, or `'DELETE'`
+- `id` — row ID
+- `type` — table name (as the backend knows it)
+- `data` — JSON object of column values (omit for DELETE)
+- `old_values` — optional previous values for conflict resolution
+- `metadata` — optional metadata string
+
+### Migrating from ps_untyped
+
+If PowerSync has already synced data for a table before you added it as a raw table, it's stored in `ps_untyped`. After creating the raw table and defining it in the schema, run:
+
+```sql
+INSERT INTO my_table (id, col1, col2)
+  SELECT id, data ->> 'col1', data ->> 'col2'
+  FROM ps_untyped WHERE type = 'my_table';
+DELETE FROM ps_untyped WHERE type = 'my_table';
+```
+
+Not needed if the raw table definition was present from the very first `connect()` call.
+
+### Raw Table Caveats
+
+- Rust client only — the JavaScript sync client logs a warning and ignores raw tables
+- No automatic column migration — adding columns requires deleting all data and resyncing, or a manual workaround
+- Foreign keys — must use `DEFERRABLE INITIALLY DEFERRED`; enable with `PRAGMA foreign_keys = ON`; avoid FK references from high-priority to lower-priority raw tables (priorities sync in separate transactions)
+- `disconnectAndClear()` won't clear raw tables by default — add a `clear` statement to `RawTable` if needed
+- The `name` property matches the backend table name, not the local SQLite table name — `put`/`delete` can target any local table
+
+## Drizzle ORM Integration
+
+See [Drizzle ORM Setup](https://docs.powersync.com/client-sdks/orms/javascript-web/drizzle.md) for full setup instructions.
+
+```ts
+import { drizzle } from '@powersync/drizzle-driver';
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { eq } from 'drizzle-orm';
+
+// Define Drizzle schema
+export const todos = sqliteTable('todos', {
+  id: text('id').primaryKey(),
+  description: text('description').notNull(),
+  completed: integer('completed').notNull().default(0),
+  listId: text('list_id')
+});
+
+// Create Drizzle instance
+const drizzleDb = drizzle(db);
+
+// Type-safe queries
+const activeTodos = await drizzleDb
+  .select()
+  .from(todos)
+  .where(eq(todos.completed, 0));
+```
+
+## Debugging
+
+See [Debugging Overview](https://docs.powersync.com/debugging/tools-and-techniques.md) for the full list of tools and techniques.
+
+### Diagnostics App
+
+https://diagnostics-app.powersync.com
+
+Connect this to a running PowerSync instance to inspect tables, rows, sync buckets, and run arbitrary SQL against the local database. This is the fastest way to isolate whether a problem is in the PowerSync service or in the client:
+
+- If the diagnostics app shows the correct data → the service is syncing correctly → the issue is in your client code (query, schema, rendering)
+- If the diagnostics app shows incorrect or missing data → the issue is in the PowerSync service configuration (sync rules, backend connector, permissions)
+
+### Enable SDK Logging (Development)
+
+```ts
+import { createBaseLogger, LogLevel } from '@powersync/react'; // or @powersync/common
+
+const logger = createBaseLogger();
+logger.useDefaults(); // output to console
+logger.setLevel(LogLevel.DEBUG); // DEBUG | INFO | WARN | ERROR | TRACE | OFF
+```
+
+### Production Logging
+
+Enable PowerSync logging in production — it is extremely helpful for debugging sync issues reported by users. Use whatever logging provider your app already uses (Sentry, Datadog, Firebase Crashlytics, etc.).
+
+The key pattern is: use `WARN` level in production (captures errors and warnings without noise), and pipe warnings/errors to your log aggregation service. Capture all levels as breadcrumbs so you have context leading up to an error.
+
+Example using Sentry (substitute your own provider):
+
+```ts
+import { createBaseLogger, LogLevel } from '@powersync/react-native';
+
+const logger = createBaseLogger();
+logger.useDefaults();
+logger.setLevel(LogLevel.WARN); // WARN and above in production
+
+logger.setHandler((messages, context) => {
+  if (!context?.level) return;
+
+  const messageArray = Array.from(messages);
+  const mainMessage = String(messageArray[0] || '');
+  const extra = messageArray.slice(1).reduce((acc, curr) => ({ ...acc, ...curr }), {});
+  const level = context.level.name.toLowerCase();
+
+  // Capture everything as breadcrumbs for pre-error context
+  Sentry.addBreadcrumb({
+    message: mainMessage,
+    level: level as Sentry.SeverityLevel,
+    data: extra,
+    timestamp: Date.now()
+  });
+
+  // Only send warn/error to the logging service
+  if (level === 'warn' || level === 'error') {
+    Sentry.logger[level](mainMessage, extra);
+  }
+});
+```
+
+Also register a status listener to capture `uploadError` and `downloadError` — these won't appear in the SDK logger automatically:
+
+```ts
+db.registerListener({
+  statusChanged: (status) => {
+    if (status.dataFlowStatus?.downloadError) {
+      logger.error('PowerSync download error', {
+        error: status.dataFlowStatus.downloadError,
+        lastSyncedAt: status.lastSyncedAt,
+        connected: status.connected,
+        sdkVersion: db.sdkVersion,
+      });
+    }
+    if (status.dataFlowStatus?.uploadError) {
+      logger.error('PowerSync upload error', {
+        error: status.dataFlowStatus.uploadError,
+        lastSyncedAt: status.lastSyncedAt,
+        connected: status.connected,
+        sdkVersion: db.sdkVersion,
+      });
+    }
+  }
+});
+```
+
+Context to include in logs: user/session ID, SDK version (`db.sdkVersion`), `lastSyncedAt`, `connected` status. Avoid logging sensitive row data.
+
+### Web: SQL Logging to Chrome Performance Timeline
+
+```ts
+const db = new PowerSyncDatabase({
+  schema,
+  database: { dbFilename: 'app.db', debugMode: true }
+});
+// All SQL appears in Chrome DevTools → Performance tab timeline
+```
+
+### Check Sync Status Imperatively
+
+```ts
+console.log(db.currentStatus);
+// { connected, connecting, lastSyncedAt, hasSynced, isSyncing, downloadProgress }
+```
+
+## Internals
+
+> Load this section only when debugging QueryStore eviction behaviour, investigating sync client implementation differences, or working with internal op types. Not needed for typical integration, setup, or feature work.
+
+### Sync Client Implementations
+
+The Rust-based sync client is now the default:
+
+```ts
+// Default — Rust client (no config needed)
+const db = new PowerSyncDatabase({ schema, database: { dbFilename: 'app.db' } });
+
+// Explicit (not needed unless reverting to legacy)
+import { SyncClientImplementation } from '@powersync/common';
+const db = new PowerSyncDatabase({
+  schema,
+  database: { dbFilename: 'app.db' },
+  sync: { implementation: SyncClientImplementation.RUST } // now default
+});
+```
+
+The Rust client:
+- More performant — offloads sync line decoding to native extension
+- Required for raw tables and partial checkpoints by priority
+- Stores sync data in a slightly different format than the old JS client
+- Auto-migrates from JS format on first use
+
+Do not downgrade the SDK after using the Rust client — older SDK versions using the JS client can't read the Rust format.
+
+The legacy JS client (`SyncClientImplementation.JAVASCRIPT`) is deprecated and will be removed in a future version.
+
+### QueryStore
+
+`useSuspenseQuery` uses a `QueryStore` (one per `PowerSyncDatabase` instance, stored in a `WeakMap`). The store caches `WatchedQuery` instances keyed by:
+
+```
+"${sql} -- ${JSON.stringify(params)} -- ${JSON.stringify(options)}"
+```
+
+A query is evicted (closed) when the count of `ON_DATA + ON_STATE_CHANGE + ON_ERROR` listeners reaches 0.
+
+Implication: `useSuspenseQuery` and `useQuery` with the same SQL/params/options share the same underlying `WatchedQuery`. If one component unmounts but another with the same query is still mounted, the query stays alive and is not re-fetched.
+
+### Op Types (Internal Sync vs CRUD)
+
+Internal bucket ops (`OpTypeEnum`) — used inside sync protocol, not exposed to userland:
+- `CLEAR=1`, `MOVE=2`, `PUT=3`, `REMOVE=4`
+
+CRUD upload ops (`UpdateType`) — what you see in `uploadData`:
+- `PUT`, `PATCH`, `DELETE`
+
+These are separate enumerations. Don't confuse the sync-level `REMOVE` with the CRUD-level `DELETE`.
+
+## Common Pitfalls
+
+See also [Error Codes Reference](https://docs.powersync.com/debugging/error-codes.md#error-codes-reference) for PowerSync service error codes.
+
+### 1. All children re-render on every table change
+
+Without `rowComparator`, every write to a watched table returns a new array — all children re-render even if their row didn't change.
+
+```ts
+// BAD — all ListItem components re-render on any lists write
+const { data: lists } = useQuery('SELECT * FROM lists');
+return lists.map(l => <ListItem list={l} />);
+
+// GOOD — only changed rows get new references, React.memo skips the rest
+const { data: lists } = useQuery('SELECT * FROM lists', [], {
+  rowComparator: { keyBy: r => r.id, compareBy: r => JSON.stringify(r) }
+});
+const ListItem = React.memo(({ list }) => <Text>{list.name}</Text>);
+```
+
+### 2. Awaiting connect() thinking data is ready
+
+```ts
+// WRONG — connect() is fire-and-forget, data is NOT available after await
+await db.connect(connector);
+renderApp(); // may show empty data
+
+// CORRECT
+db.connect(connector);
+await db.waitForFirstSync(); // wait for data
+renderApp();
+```
+
+### 3. Schema ID column
+
+```ts
+// WRONG
+const todos = new Table({ id: column.text, description: column.text });
+
+// RIGHT — 'id' is auto-created by PowerSync
+const todos = new Table({ description: column.text });
+```
+
+### 4. uploadData queue stuck
+
+If `transaction.complete()` is never called, `getNextCrudTransaction()` returns the same transaction forever. The upload queue stalls permanently. Always call `complete()`, even on partial failure if you want to skip a bad transaction.
+
+### 5. Web: SQLite library conflicts
+
+If another SQLite package exists in the project (`sql.js`, `better-sqlite3`, etc.), it can conflict with PowerSync's SQLite engine. Remove all other SQLite libraries. Symptom: "Could not load extension" error.
+
+### 6. useQuery data seems stale / not updating
+
+- Verify the table name in SQL exactly matches the schema key (case-sensitive)
+- Writes must go through `db.execute()` or `writeTransaction()` — writes via raw SQLite connections bypass PowerSync's change tracking
+- Check `db.currentStatus.connected` — if false, sync isn't running

--- a/.claude/skills/powersync/references/sdks/powersync-kotlin.md
+++ b/.claude/skills/powersync/references/sdks/powersync-kotlin.md
@@ -1,0 +1,450 @@
+---
+name: powersync-kotlin
+description: PowerSync Kotlin SDK — schema, queries, sync lifecycle, and backend connectors
+metadata:
+  tags: kotlin, android, ios, sqlite, offline-first
+---
+
+# PowerSync Kotlin SDK
+
+Best practices for building apps with the PowerSync Kotlin SDK.
+
+Supported targets: Android, JVM, iOS, macOS, watchOS, tvOS.
+
+## Installation
+
+Add to `build.gradle.kts`:
+
+```kotlin
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api("com.powersync:core:$powersyncVersion")
+        }
+    }
+}
+```
+
+For Supabase connector:
+
+```kotlin
+commonMain.dependencies {
+    implementation("com.powersync:connector-supabase:$powersyncVersion")
+}
+```
+
+For iOS with Cocoapods (recommended over SPM for iOS targets):
+
+```kotlin
+cocoapods {
+    pod("powersync-sqlite-core") { linkOnly = true }
+    framework {
+        isStatic = true
+        export("com.powersync:core")
+    }
+}
+```
+
+## Quick Setup
+
+### 1. Define Schema
+
+```kotlin
+import com.powersync.db.schema.Column
+import com.powersync.db.schema.Index
+import com.powersync.db.schema.IndexedColumn
+import com.powersync.db.schema.Schema
+import com.powersync.db.schema.Table
+
+val todos = Table(
+    name = "todos",
+    columns = listOf(
+        Column.text("description"),
+        Column.text("list_id"),
+        Column.integer("completed"), // booleans as INTEGER (0/1)
+        Column.text("created_at"),   // dates as ISO TEXT
+    ),
+    indexes = listOf(Index("list_idx", listOf(IndexedColumn("list_id"))))
+)
+
+val lists = Table(
+    name = "lists",
+    columns = listOf(
+        Column.text("name"),
+        Column.text("owner_id"),
+        Column.text("created_at"),
+    )
+)
+
+val schema = Schema(todos, lists)
+```
+
+Column types: `Column.text`, `Column.integer`, `Column.real` only — no boolean, date, or JSON native types.
+
+Do NOT declare an `id` column — PowerSync adds it automatically as `TEXT PRIMARY KEY`. Declaring it throws an `AssertionError`.
+
+No migrations required. Schema changes apply on next open. New columns start null; removed columns become inaccessible (data remains). Renaming = add new + remove old (data loss).
+
+### Special Table Types
+
+```kotlin
+// Local-only — not synced, not uploaded, persists across restarts
+val drafts = Table.localOnly("drafts", listOf(Column.text("content")))
+
+// Insert-only — writes uploaded, server never sends data back
+val logs = Table.insertOnly("logs", listOf(Column.text("message")))
+
+// Track previous values — available as entry.previousValues in uploadData
+val todos = Table(
+    name = "todos",
+    columns = listOf(Column.text("description"), Column.integer("completed")),
+    trackPreviousValues = TrackPreviousValuesOptions(
+        columnFilter = listOf("completed"), // null = track all columns
+        onlyWhenChanged = true
+    )
+)
+
+// Track write metadata — adds _metadata column, available as entry.metadata in uploadData
+val tasks = Table(
+    name = "tasks",
+    columns = listOf(Column.text("title")),
+    trackMetadata = true
+)
+
+// Ignore no-op updates (UPDATE that changes no values)
+val items = Table(
+    name = "items",
+    columns = listOf(Column.text("name")),
+    ignoreEmptyUpdates = true
+)
+```
+
+### 2. Create Backend Connector
+
+```kotlin
+import com.powersync.connectors.PowerSyncBackendConnector
+import com.powersync.connectors.PowerSyncCredentials
+import com.powersync.PowerSyncDatabase
+import com.powersync.db.crud.UpdateType
+
+class MyConnector : PowerSyncBackendConnector() {
+    override suspend fun fetchCredentials(): PowerSyncCredentials {
+        // Always fetch fresh credentials — do not cache stale tokens
+        return PowerSyncCredentials(
+            endpoint = "https://your-instance.powersync.journeyapps.com",
+            token = myAuthService.getToken(),
+        )
+    }
+
+    override suspend fun uploadData(database: PowerSyncDatabase) {
+        val transaction = database.getNextCrudTransaction() ?: return
+        try {
+            for (entry in transaction.crud) {
+                when (entry.op) {
+                    UpdateType.PUT -> api.upsert(entry.table, entry.id, entry.opData)
+                    UpdateType.PATCH -> api.update(entry.table, entry.id, entry.opData)
+                    UpdateType.DELETE -> api.delete(entry.table, entry.id)
+                }
+            }
+            transaction.complete(null) // MUST call — otherwise the same transaction is returned forever
+        } catch (e: Exception) {
+            throw e // PowerSync backs off and retries automatically
+        }
+    }
+}
+```
+
+**Fatal upload errors**: If `uploadData` always throws for a bad record, the queue stalls permanently. Detect unrecoverable errors (e.g. constraint violations) and call `transaction.complete(null)` to discard them. The Supabase connector handles Postgres error classes 22, 23, and 42501 automatically.
+
+#### CrudEntry Fields
+
+```kotlin
+entry.id             // String — row ID
+entry.op             // UpdateType — PUT | PATCH | DELETE
+entry.opData         // SqliteRow? — changed columns (null for DELETE)
+entry.table          // String — table name
+entry.transactionId  // Int? — groups ops from the same writeTransaction()
+entry.previousValues // SqliteRow? — requires trackPreviousValues on table
+entry.metadata       // String? — requires trackMetadata on table
+```
+
+Op semantics: `PUT` = full insert/replace (all non-null columns), `PATCH` = partial update (changed columns only), `DELETE` = deletion (`opData` is null).
+
+For batching multiple transactions at once, use `database.getCrudBatch(limit)` or `database.getCrudTransactions()`. Both follow the same `complete()` contract.
+
+#### Supabase Connector
+
+```kotlin
+val connector = SupabaseConnector(
+    supabaseUrl = "https://your-project.supabase.co",
+    supabaseKey = "your-anon-key",
+    powerSyncEndpoint = "https://your-instance.powersync.journeyapps.com",
+)
+```
+
+`SupabaseConnector` is open — override `uploadCrudEntry` and `handleError` for custom behaviour.
+
+### 3. Initialize and Connect
+
+```kotlin
+val db = PowerSyncDatabase(
+    factory = factory,       // platform-specific PersistentConnectionFactory
+    schema = schema,
+    dbFilename = "app.db",
+    scope = coroutineScope,
+)
+
+// Starts sync stream and uploadData loop in the background (non-blocking)
+db.connect(connector)
+
+// Pass sync parameters to the server if needed
+db.connect(
+    connector = connector,
+    params = mapOf("userId" to JsonParam.String("abc123")),
+)
+
+// Wait for first sync before showing data-dependent UI
+db.waitForFirstSync()
+```
+
+Use a **single `PowerSyncDatabase` instance** per database file. Multiple instances for the same file cause lock contention and missed watch updates — share via dependency injection.
+
+#### Disconnect and Clear
+
+```kotlin
+db.disconnect()                               // stop syncing, keep local data
+db.disconnectAndClear()                       // stop syncing, wipe synced tables (e.g. on sign-out)
+db.disconnectAndClear(clearLocal = false, soft = true) // soft-wipe: same user can re-sync faster
+db.close()                                    // cannot be reused after this
+```
+
+`disconnect()` — temporary offline, token refresh, app backgrounding. Safe to reconnect as the same user. `disconnectAndClear()` — user sign-out or account switch, prevents stale data leaking to the next user. `close()` — app termination, instance cannot be reused after this call.
+
+## Query Patterns
+
+### Watch Queries (Reactive)
+
+```kotlin
+import com.powersync.db.getString
+import com.powersync.db.getStringOptional
+import com.powersync.db.getBoolean
+
+fun watchTodos(listId: String): Flow<List<TodoItem>> =
+    db.watch(
+        sql = "SELECT * FROM todos WHERE list_id = ? ORDER BY id",
+        parameters = listOf(listId),
+    ) { cursor ->
+        TodoItem(
+            id = cursor.getString("id"),
+            description = cursor.getString("description"),
+            completed = cursor.getBoolean("completed"),
+            completedAt = cursor.getStringOptional("completed_at"),
+        )
+    }
+```
+
+Collect in a ViewModel:
+
+```kotlin
+viewModelScope.launch {
+    db.watch("SELECT * FROM lists") { cursor ->
+        ListItem(id = cursor.getString("id"), name = cursor.getString("name"))
+    }.collect { _uiState.value = it }
+}
+```
+
+React to table changes without re-running a query:
+
+```kotlin
+db.onChange(tables = setOf("todos", "lists")).collect { changedTables -> }
+```
+
+### One-Time Queries
+
+```kotlin
+val todos = db.getAll("SELECT * FROM todos WHERE list_id = ?", listOf(listId)) { cursor ->
+    TodoItem(id = cursor.getString("id"), ...)
+}
+
+val todo  = db.get("SELECT * FROM todos WHERE id = ?", listOf(id)) { cursor -> TodoItem(...) }         // throws if not found
+val todo  = db.getOptional("SELECT * FROM todos WHERE id = ?", listOf(id)) { cursor -> TodoItem(...) } // null if not found
+```
+
+### SqlCursor (by name)
+
+```kotlin
+cursor.getString("description")          // throws if null
+cursor.getStringOptional("completed_at") // null if null
+cursor.getLong("count")
+cursor.getLongOptional("optional_int")
+cursor.getDouble("amount")
+cursor.getBoolean("completed")
+cursor.getBytes("blob_data")
+```
+
+Import extension functions from `com.powersync.db`.
+
+## Writes and Transactions
+
+```kotlin
+// Single operation — uuid() is a PowerSync built-in SQLite function
+db.execute(
+    "INSERT INTO lists (id, created_at, name, owner_id) VALUES (uuid(), datetime(), ?, ?)",
+    listOf("My List", userId)
+)
+
+// Multiple operations atomically — auto-commits, auto-rollbacks on exception
+db.writeTransaction { tx ->
+    tx.execute("DELETE FROM lists WHERE id = ?", listOf(listId))
+    tx.execute("DELETE FROM todos WHERE list_id = ?", listOf(listId))
+}
+```
+
+ID generation — every table has `id TEXT PRIMARY KEY` added automatically:
+
+```kotlin
+db.execute("INSERT INTO todos (id, description) VALUES (uuid(), ?)", listOf("Buy milk"))
+// or generate in Kotlin:
+import com.benasher44.uuid.uuid4
+db.execute("INSERT INTO todos (id, description) VALUES (?, ?)", listOf(uuid4().toString(), "Buy milk"))
+```
+
+## Compose Integration
+
+```kotlin
+commonMain.dependencies {
+    implementation("com.powersync:compose:$powersyncVersion")
+}
+```
+
+```kotlin
+import com.powersync.compose.composeState
+
+@Composable
+fun GuardBySync(db: PowerSyncDatabase, content: @Composable () -> Unit) {
+    val status by db.currentStatus.composeState()
+
+    if (status.hasSynced == true) {
+        content()
+        return
+    }
+
+    val progress = status.downloadProgress
+    if (progress != null) {
+        LinearProgressIndicator(progress = progress.fraction)
+        Text("Downloaded ${progress.downloadedOperations} of ${progress.totalOperations}")
+    } else {
+        LinearProgressIndicator() // indeterminate while DB is opening
+    }
+}
+```
+
+## Sync Status
+
+```kotlin
+val status = db.currentStatus
+
+status.connected        // Boolean — sync stream is active
+status.connecting       // Boolean
+status.downloading      // Boolean
+status.uploading        // Boolean
+status.hasSynced        // Boolean? — null = DB still opening; true = at least one full sync completed
+status.lastSyncedAt     // Instant?
+status.downloadProgress // SyncDownloadProgress? — non-null only while downloading
+status.anyError         // Any? — uploadError ?: downloadError
+```
+
+Observe as a Flow:
+
+```kotlin
+db.currentStatus.asFlow().collect { status: SyncStatusData -> }
+```
+
+`hasSynced` persists across app restarts once set.
+
+### Sync Priorities
+
+Buckets can be assigned priorities (lower number = higher priority) on the server. Higher-priority data syncs first. See [Prioritized Sync](https://docs.powersync.com/usage/use-case-examples/prioritized-sync.md).
+
+```kotlin
+db.waitForFirstSync(priority = StreamPriority(1))
+
+val entry = db.currentStatus.statusForPriority(StreamPriority(1))
+entry.hasSynced    // Boolean?
+entry.lastSyncedAt // Instant?
+
+val progress = status.downloadProgress?.untilPriority(StreamPriority(1))
+progress?.fraction             // Float 0.0–1.0
+progress?.downloadedOperations // Int
+progress?.totalOperations      // Int
+```
+
+## Sync Streams
+
+Sync Streams are the recommended way to define what data syncs to each client. See [Sync Config](references/sync-config.md) for server-side configuration (YAML definitions, parameters, CTEs) and [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md) for full Kotlin examples.
+
+If `auto_subscribe` is not set to `true` in the sync config, subscribe to streams from client code:
+
+```kotlin
+import com.powersync.utils.JsonParam
+
+// Create a stream handle and subscribe
+val stream = db.syncStream(
+    name = "my_orders",
+    parameters = mapOf("userId" to JsonParam.String(currentUserId)),
+)
+val subscription = stream.subscribe(
+    ttl = 1.hours,                // optional — keep data alive after unsubscribe
+    priority = StreamPriority(1), // optional — lower number = higher priority
+)
+
+// Wait for this specific stream to complete its first sync
+subscription.waitForFirstSync()
+
+// Check stream status
+val streamStatus = db.currentStatus.forStream(subscription)
+streamStatus?.subscription?.hasSynced       // Boolean
+streamStatus?.subscription?.lastSyncedAt    // Instant?
+streamStatus?.subscription?.active          // Boolean
+streamStatus?.subscription?.isDefault       // Boolean
+streamStatus?.subscription?.expiresAt       // Instant?
+
+// Unsubscribe when done — TTL starts running after this
+subscription.unsubscribe()
+
+// Or unsubscribe all subscriptions for a stream
+stream.unsubscribeAll()
+```
+
+Same stream name with different parameters creates separate subscriptions. Subscribing while offline is supported — subscriptions are tracked locally and sent on next connect.
+
+## Background Sync (Android)
+
+Share a single `PowerSyncDatabase` instance between the UI and any foreground service — do not create separate instances or use separate processes.
+
+```kotlin
+class SyncService : Service() {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val db = (application as MyApp).database
+        serviceScope.launch { db.connect(connector) }
+        return START_STICKY
+    }
+    override fun onDestroy() { serviceScope.launch { db.disconnect() } }
+}
+```
+
+Full example: [`demos/supabase-todolist/androidBackgroundSync`](https://github.com/powersync-ja/powersync-kotlin/tree/main/demos/supabase-todolist/androidBackgroundSync)
+
+## ORM Integrations
+
+- **Room** (alpha) — typed queries with compile-time validation: `com.powersync:powersync-room:$powersyncVersion` · [Docs](https://docs.powersync.com/client-sdk-references/kotlin-multiplatform/libraries/room.md)
+- **SQLDelight** (beta) — `PowerSyncDriver` implements `SqlDriver`: `com.powersync:powersync-sqldelight:$powersyncVersion` · [Docs](https://docs.powersync.com/client-sdk-references/kotlin-multiplatform/libraries/sqldelight.md)
+
+## Additional Resources
+
+Only read these if the content above does not provide enough context for the task.
+
+- [Kotlin API docs](https://powersync-ja.github.io/powersync-kotlin/) — all available APIs
+- [Full SDK reference](https://docs.powersync.com/client-sdk-references/kotlin-multiplatform.md) — full SDK documentation
+- [supabase-todolist](https://github.com/powersync-ja/powersync-kotlin/tree/main/demos/supabase-todolist) — PowerSync + Supabase (KMP) example
+- [android-supabase-todolist](https://github.com/powersync-ja/powersync-kotlin/tree/main/demos/android-supabase-todolist) — PowerSync + Supabase (Android) example

--- a/.claude/skills/powersync/references/sdks/powersync-swift.md
+++ b/.claude/skills/powersync/references/sdks/powersync-swift.md
@@ -1,0 +1,210 @@
+---
+name: powersync-swift
+description: PowerSync Swift SDK — schema, queries, sync lifecycle, backend connectors, and GRDB ORM support
+metadata:
+  tags: swift, ios, macos, grdb, orm, sqlite, offline-first
+---
+
+# PowerSync Swift SDK
+
+Best practices and guidance for building apps with the PowerSync Swift SDK.
+
+| Resource | Description |
+|----------|-------------|
+| [Swift API reference](https://powersync-ja.github.io/powersync-swift/documentation/powersync/) | Full API reference, consult only when the inline examples don't cover your case. |
+| [Supported Platforms](https://docs.powersync.com/resources/supported-platform.md#swift-sdk) | Supported platforms and features, consult for compatibility details. |
+
+## Installation
+
+| Method | Instructions |
+|--------|-------------|
+| `Package.swift` | [Installation - Package.swift](https://docs.powersync.com/client-sdks/reference/swift.md#package-swift) |
+| Xcode | [Installation - Xcode](https://docs.powersync.com/client-sdks/reference/swift.md#xcode) |
+
+## Setup
+
+### 1. Define Schema
+
+```swift
+import PowerSync
+
+let lists = Table(
+    name: "lists",
+    columns: [
+        // id column is automatically included
+        .text("name"),
+        .text("created_at"),
+        .text("owner_id")
+    ]
+)
+
+let todos = Table(
+    name: "todos",
+    columns: [
+        .text("list_id"),
+        .text("description"),
+        .integer("completed"), // 0 or 1
+        .text("created_at"),
+        .text("completed_at"),
+        .text("created_by"),
+        .text("completed_by")
+    ],
+    indexes: [
+        Index(name: "list_id", columns: [IndexedColumn.ascending("list_id")])
+    ]
+)
+
+let AppSchema = Schema(tables: [lists, todos])
+```
+
+See [Define the Client-Side Schema](https://docs.powersync.com/client-sdks/reference/swift.md#1-define-the-client-side-schema) for more information.
+
+### 2. Create Backend Connector
+
+```swift
+import PowerSync
+
+@Observable
+@MainActor
+final class MyConnector: PowerSyncBackendConnectorProtocol {
+    private let apiClient: APIClient
+
+    init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    func fetchCredentials() async throws -> PowerSyncCredentials? {
+        let response = try await apiClient.getPowerSyncToken()
+        return PowerSyncCredentials(
+            endpoint: "https://your-instance.powersync.journeyapps.com",
+            token: response.token,
+            expiresAt: response.expiresAt
+        )
+    }
+
+    func uploadData(database: PowerSyncDatabaseProtocol) async throws {
+        guard let transaction = try await database.getNextCrudTransaction() else { return }
+
+        do {
+            for entry in transaction.crud {
+                switch entry.op {
+                case .put:
+                    var data = entry.opData ?? [:]
+                    data["id"] = entry.id
+                    try await apiClient.upsert(table: entry.table, id: entry.id, data: data)
+                case .patch:
+                    guard let opData = entry.opData else { continue }
+                    try await apiClient.update(table: entry.table, id: entry.id, data: opData)
+                case .delete:
+                    try await apiClient.delete(table: entry.table, id: entry.id)
+                }
+            }
+            try await transaction.complete()
+        } catch {
+            throw error
+        }
+    }
+}
+```
+
+Use `getCrudBatch` instead of `getNextCrudTransaction` when uploading large numbers of mutations in bulk.
+
+See [Integrate with your Backend](https://docs.powersync.com/client-sdks/reference/swift.md#3-integrate-with-your-backend) for more information.
+
+### 3. Instantiate and Connect
+
+```swift
+@Observable
+@MainActor
+final class SystemManager {
+    let connector = MyConnector()
+    let db: PowerSyncDatabaseProtocol
+
+    init() {
+        db = PowerSyncDatabase(
+            schema: AppSchema,
+            dbFilename: "powersync-swift.sqlite"
+        )
+    }
+
+    func connect() async throws {
+        try await db.connect(connector: connector)
+    }
+}
+```
+
+See [Instantiate the PowerSync Database](https://docs.powersync.com/client-sdks/reference/swift.md#2-instantiate-the-powersync-database) for more information.
+
+## Sync Streams
+
+See [sync-config.md](references/sync-config.md) for how to subscribe to Sync Streams when `auto_subscribe` is not set to `true` in the PowerSync Service config.
+
+## Query Patterns
+
+See [Using PowerSync: CRUD](https://docs.powersync.com/client-sdks/reference/swift.md#using-powersync-crud-functions) for the full API reference.
+
+### One-Time Queries
+
+```swift
+// Fetch all matching rows
+let todos = try await db.getAll("SELECT * FROM todos WHERE list_id = ?", parameters: [listId])
+
+// Fetch single row — throws if not found
+let todo = try await db.get("SELECT * FROM todos WHERE id = ?", parameters: [id])
+
+// Fetch single row — returns nil if not found
+let todo = try await db.getOptional("SELECT * FROM todos WHERE id = ?", parameters: [id])
+```
+
+### Reactive Queries
+
+```swift
+// Watch a query — emits on every change to the watched tables
+for try await todos in db.watch("SELECT * FROM todos WHERE list_id = ?", parameters: [listId]) {
+    // update UI
+}
+```
+
+### Writing Data
+
+```swift
+// Single mutation
+try await db.execute(
+    "INSERT INTO todos (id, description, completed) VALUES (uuid(), ?, ?)",
+    parameters: ["New todo", 0]
+)
+
+// Multiple related mutations as a single unit
+try await db.writeTransaction { tx in
+    try await tx.execute("INSERT INTO lists (id, name) VALUES (?, ?)", parameters: [listId, "Shopping"])
+    try await tx.execute("INSERT INTO todos (id, list_id, description) VALUES (uuid(), ?, ?)", parameters: [listId, "Milk"])
+}
+```
+
+## ORM — GRDB
+
+PowerSync Swift supports GRDB as an ORM. Requires PowerSync Swift v1.9.0+.
+
+Setup requires a `DatabasePool` with PowerSync config — see [GRDB Setup](https://docs.powersync.com/client-sdks/orms/swift/grdb.md#setup).
+
+```swift
+// Define a GRDB record type
+struct Todo: Codable, Identifiable, FetchableRecord, PersistableRecord {
+    var id: String
+    var description: String
+    var completed: Int
+}
+
+// Read
+let todos = try await pool.read { db in
+    try Todo.fetchAll(db)
+}
+
+// Write
+try await pool.write { db in
+    var todo = Todo(id: UUID().uuidString, description: "Buy milk", completed: 0)
+    try todo.insert(db)
+}
+```
+
+See [GRDB Architecture](https://docs.powersync.com/client-sdks/orms/swift/grdb.md#architecture) for how the PowerSync + GRDB integration works.

--- a/.claude/skills/powersync/references/supabase-auth.md
+++ b/.claude/skills/powersync/references/supabase-auth.md
@@ -1,0 +1,282 @@
+---
+name: supabase-auth
+description: Configuring PowerSync with Supabase — database publication setup, JWT signing keys, Cloud dashboard setup, self-hosted service.yaml config, fetchCredentials() implementation, and error codes
+metadata:
+  tags: supabase, auth, jwt, jwks, client_auth, fetchCredentials, authentication, hs256, rs256, publication, replica-identity
+---
+
+# PowerSync + Supabase Auth
+
+PowerSync verifies Supabase JWTs directly when connected to a Supabase-hosted Postgres database. This file covers everything needed to configure authentication end-to-end.
+
+## Supabase Database Setup
+
+Supabase already has logical replication enabled at the WAL level. You still need to create a publication so PowerSync knows which tables to replicate, and set `REPLICA IDENTITY FULL` on each table so that DELETE operations include the full row (required for PowerSync to sync deletes to clients).
+
+Run this in the Supabase SQL Editor **after creating your tables**:
+
+```sql
+-- Create the PowerSync publication (required)
+-- List every table PowerSync should replicate
+CREATE PUBLICATION powersync FOR TABLE lists, todos;
+```
+
+When you add a new table that PowerSync should replicate, add it to the publication. To replicate all current and future tables automatically (simpler but less precise):
+
+```sql
+CREATE PUBLICATION powersync FOR ALL TABLES;
+```
+
+## JWT Signing Key Types
+
+Supabase projects use one of two signing key types. **Check which your project uses** at [Project Settings → JWT](https://supabase.com/dashboard/project/_/settings/jwt) in the Supabase Dashboard before configuring PowerSync.
+
+| Type | Algorithm | Notes |
+|------|-----------|-------|
+| **New JWT signing keys** | RS256 (asymmetric) | Recommended. PowerSync auto-detects from the connection string. |
+| **Legacy JWT signing keys** | HS256 (symmetric) | Requires supplying the JWT secret to PowerSync. Consider migrating. |
+
+---
+
+## PowerSync Cloud Setup
+
+Configure via the **Client Auth** section of your instance in the [PowerSync Dashboard](https://dashboard.powersync.com/).
+
+### New JWT signing keys (recommended)
+
+1. Enable the **Use Supabase Auth** checkbox.
+2. Leave the **Supabase JWT Secret** field empty.
+3. Click **Save and Deploy**.
+
+PowerSync auto-detects your Supabase project from the database connection string and configures the JWKS URI (`https://<project-ref>.supabase.co/auth/v1/.well-known/jwks.json`) and JWT audience (`authenticated`) automatically.
+
+### Legacy JWT signing keys (HS256)
+
+1. Enable the **Use Supabase Auth** checkbox.
+2. Copy your **JWT Secret** from Supabase → [Project Settings → JWT](https://supabase.com/dashboard/project/_/settings/jwt).
+3. Paste it into the **Supabase JWT Secret (Legacy)** field.
+4. Click **Save and Deploy**.
+
+### Manual JWKS (non-standard connections)
+
+Use this when PowerSync cannot auto-detect your Supabase project (self-hosted Supabase, local Docker, non-standard connection string):
+
+1. Leave **Use Supabase Auth** unchecked.
+2. Add a **JWKS URI**, e.g. `http://localhost:54321/auth/v1/.well-known/jwks.json`.
+3. Add `authenticated` as an accepted **JWT Audience**.
+4. Click **Save and Deploy**.
+
+> Skipping the `authenticated` audience causes `PSYNC_S2105` errors — see Troubleshooting below.
+
+---
+
+## Self-Hosted `service.yaml` Config
+
+### New JWT signing keys (recommended)
+
+PowerSync auto-detects the Supabase project from the connection string:
+
+```yaml
+client_auth:
+  supabase: true
+```
+
+PowerSync automatically sets:
+- JWKS URI: `https://<project-ref>.supabase.co/auth/v1/.well-known/jwks.json`
+- Audience: `authenticated`
+
+### Legacy JWT signing keys (HS256)
+
+```yaml
+client_auth:
+  supabase: true
+  supabase_jwt_secret: !env SUPABASE_JWT_SECRET
+```
+
+Get the secret from Supabase → Project Settings → JWT. Use `!env` to avoid hardcoding secrets.
+
+### Local Supabase (`supabase start`)
+
+**IMPORTANT:** Local Supabase (via `supabase start`) uses **ES256 asymmetric JWT signing keys**, not the legacy HS256 shared secret. This means:
+
+- `supabase: true` alone **will not work** — it cannot auto-detect a local project from the connection string.
+- `supabase: true` + `supabase_jwt_secret` **will not work** — it registers an HS256 key, but local Supabase issues ES256 tokens with a `kid` that doesn't match.
+- You **must** use manual JWKS pointing to the local Supabase JWKS endpoint.
+
+The error you'll see if misconfigured:
+```
+PSYNC_S2101: Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID
+```
+With details showing: `Known keys: <kid: *, kty: oct, alg: HS256>` but the token has `alg: ES256` with a specific `kid`.
+
+**Correct config for local Supabase:**
+
+```yaml
+client_auth:
+  # Use host.docker.internal to reach the host machine from inside the PowerSync Docker container.
+  # Alternatively, use the Supabase Kong container name (e.g. supabase_kong_<project-id>)
+  # if both are on the same Docker network.
+  jwks_uri: http://host.docker.internal:54321/auth/v1/.well-known/jwks.json
+  audience:
+    - authenticated
+  block_local_jwks: false
+```
+
+Key details:
+- Use `host.docker.internal` or the Supabase container name (not `localhost`) because this URI is resolved **from inside the PowerSync Docker container**.
+- `block_local_jwks: false` is required because `host.docker.internal` resolves to a local/private IP, which PowerSync blocks by default.
+- The well-known local Supabase JWT secret (`super-secret-jwt-token-with-at-least-32-characters-long`) is **not used** for token signing in newer Supabase versions — it's only used for the service role key and anon key.
+
+**SSL for local Supabase Postgres:** Local Supabase does not support SSL. You **must** set `sslmode: disable` on the replication connection in `service.yaml`. The `sslmode=disable` query string in the URI alone does not work — pgwire ignores it. Use the YAML key instead:
+
+```yaml
+replication:
+  connections:
+    - type: postgresql
+      uri: postgresql://postgres:postgres@host.docker.internal:54322/postgres
+      sslmode: disable
+```
+
+Without this you will see: `Replication error postgres does not support ssl`.
+
+You can verify your local Supabase is using ES256 by checking:
+```bash
+curl -s http://127.0.0.1:54321/auth/v1/.well-known/jwks.json
+# Returns: {"keys":[{"alg":"ES256","crv":"P-256","kty":"EC",...}]}
+```
+
+### Manual JWKS (other non-standard connections)
+
+Use when `supabase: true` cannot auto-detect the project (e.g. self-hosted Supabase, custom auth proxy):
+
+```yaml
+client_auth:
+  jwks_uri: http://localhost:54321/auth/v1/.well-known/jwks.json
+  audience:
+    - authenticated
+```
+
+> Do **not** combine `supabase: true` with `jwks_uri`. Use one or the other.
+
+---
+
+## `fetchCredentials()` — Client Implementation
+
+`fetchCredentials()` in your backend connector should return the Supabase session JWT. The examples below use the JS Supabase client; equivalent patterns exist for [Dart](https://github.com/powersync-ja/powersync.dart/blob/9ef224175c8969f5602c140bcec6dd8296c31260/demos/supabase-todolist/lib/powersync.dart#L38) and [Kotlin](https://github.com/powersync-ja/powersync-kotlin/blob/main/connectors/supabase/src/commonMain/kotlin/com/powersync/connector/supabase/SupabaseConnector.kt).
+
+### Standard Supabase Auth (JS/TS)
+
+```ts
+import { createClient } from '@supabase/supabase-js';
+import type { PowerSyncBackendConnector, PowerSyncCredentials } from '@powersync/web'; // or @powersync/react-native
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+export const connector: PowerSyncBackendConnector = {
+  async fetchCredentials(): Promise<PowerSyncCredentials> {
+    const { data: { session }, error } = await supabase.auth.getSession();
+    if (error || !session) throw error ?? new Error('No session');
+    return {
+      endpoint: POWERSYNC_URL,
+      token: session.access_token,
+      expiresAt: new Date(session.expires_at! * 1000),
+    };
+  },
+  // ...uploadData
+};
+```
+
+### Anonymous Sign-In (JS/TS)
+
+```ts
+async fetchCredentials(): Promise<PowerSyncCredentials> {
+  // Sign in anonymously if no session exists
+  let { data: { session } } = await supabase.auth.getSession();
+  if (!session) {
+    const { data, error } = await supabase.auth.signInAnonymously();
+    if (error) throw error;
+    session = data.session!;
+  }
+  return {
+    endpoint: POWERSYNC_URL,
+    token: session.access_token,
+    expiresAt: new Date(session.expires_at! * 1000),
+  };
+},
+```
+
+`fetchCredentials` is called automatically on reconnect — always return a fresh token, never a cached one.
+
+---
+
+## `auth.user_id()` in Sync Streams
+
+`auth.user_id()` returns the Supabase user's UUID (the `sub` claim from the JWT). Use it to scope sync queries per user:
+
+```yaml
+streams:
+  my_todos:
+    auto_subscribe: true
+    query: SELECT * FROM todos WHERE user_id = auth.user_id()
+```
+
+For Sync Rules (legacy), use `request.user_id()` instead.
+
+---
+
+## Kotlin: Built-in Supabase Connector
+
+The Kotlin SDK includes a first-party Supabase connector that handles `fetchCredentials` and session management automatically:
+
+```kotlin
+// build.gradle.kts
+implementation("com.powersync:connector-supabase:$powersyncVersion")
+```
+
+```kotlin
+val connector = SupabaseConnector(
+    supabaseUrl = "https://your-project.supabase.co",
+    supabaseKey = "your-anon-key",
+    powerSyncEndpoint = "https://your-instance.powersync.journeyapps.com",
+)
+```
+
+---
+
+## Troubleshooting
+
+### `PSYNC_S2101` — Could not find an appropriate key in the keystore
+
+PowerSync cannot verify the JWT signature. Check the error logs for `Known keys` and `tokenDetails` to diagnose the mismatch.
+
+| Cause | Symptom | Solution |
+|-------|---------|---------|
+| **Local Supabase with `supabase_jwt_secret`** | Known keys show `HS256` but token uses `ES256` with a specific `kid` | Local Supabase uses ES256 asymmetric keys. Switch to manual JWKS config — see "Local Supabase" section above. |
+| Incomplete Supabase key migration | Token `alg` doesn't match keystore | Complete the "Rotate to asymmetric JWTs" step in the [Supabase migration guide](https://supabase.com/blog/jwt-signing-keys#start-using-asymmetric-jwts-today). |
+| Stale tokens after migration | Old tokens fail, new logins work | Have users sign out and back in to receive new tokens. |
+| Auto-detection failed | `supabase: true` but no keys registered | PowerSync couldn't detect your Supabase project from the connection string. Use manual JWKS config. |
+| Wrong JWT secret | HS256 verification fails | For legacy HS256 keys, verify the secret matches Supabase → Project Settings → JWT. |
+| `block_local_jwks` blocking JWKS fetch | JWKS URI resolves to private IP, keys never fetched | Set `block_local_jwks: false` for local development. |
+
+### `PSYNC_S2105` — JWT payload is missing a required claim "aud"
+
+Using manual JWKS config without specifying an audience. Add `authenticated` to the audience list (Cloud dashboard or `audience: [authenticated]` in `service.yaml`).
+
+### Auto-detection warning
+
+If you see:
+```
+Supabase Auth is enabled, but no Supabase connection string found. Skipping Supabase JWKS URL configuration.
+```
+
+PowerSync couldn't detect your project from the connection string. Switch to manual JWKS configuration.
+
+---
+
+## Migrating from Legacy to New JWT Signing Keys
+
+1. Follow **all steps** in the [Supabase JWT migration guide](https://supabase.com/blog/jwt-signing-keys#start-using-asymmetric-jwts-today), including the **"Rotate to asymmetric JWTs"** step. The migration is not complete without this step.
+2. Update PowerSync config:
+   - **Cloud / self-hosted with standard connection**: No change needed — PowerSync auto-detects the new JWKS. Remove any previously set legacy JWT secret.
+   - **Manual JWKS**: Ensure `jwks_uri` points to the Supabase JWKS endpoint and `authenticated` is in the audience list.
+3. Have all users sign out and sign back in to receive tokens signed with the new keys.

--- a/.claude/skills/powersync/references/sync-config.md
+++ b/.claude/skills/powersync/references/sync-config.md
@@ -1,0 +1,581 @@
+---
+name: sync-config
+description: PowerSync Sync Config — Sync Streams (new), Sync Rules (legacy), parameters, CTEs, common patterns, and migration guidance
+metadata:
+  tags: sync-streams, sync-rules, sync-config, yaml, buckets, parameters, cte, migration
+---
+
+# Sync Config
+
+Expert guidance on Sync Config. Sync config is divided into two sections:
+1. Sync Streams (new, default) - The latest implementation of Sync Config. New apps should use Sync Streams by default. Prioritize Sync Streams above Sync Rules.
+2. Sync Rules (legacy) - The first implementation of Sync Config. New apps should not use Sync Rules, prioritize Sync Streams over Sync Rules.
+
+Critical warnings for fast setup:
+
+- `sync-config.yaml` must begin with a top-level `config:` block containing `edition: 3`.
+- If the app is stuck on `Syncing...`, first assume sync config was never deployed or backend setup is incomplete.
+
+# Sync Streams
+
+Sync Streams define exactly which data is synced to each client by using named, SQL-like queries and subscription parameters.
+
+For a full overview, see [Sync Streams Overview](https://docs.powersync.com/sync/streams/overview.md)
+
+## Requirements 
+
+### PowerSync Service
+- Self-hosted: v1.20.0+ 
+- Cloud: Already met
+
+### Sync Config
+Must use config edition 3 in their sync config:
+```yaml
+config:
+  edition: 3
+```
+
+### PowerSync SDKs
+There are minimum SDK requirements when using Sync Streams in an application. See [Minimum SDK Versions](https://docs.powersync.com/sync/streams/migration.md#minimum-sdk-versions) for a full list for each supported PowerSync SDK.
+
+IMPORTANT
+Client applications using a lower version than the `Rust Client Default` should make sure to enable the Rust Sync Client to use Sync Streams. 
+
+## sync-config.yaml File Format
+
+**IMPORTANT:** The `sync-config.yaml` file **must** begin with a top-level `config:` block specifying the edition. Without this wrapper, the PowerSync Service will reject the config. This is the most common deployment error — do not omit it.
+
+```yaml
+# powersync/sync-config.yaml — required structure
+config:
+  edition: 3        # <-- REQUIRED top-level wrapper
+
+streams:
+  my_data:
+    auto_subscribe: true
+    query: SELECT * FROM my_table WHERE user_id = auth.user_id()
+```
+
+### Minimal Supabase-Oriented Example
+
+```yaml
+config:
+  edition: 3
+
+streams:
+  posts:
+    auto_subscribe: true
+    query: SELECT * FROM posts WHERE user_id = auth.user_id()
+```
+
+## Structure
+```yaml
+config:
+  edition: 3
+
+streams:
+  <stream_name>:
+    # CTEs (optional) - define with block inside each stream
+    with:
+      <cte_name>: SELECT ... FROM ...
+
+    # Behavior options (place above query/queries)
+    auto_subscribe: true    # Auto-subscribe clients on connect (default: false)
+    priority: 1             # Sync priority (optional). Lower number -> higher priority
+    accept_potentially_dangerous_queries: true  # Silence security warnings (default: false)
+
+    # Query options (use one)
+    query: SELECT * FROM <table> WHERE ...         # Single query
+    queries:                                       # Multiple queries
+      - SELECT * FROM <table_a> WHERE ...
+      - SELECT * FROM <table_b> WHERE ...
+```
+
+> **Bucket limit**: Each unique `(stream name + parameter values)` combination creates one internal bucket. The default limit is **1,000 buckets per user**. If a stream with subscription parameters could create many combinations, use `queries:` (multiple queries inside one stream) instead of separate streams — this keeps everything in one bucket.
+
+## Stream Options
+
+Behavior options placed above `query`/`queries` in each stream definition.
+
+### `auto_subscribe` (default: `false`)
+
+When `true`, clients automatically subscribe on connect — no client-side `syncStream()` call needed.
+
+Use for:
+- Reference/global data all users need (e.g. `categories`, `app_config`)
+- User-scoped data that should always be available offline
+
+Do not use with streams that use `subscription.parameter()`. There is no mechanism to supply the parameter value at auto-subscribe time, so the subscription will produce empty results.
+
+```yaml
+streams:
+  categories:
+    auto_subscribe: true
+    query: SELECT * FROM categories
+
+  my_orders:
+    auto_subscribe: true
+    query: SELECT * FROM orders WHERE user_id = auth.user_id()
+
+  # No auto_subscribe — requires client-supplied parameter
+  order_items:
+    query: |
+      SELECT * FROM order_items
+      WHERE order_id = subscription.parameter('order_id')
+        AND order_id IN (SELECT id FROM orders WHERE user_id = auth.user_id())
+```
+
+### `priority`
+
+Controls sync order. Lower number = higher priority. Valid range is `0`–`3`; default is `3`.
+
+Use when some data must be available sooner (e.g. user profile before activity feed):
+
+```yaml
+streams:
+  user_profile:
+    priority: 1
+    auto_subscribe: true
+    query: SELECT * FROM profiles WHERE user_id = auth.user_id()
+
+  activity_feed:
+    priority: 2
+    auto_subscribe: true
+    query: SELECT * FROM activity WHERE user_id = auth.user_id()
+```
+
+**Priority 0 — special case**: syncs regardless of pending uploads, bypassing the normal upload-consistency guarantee. Use only for append-only/CRDT workloads (e.g. Yjs collaborative editing). Misuse causes flickering or out-of-order data.
+
+The client can also override the priority per-subscription — see [Client Usage](#client-usage).
+
+See [Prioritized Sync](https://docs.powersync.com/sync/advanced/prioritized-sync.md) for full details.
+
+### `accept_potentially_dangerous_queries` (default: `false`)
+
+PowerSync raises a warning when a stream query uses `subscription.parameter()` or `connection.parameter()` (client-controlled values that are not signed). Set to `true` only after adding an `AND auth.user_id()` guard that scopes the client-supplied value to rows the user actually owns:
+
+```yaml
+streams:
+  workspace_data:
+    accept_potentially_dangerous_queries: true
+    query: |
+      SELECT * FROM documents
+      WHERE workspace_id = subscription.parameter('workspace_id')
+        AND workspace_id IN (SELECT id FROM workspaces WHERE owner_id = auth.user_id())
+```
+
+The inner `AND` clause is what makes this safe — it prevents a client from requesting data outside their own workspaces.
+
+## Common Patterns
+
+### Global data
+
+No filter — same data for all users. Use `auto_subscribe: true` so clients receive it automatically on connect.
+
+```yaml
+streams:
+  categories:
+    auto_subscribe: true
+    query: SELECT * FROM categories
+
+  products:
+    auto_subscribe: true
+    query: SELECT * FROM products WHERE active = true
+```
+
+### Personal data
+
+Filter by the authenticated user using `auth.user_id()`.
+
+```yaml
+streams:
+  my_notes:
+    auto_subscribe: true
+    query: SELECT * FROM notes WHERE owner_id = auth.user_id()
+
+  my_orders:
+    auto_subscribe: true
+    query: SELECT * FROM orders WHERE user_id = auth.user_id()
+```
+
+### JOIN
+
+Use `INNER JOIN` to filter rows via a related table (e.g. a membership table):
+
+```yaml
+streams:
+  team_projects:
+    query: |
+      SELECT p.*
+      FROM projects p
+      INNER JOIN team_members tm ON tm.team_id = p.team_id
+      WHERE tm.user_id = auth.user_id()
+```
+
+### Subquery
+
+Use `WHERE id IN (SELECT ...)` for indirect access through a related table:
+
+```yaml
+streams:
+  org_documents:
+    query: |
+      SELECT * FROM documents
+      WHERE org_id IN (
+        SELECT org_id FROM org_members WHERE user_id = auth.user_id()
+      )
+```
+
+### On-demand with subscription parameter
+
+Client subscribes to a specific resource at runtime. Always include an auth guard.
+
+```yaml
+streams:
+  list_todos:
+    accept_potentially_dangerous_queries: true
+    query: |
+      SELECT * FROM todos
+      WHERE list_id = subscription.parameter('list_id')
+        AND list_id IN (SELECT id FROM lists WHERE owner_id = auth.user_id())
+```
+
+See [Writing Queries](https://docs.powersync.com/sync/streams/queries.md) for JOIN, subquery, and multiple queries per stream details.
+See [Examples & Demos](https://docs.powersync.com/sync/streams/examples.md) for complete working app patterns.
+
+## Query Parameters
+
+There are three kinds of query parameters. Choose based on where the value comes from and how often it changes.
+
+### Auth parameters
+
+Values from the signed JWT — the most secure option. Use when filtering by who the user is. These cannot be tampered with by the client.
+
+```yaml
+streams:
+  my_orders:
+    query: SELECT * FROM orders WHERE user_id = auth.user_id()
+
+  tenant_data:
+    query: SELECT * FROM records WHERE tenant_id = auth.jwt() ->> 'tenant_id'
+```
+
+See [Auth Parameters](https://docs.powersync.com/sync/streams/parameters.md#auth-parameters) for all available JWT claims.
+
+### Subscription parameters
+
+The client chooses what to sync at runtime. Each subscription is independent — a user can have multiple subscriptions to the same stream with different values. Always scope with an auth guard to prevent a client from accessing data they don't own.
+
+```yaml
+streams:
+  list_todos:
+    accept_potentially_dangerous_queries: true
+    query: |
+      SELECT * FROM todos
+      WHERE list_id = subscription.parameter('list_id')
+        AND list_id IN (SELECT id FROM lists WHERE owner_id = auth.user_id())
+```
+
+See [Subscription Parameters](https://docs.powersync.com/sync/streams/parameters.md#subscription-parameters) for full reference.
+
+### Connection parameters
+
+Apply globally across all streams for the session. Use for values that rarely change, like environment flags or feature toggles. Changing them requires reconnecting.
+
+```yaml
+streams:
+  config:
+    auto_subscribe: true
+    query: SELECT * FROM config WHERE env = connection.parameter('environment')
+```
+
+See [Connection Parameters](https://docs.powersync.com/sync/streams/parameters.md#connection-parameters) for full reference.
+
+## Common Table Expressions (CTEs)
+
+Reusable query patterns for your Sync Streams. You can create Global and Scoped CTEs. 
+
+Global 
+```yaml
+with:
+  user_orgs: SELECT org_id FROM org_members WHERE user_id = auth.user_id()
+
+streams:
+  org_projects:
+    query: SELECT * FROM projects WHERE org_id IN user_orgs
+  
+  org_repositories:
+    query: SELECT * FROM repositories WHERE org_id IN user_orgs
+  
+  org_settings:
+    query: SELECT * FROM settings WHERE org_id IN user_orgs
+```
+
+Scoped 
+```yaml
+streams:
+  project_data:
+    with:
+      accessible_projects: |
+        SELECT id FROM projects 
+        WHERE org_id IN (SELECT org_id FROM org_members WHERE user_id = auth.user_id())
+    queries:
+      - SELECT * FROM projects WHERE id IN accessible_projects
+      - SELECT * FROM tasks WHERE project_id IN accessible_projects
+      - SELECT * FROM comments WHERE project_id IN accessible_projects
+```
+
+### CTE Limitations
+
+This won't work
+```yaml
+# This won't work - cte2 cannot reference cte1
+with:
+  cte1: SELECT org_id FROM org_members WHERE user_id = auth.user_id()
+  cte2: SELECT id FROM projects WHERE org_id IN cte1  # Error!
+
+```
+
+For a full breakdown, see [Limitations](https://docs.powersync.com/sync/streams/ctes.md#limitations).
+
+## Migration
+
+There are big differences between Sync Rules and Sync Streams, consider the following when migrating from Sync Rules to Sync Streams. See [Sync Streams Migrations](https://docs.powersync.com/sync/streams/migration.md) for information such as:
+- How to migrate
+- The tools that can make it easier 
+- Understanding the difference between Sync Rules and Sync Streams
+- Migration examples for common scenarios
+
+## Client Usage
+
+Client applications subscribe to Sync Streams to start syncing data. See [Client-Side Usage](https://docs.powersync.com/sync/streams/client-usage.md) for a full breakdown.
+
+### TTL (Time-To-Live)
+
+Each subscription has a TTL that keeps data cached after unsubscribing. Default is **24 hours**.
+
+```js
+// Default (24h cache after unsubscribe)
+const sub = await db.syncStream('todos', { list_id: 'abc' }).subscribe();
+
+// Custom TTL in seconds
+const sub = await db.syncStream('todos', { list_id: 'abc' }).subscribe({ ttl: 3600 }); // 1 hour
+
+// Remove data immediately on unsubscribe
+const sub = await db.syncStream('todos', { list_id: 'abc' }).subscribe({ ttl: 0 });
+
+// Keep forever
+const sub = await db.syncStream('todos', { list_id: 'abc' }).subscribe({ ttl: Infinity });
+```
+
+### Priority Override
+
+Override the stream's YAML-defined priority for a specific subscription:
+
+```js
+const sub = await db.syncStream('todos', { list_id: 'abc' }).subscribe({ priority: 1 });
+```
+
+When multiple components subscribe to the same stream+parameters with different priorities, PowerSync uses the highest priority until all those subscriptions end.
+
+There are examples available for each PowerSync Client SDK.
+
+| SDK                  | Client Usage Reference URL                                                                                         |
+|----------------------|-------------------------------------------------------------------------------------------------------------------|
+| TypeScript/JavaScript| [Client Usage](https://docs.powersync.com/sync/streams/client-usage.md#typescript%2Fjavascript)                           |
+| Dart                 | [Client Usage](https://docs.powersync.com/sync/streams/client-usage.md#dart)                                              |
+| Kotlin               | [Client Usage](https://docs.powersync.com/sync/streams/client-usage.md#kotlin)                                            |
+| Swift                | [Client Usage](https://docs.powersync.com/sync/streams/client-usage.md#swift)                                             |
+| .NET                 | [Client Usage](https://docs.powersync.com/sync/streams/client-usage.md#net)                                               |
+
+### Frameworks 
+
+| Framework                 | Client Usage Reference URL                                                                                         |
+|---------------------------|--------------------------------------------------------------------------------------------------------------------|
+| React                     | [Client Usage](https://docs.powersync.com/sync/streams/client-usage.md#react-hooks)                                        |
+
+## Advanced Topics
+
+Reference these when the standard patterns don't cover your use case:
+
+| Topic | When to use |
+|-------|-------------|
+| [Client ID](https://docs.powersync.com/sync/advanced/client-id.md) | Filter or scope data by which specific client device is syncing |
+| [Sync Data by Time](https://docs.powersync.com/sync/advanced/sync-data-by-time.md) | Limit sync to a rolling time window (e.g. last 30 days) |
+| [Schemas and Connections](https://docs.powersync.com/sync/advanced/schemas-and-connections.md) | Source data from multiple database schemas or connections |
+| [Multiple Client Versions](https://docs.powersync.com/sync/advanced/multiple-client-versions.md) | Support different schema versions across app releases |
+| [Partitioned Tables](https://docs.powersync.com/sync/advanced/partitioned-tables.md) | Sync from Postgres partitioned tables |
+| [Sharded Databases](https://docs.powersync.com/sync/advanced/sharded-databases.md) | Source data from multiple database shards |
+
+# Sync Rules (Legacy, use Sync Streams for new applications)
+
+Sync rules define how data is partitioned into buckets and distributed to clients. This is considered legacy, however will still be supported. For the best experience use [sync-streams](#sync-streams).
+
+## Structure
+
+```yaml
+bucket_definitions:
+  <bucket_name>:
+    parameters: SELECT ...   # Which buckets user can access
+    data:                    # What data goes in each bucket
+      - SELECT ... WHERE column = bucket.parameter
+```
+
+## Parameter Queries
+
+Determine bucket access for authenticated users:
+
+```yaml
+# User's own data
+parameters: SELECT request.user_id() AS user_id
+
+# From database table
+parameters: SELECT org_id FROM users WHERE id = request.user_id()
+
+# From JWT claims
+parameters: SELECT request.jwt() ->> 'tenant_id' AS tenant_id
+
+# From client parameters
+parameters: SELECT request.parameters() ->> 'workspace_id' AS workspace_id
+```
+
+## Data Queries
+
+Define what rows go into each bucket:
+
+```yaml
+data:
+  # Basic - all columns
+  - SELECT * FROM documents WHERE user_id = bucket.user_id
+
+  # Column selection
+  - SELECT id, name, created_at FROM projects WHERE org_id = bucket.org_id
+
+  # Transformations
+  - SELECT id, UPPER(status) as status FROM tasks WHERE team_id = bucket.team_id
+```
+
+## Supported SQL Features
+
+### Functions
+
+| Category | Functions |
+|----------|-----------|
+| String | `upper()`, `lower()`, `substring()`, `length()`, `hex()`, `base64()` |
+| JSON | `json_extract()`, `->`, `->>`, `json_array_length()`, `json_valid()` |
+| Type | `typeof()`, `cast()` |
+| Utility | `ifnull()`, `iif()`, `uuid_blob()` |
+| Date/Time | `unixepoch()`, `datetime()` |
+| Geospatial | `st_asgeojson()`, `st_astext()`, `st_x()`, `st_y()` |
+
+### Operators (non-parameter comparisons)
+
+- Comparison: `=`, `!=`, `<`, `>`, `<=`, `>=`
+- Logical: `AND`, `OR`, `NOT`, `IS`, `IS NOT`
+- Arithmetic: `+`, `-`, `*`, `/`, `%`
+- String: `||` (concatenation)
+- Null: `IS NULL`, `IS NOT NULL`
+
+### Parameter Comparisons (bucket.* or token_parameters.*)
+
+Only `=` and `IN` supported:
+```yaml
+# Allowed
+WHERE user_id = bucket.user_id
+WHERE bucket.role IN roles_array
+
+# NOT allowed
+WHERE user_id > bucket.user_id
+WHERE upper(bucket.name) = column
+```
+
+## Not Supported
+
+- JOINs (in data queries)
+- GROUP BY, HAVING
+- ORDER BY, LIMIT, OFFSET, DISTINCT
+- Subqueries, CTEs
+- Window functions
+- `COALESCE()` - use `ifnull()` instead
+
+## Common Patterns
+
+### Personal Data
+
+```yaml
+bucket_definitions:
+  my_data:
+    parameters: SELECT request.user_id() AS user_id
+    data:
+      - SELECT * FROM notes WHERE owner_id = bucket.user_id
+      - SELECT * FROM settings WHERE user_id = bucket.user_id
+```
+
+### Team/Organization
+
+```yaml
+bucket_definitions:
+  team_data:
+    parameters: |
+      SELECT team_id FROM team_members
+      WHERE user_id = request.user_id()
+    data:
+      - SELECT * FROM projects WHERE team_id = bucket.team_id
+      - SELECT * FROM tasks WHERE team_id = bucket.team_id
+```
+
+### Role-Based Access
+
+```yaml
+bucket_definitions:
+  admin_data:
+    parameters: |
+      SELECT 1 AS is_admin FROM users
+      WHERE id = request.user_id() AND role = 'admin'
+    data:
+      - SELECT * FROM audit_logs WHERE bucket.is_admin = 1
+```
+
+### Global Data (all users)
+
+```yaml
+bucket_definitions:
+  global:
+    parameters: SELECT 'global' AS scope
+    data:
+      - SELECT * FROM app_config WHERE bucket.scope = 'global'
+```
+
+### Multi-Tenant Organization
+
+```yaml
+bucket_definitions:
+  org_data:
+    parameters: |
+      SELECT org_id
+      FROM users
+      WHERE id = request.user_id()
+    data:
+      - SELECT * FROM documents WHERE org_id = bucket.org_id
+      - SELECT * FROM folders WHERE org_id = bucket.org_id
+
+  # User's private data within org
+  private_data:
+    parameters: |
+      SELECT org_id, request.user_id() AS user_id
+      FROM users
+      WHERE id = request.user_id()
+    data:
+      - SELECT * FROM drafts WHERE org_id = bucket.org_id AND author_id = bucket.user_id
+```
+
+### JWT Claims
+
+```yaml
+bucket_definitions:
+  tenant_data:
+    parameters: |
+      SELECT request.jwt() ->> 'tenant_id' AS tenant_id
+    data:
+      - SELECT * FROM records WHERE tenant_id = bucket.tenant_id
+```

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,6 +11,10 @@
     "neon": {
       "type": "http",
       "url": "https://mcp.neon.tech/mcp"
+    },
+    "docs": {
+      "type": "http",
+      "url": "https://docs.powersync.com/mcp"
     }
   }
 }

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -46,5 +46,13 @@
         "source.organizeImports.biome": true
       }
     }
+  },
+  "context_servers": {
+    "docs": {
+      "source": "custom",
+      "type": "http",
+      "url": "https://docs.powersync.com/mcp",
+      "headers": {}
+    }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,6 +11,11 @@
       "sourceType": "github",
       "computedHash": "515ba75178bd44875812d9a560bdf14651f86709f89cf1d4f209638e879807f3"
     },
+    "powersync": {
+      "source": "powersync-ja/agent-skills",
+      "sourceType": "github",
+      "computedHash": "55734cdb9484980e5c0bfd10cdf201fd1ddfdc06ade5837294ebff21af6ab936"
+    },
     "shadcn": {
       "source": "shadcn/ui",
       "sourceType": "github",


### PR DESCRIPTION
## Summary

- Install the PowerSync agent skill (`powersync-ja/agent-skills`) for Claude Code with reference docs
- Register the PowerSync docs MCP server (`https://docs.powersync.com/mcp`) in `.mcp.json`
- Add PowerSync docs context server to Zed editor settings

## Test plan

- [ ] Verify `/powersync` skill is available in Claude Code
- [ ] Verify MCP docs server responds in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)