### PR TITLE
perf: cache ensureUserExists result to avoid per-request DB upsert

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import type { ReactElement, ReactNode } from "react";
-import { ensureUserExists } from "@/auth/ensure-user";
+import { getOrEnsureUserSettings } from "@/auth/ensure-user";
 import { auth } from "@/auth/server";
 import { AppSidebar } from "@/components/app-sidebar";
 import { HeaderTitle } from "@/components/header-title";
@@ -25,9 +25,10 @@ export default async function AppLayout({
     redirect("/auth/sign-in");
   }
 
-  // ensureUserExists is idempotent (INSERT ... ON CONFLICT DO UPDATE).
-  // Returns the user's persisted locale and theme for cookie restoration.
-  const settings = await ensureUserExists();
+  // Pass the pre-fetched session to avoid a duplicate auth.getSession() call.
+  // Uses a cookie cache to skip the DB upsert on repeat page loads.
+  // Falls through to ensureUserExists() when the cookie is absent or stale.
+  const settings = await getOrEnsureUserSettings(session);
 
   // Locale restoration from DB is handled client-side by LocaleRestorer
   // (rendered below). Server Components cannot reliably set cookies in
@@ -37,7 +38,11 @@ export default async function AppLayout({
     <PowerSyncProvider>
       <SyncErrorToaster />
       {settings && (
-        <SettingsRestorer dbLocale={settings.locale} dbTheme={settings.theme} />
+        <SettingsRestorer
+          dbLocale={settings.locale}
+          dbTheme={settings.theme}
+          userId={session.user.id}
+        />
       )}
       <SidebarProvider>
         <AppSidebar />

--- a/src/app/(app)/settings/actions.test.ts
+++ b/src/app/(app)/settings/actions.test.ts
@@ -16,6 +16,12 @@ const unauthenticatedSession: MockSession = {
 
 vi.mock("server-only", () => ({}));
 
+const mockCookieDelete = vi.fn();
+const mockCookies = vi.fn().mockResolvedValue({ delete: mockCookieDelete });
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}));
+
 vi.mock("@/auth/server", () => ({
   auth: {
     getSession: vi.fn().mockResolvedValue(authenticatedSession),
@@ -122,6 +128,22 @@ describe("settings server actions", () => {
       await updateLocale("zz");
       expect(mockUpdate).not.toHaveBeenCalled();
     });
+
+    it("deletes the user-synced cookie on successful update", async () => {
+      const { updateLocale } = await import("./actions");
+      await updateLocale("fr");
+
+      expect(mockCookieDelete).toHaveBeenCalledWith("user-synced");
+    });
+
+    it("does not delete the user-synced cookie on failure", async () => {
+      mockUpdateReturning.mockRejectedValueOnce(new Error("DB error"));
+
+      const { updateLocale } = await import("./actions");
+      await updateLocale("fr");
+
+      expect(mockCookieDelete).not.toHaveBeenCalled();
+    });
   });
 
   describe("updateTheme", () => {
@@ -192,6 +214,22 @@ describe("settings server actions", () => {
       const { updateTheme } = await import("./actions");
       await updateTheme("invalid");
       expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("deletes the user-synced cookie on successful update", async () => {
+      const { updateTheme } = await import("./actions");
+      await updateTheme("dark");
+
+      expect(mockCookieDelete).toHaveBeenCalledWith("user-synced");
+    });
+
+    it("does not delete the user-synced cookie on failure", async () => {
+      mockUpdateReturning.mockRejectedValueOnce(new Error("DB error"));
+
+      const { updateTheme } = await import("./actions");
+      await updateTheme("dark");
+
+      expect(mockCookieDelete).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -2,7 +2,9 @@
 
 import "server-only";
 import { eq } from "drizzle-orm";
+import { cookies } from "next/headers";
 import { auth } from "@/auth/server";
+import { USER_SYNCED_COOKIE } from "@/auth/sync-cookie";
 import { getDb } from "@/db";
 import { users } from "@/db/schema/users";
 import type { Locale } from "@/i18n/config";
@@ -41,6 +43,9 @@ export async function updateLocale(locale: string): Promise<ActionResult> {
       return { success: false, error: "User not found" };
     }
 
+    // Invalidate the user-synced cache so the next page load re-reads from DB
+    (await cookies()).delete(USER_SYNCED_COOKIE);
+
     return { success: true };
   } catch (error: unknown) {
     console.error("Failed to update locale:", {
@@ -77,6 +82,9 @@ export async function updateTheme(theme: string): Promise<ActionResult> {
     if (rows.length === 0) {
       return { success: false, error: "User not found" };
     }
+
+    // Invalidate the user-synced cache so the next page load re-reads from DB
+    (await cookies()).delete(USER_SYNCED_COOKIE);
 
     return { success: true };
   } catch (error: unknown) {

--- a/src/auth/ensure-user.test.ts
+++ b/src/auth/ensure-user.test.ts
@@ -7,6 +7,12 @@ vi.mock("next/server", () => ({
   after: mockAfter,
 }));
 
+const mockCookieGet = vi.fn();
+const mockCookies = vi.fn().mockResolvedValue({ get: mockCookieGet });
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}));
+
 const mockReturning = vi.fn().mockResolvedValue([
   {
     id: "user-1",
@@ -330,5 +336,96 @@ describe("ensureUserExists", () => {
     );
 
     consoleSpy.mockRestore();
+  });
+});
+
+describe("getOrEnsureUserSettings", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns cached settings from cookie when userId matches (fast path)", async () => {
+    const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {},
+        user: { id: uuid, email: "test@example.com", name: "Test User" },
+      },
+    });
+    mockCookieGet.mockReturnValue({ value: `${uuid}|fr|dark` });
+
+    const { getOrEnsureUserSettings } = await import("@/auth/ensure-user");
+    const result = await getOrEnsureUserSettings();
+
+    expect(result).toEqual({ locale: "fr", theme: "dark" });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("falls through to ensureUserExists when no cookie exists (slow path)", async () => {
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {},
+        user: { id: "user-1", email: "test@example.com", name: "Test User" },
+      },
+    });
+    mockCookieGet.mockReturnValue(undefined);
+
+    const { getOrEnsureUserSettings } = await import("@/auth/ensure-user");
+    const result = await getOrEnsureUserSettings();
+
+    expect(result).toEqual({ locale: "en", theme: "system" });
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
+  it("falls through to ensureUserExists when userId mismatches", async () => {
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {},
+        user: {
+          id: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+          email: "other@example.com",
+          name: "Other",
+        },
+      },
+    });
+    mockCookieGet.mockReturnValue({
+      value: "a1b2c3d4-e5f6-7890-abcd-ef1234567890|en|system",
+    });
+
+    const { getOrEnsureUserSettings } = await import("@/auth/ensure-user");
+    const result = await getOrEnsureUserSettings();
+
+    expect(mockInsert).toHaveBeenCalled();
+    expect(result).toEqual({ locale: "en", theme: "system" });
+  });
+
+  it("falls through to ensureUserExists when cookie is malformed", async () => {
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {},
+        user: { id: "user-1", email: "test@example.com", name: "Test User" },
+      },
+    });
+    mockCookieGet.mockReturnValue({ value: "garbage" });
+
+    const { getOrEnsureUserSettings } = await import("@/auth/ensure-user");
+    const result = await getOrEnsureUserSettings();
+
+    expect(mockInsert).toHaveBeenCalled();
+    expect(result).toEqual({ locale: "en", theme: "system" });
+  });
+
+  it("returns null when there is no session", async () => {
+    mockGetSession.mockResolvedValue({ data: null });
+
+    const { getOrEnsureUserSettings } = await import("@/auth/ensure-user");
+    const result = await getOrEnsureUserSettings();
+
+    expect(result).toBeNull();
+    expect(mockInsert).not.toHaveBeenCalled();
   });
 });

--- a/src/auth/ensure-user.ts
+++ b/src/auth/ensure-user.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { sql } from "drizzle-orm";
+import { cookies } from "next/headers";
 import { after } from "next/server";
 import { getDb } from "@/db";
 import { userPreferences } from "@/db/schema/user-preferences";
@@ -10,6 +11,7 @@ import { sendWelcomeEmail } from "@/lib/email";
 import type { Theme } from "@/lib/theme";
 import { isTheme } from "@/lib/theme";
 import { auth } from "./server";
+import { parseSyncCookie, USER_SYNCED_COOKIE } from "./sync-cookie";
 
 /** Persisted user settings needed by the app layout for locale/theme restoration. */
 interface UserSettings {
@@ -26,6 +28,11 @@ interface UpsertResult {
   xmax: string;
 }
 
+/** Session shape derived from Neon Auth — stays in sync with library updates. */
+type SessionData = NonNullable<
+  Awaited<ReturnType<typeof auth.getSession>>["data"]
+>;
+
 /**
  * Ensures the authenticated user exists in the `public.users` table and
  * that a corresponding `user_preferences` row exists.
@@ -40,8 +47,10 @@ interface UpsertResult {
  * Returns the user's persisted locale and theme so the app layout can
  * restore them into cookies/headers on new device login.
  */
-export async function ensureUserExists(): Promise<UserSettings | null> {
-  const { data: session } = await auth.getSession();
+export async function ensureUserExists(
+  prefetchedSession?: SessionData
+): Promise<UserSettings | null> {
+  const session = prefetchedSession ?? (await auth.getSession()).data;
 
   if (!session?.user) {
     return null;
@@ -144,6 +153,42 @@ export async function ensureUserExists(): Promise<UserSettings | null> {
     locale: isLocale(row.locale) ? row.locale : defaultLocale,
     theme: isTheme(row.theme) ? row.theme : "system",
   };
+}
+
+/**
+ * Returns user settings, using a cookie cache to avoid per-request DB upserts.
+ *
+ * Fast path: If the `user-synced` cookie exists and its userId matches the
+ * current session, returns cached locale/theme without touching the database.
+ *
+ * Slow path: Falls through to `ensureUserExists()` for the full DB upsert
+ * (first login, different user, expired/malformed cookie).
+ *
+ * Called once per request from the app layout, which passes its pre-fetched
+ * session to avoid duplicate `auth.getSession()` calls.
+ */
+export async function getOrEnsureUserSettings(
+  prefetchedSession?: SessionData
+): Promise<UserSettings | null> {
+  const session = prefetchedSession ?? (await auth.getSession()).data;
+
+  if (!session?.user?.id) {
+    return null;
+  }
+
+  const cookieStore = await cookies();
+  const syncCookie = cookieStore.get(USER_SYNCED_COOKIE)?.value;
+
+  if (syncCookie) {
+    const parsed = parseSyncCookie(syncCookie);
+    if (parsed && parsed.userId === session.user.id) {
+      return { locale: parsed.locale, theme: parsed.theme };
+    }
+  }
+
+  // Cookie absent, mismatched, or malformed — fall through to DB upsert.
+  // Pass the pre-fetched session to avoid a duplicate auth.getSession() call.
+  return ensureUserExists(session);
 }
 
 export type { UserSettings };

--- a/src/auth/sync-cookie.test.ts
+++ b/src/auth/sync-cookie.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { buildSyncCookieValue, parseSyncCookie } from "./sync-cookie";
+
+const TEST_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+describe("buildSyncCookieValue", () => {
+  it("joins userId, locale, and theme with pipe delimiter", () => {
+    expect(buildSyncCookieValue(TEST_UUID, "en", "dark")).toBe(
+      `${TEST_UUID}|en|dark`
+    );
+  });
+
+  it("handles different locale and theme values", () => {
+    expect(buildSyncCookieValue(TEST_UUID, "fr", "system")).toBe(
+      `${TEST_UUID}|fr|system`
+    );
+  });
+});
+
+describe("parseSyncCookie", () => {
+  it("parses a valid cookie value", () => {
+    expect(parseSyncCookie(`${TEST_UUID}|en|dark`)).toEqual({
+      userId: TEST_UUID,
+      locale: "en",
+      theme: "dark",
+    });
+  });
+
+  it("parses all valid locales", () => {
+    for (const locale of ["en", "fr", "es", "pt", "it", "de", "nl"]) {
+      const result = parseSyncCookie(`${TEST_UUID}|${locale}|system`);
+      expect(result).toEqual({
+        userId: TEST_UUID,
+        locale,
+        theme: "system",
+      });
+    }
+  });
+
+  it("parses all valid themes", () => {
+    for (const theme of ["light", "dark", "system"]) {
+      const result = parseSyncCookie(`${TEST_UUID}|en|${theme}`);
+      expect(result).toEqual({
+        userId: TEST_UUID,
+        locale: "en",
+        theme,
+      });
+    }
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseSyncCookie("")).toBeNull();
+  });
+
+  it("returns null for too few parts", () => {
+    expect(parseSyncCookie(`${TEST_UUID}|en`)).toBeNull();
+  });
+
+  it("returns null for too many parts", () => {
+    expect(parseSyncCookie(`${TEST_UUID}|en|dark|extra`)).toBeNull();
+  });
+
+  it("returns null for invalid locale", () => {
+    expect(parseSyncCookie(`${TEST_UUID}|xx|dark`)).toBeNull();
+  });
+
+  it("returns null for invalid theme", () => {
+    expect(parseSyncCookie(`${TEST_UUID}|en|neon`)).toBeNull();
+  });
+
+  it("returns null when userId is empty", () => {
+    expect(parseSyncCookie("|en|dark")).toBeNull();
+  });
+
+  it("returns null when userId is not a valid UUID", () => {
+    expect(parseSyncCookie("not-a-uuid|en|dark")).toBeNull();
+  });
+
+  it("accepts uppercase UUID", () => {
+    const upper = TEST_UUID.toUpperCase();
+    expect(parseSyncCookie(`${upper}|en|dark`)).toEqual({
+      userId: upper,
+      locale: "en",
+      theme: "dark",
+    });
+  });
+});

--- a/src/auth/sync-cookie.ts
+++ b/src/auth/sync-cookie.ts
@@ -1,0 +1,50 @@
+import type { Locale } from "@/i18n/config";
+import { isLocale } from "@/i18n/config";
+import type { Theme } from "@/lib/theme";
+import { isTheme } from "@/lib/theme";
+
+/** Cookie name for the user-synced sentinel. */
+export const USER_SYNCED_COOKIE = "user-synced";
+
+/** Seven days in seconds. */
+export const USER_SYNCED_MAX_AGE = 60 * 60 * 24 * 7;
+
+/** Delimiter used in the cookie value. */
+const COOKIE_DELIMITER = "|";
+
+/** UUID v4 format (case-insensitive) — defense-in-depth for cookie parsing. */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Builds the cookie value string for the user-synced sentinel. */
+export function buildSyncCookieValue(
+  userId: string,
+  locale: Locale,
+  theme: Theme
+): string {
+  return [userId, locale, theme].join(COOKIE_DELIMITER);
+}
+
+/**
+ * Parses the user-synced cookie value into its components.
+ * Returns null if the value is malformed or contains invalid locale/theme.
+ */
+export function parseSyncCookie(
+  value: string
+): { userId: string; locale: Locale; theme: Theme } | null {
+  const parts = value.split(COOKIE_DELIMITER);
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const [userId, rawLocale, rawTheme] = parts;
+  if (!(userId && rawLocale && rawTheme && UUID_RE.test(userId))) {
+    return null;
+  }
+
+  if (!(isLocale(rawLocale) && isTheme(rawTheme))) {
+    return null;
+  }
+
+  return { userId, locale: rawLocale, theme: rawTheme };
+}

--- a/src/features/settings/components/settings-restorer.test.tsx
+++ b/src/features/settings/components/settings-restorer.test.tsx
@@ -77,11 +77,13 @@ describe("SettingsRestorer", () => {
     // Clear any cookies set during the test via the restored native descriptor
     // biome-ignore lint/suspicious/noDocumentCookie: test cleanup requires direct cookie manipulation to expire test cookies
     document.cookie = "NEXT_LOCALE=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    // biome-ignore lint/suspicious/noDocumentCookie: test cleanup requires direct cookie manipulation to expire test cookies
+    document.cookie = "user-synced=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
     localStorageStub.clear();
   });
 
   it("restores locale from DB when no cookie exists and locale is non-default", () => {
-    render(<SettingsRestorer dbLocale="fr" dbTheme="system" />);
+    render(<SettingsRestorer dbLocale="fr" dbTheme="system" userId="user-1" />);
 
     // Should set the cookie from DB value
     expect(document.cookie).toContain("NEXT_LOCALE=fr");
@@ -90,7 +92,7 @@ describe("SettingsRestorer", () => {
   });
 
   it("sets cookie and refreshes when DB locale is 'en' and no cookie exists", () => {
-    render(<SettingsRestorer dbLocale="en" dbTheme="system" />);
+    render(<SettingsRestorer dbLocale="en" dbTheme="system" userId="user-1" />);
 
     // Cookie IS set (so Accept-Language negotiation doesn't override explicit "en")
     expect(document.cookie).toContain("NEXT_LOCALE=en");
@@ -105,7 +107,7 @@ describe("SettingsRestorer", () => {
       value: "NEXT_LOCALE=es",
     });
 
-    render(<SettingsRestorer dbLocale="en" dbTheme="system" />);
+    render(<SettingsRestorer dbLocale="en" dbTheme="system" userId="user-1" />);
 
     expect(mockUpdateLocale).toHaveBeenCalledWith("es");
   });
@@ -116,42 +118,65 @@ describe("SettingsRestorer", () => {
       value: "NEXT_LOCALE=fr",
     });
 
-    render(<SettingsRestorer dbLocale="fr" dbTheme="system" />);
+    render(<SettingsRestorer dbLocale="fr" dbTheme="system" userId="user-1" />);
 
     expect(mockUpdateLocale).not.toHaveBeenCalled();
   });
 
   it("restores theme from DB when no local theme is set", () => {
-    render(<SettingsRestorer dbLocale="en" dbTheme="dark" />);
+    render(<SettingsRestorer dbLocale="en" dbTheme="dark" userId="user-1" />);
 
     expect(mockSetTheme).toHaveBeenCalledWith("dark");
   });
 
   it("does not restore theme when DB theme is system (default)", () => {
-    render(<SettingsRestorer dbLocale="en" dbTheme="system" />);
+    render(<SettingsRestorer dbLocale="en" dbTheme="system" userId="user-1" />);
 
     expect(mockSetTheme).not.toHaveBeenCalled();
   });
 
   it("does not sync theme when localStorage matches DB", () => {
     localStorageStore.theme = "dark";
-    render(<SettingsRestorer dbLocale="en" dbTheme="dark" />);
+    render(<SettingsRestorer dbLocale="en" dbTheme="dark" userId="user-1" />);
     expect(mockUpdateTheme).not.toHaveBeenCalled();
   });
 
   it("syncs offline theme change from localStorage to DB when they differ", () => {
     localStorageStore.theme = "dark";
 
-    render(<SettingsRestorer dbLocale="en" dbTheme="light" />);
+    render(<SettingsRestorer dbLocale="en" dbTheme="light" userId="user-1" />);
 
     expect(mockUpdateTheme).toHaveBeenCalledWith("dark");
   });
 
   it("renders nothing (returns null)", () => {
     const { container } = render(
-      <SettingsRestorer dbLocale="en" dbTheme="system" />
+      <SettingsRestorer dbLocale="en" dbTheme="system" userId="user-1" />
     );
 
     expect(container.innerHTML).toBe("");
+  });
+
+  it("sets user-synced cookie after sync", () => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "NEXT_LOCALE=en",
+    });
+
+    render(<SettingsRestorer dbLocale="en" dbTheme="system" userId="user-1" />);
+
+    expect(document.cookie).toContain("user-synced=user-1|en|system");
+  });
+
+  it("sets user-synced cookie with resolved locale from offline change", () => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "NEXT_LOCALE=es",
+    });
+
+    render(<SettingsRestorer dbLocale="en" dbTheme="dark" userId="user-1" />);
+
+    // Locale should be the cookie value (local wins on offline change)
+    expect(document.cookie).toContain("user-synced=user-1|es|dark");
   });
 });

--- a/src/features/settings/components/settings-restorer.tsx
+++ b/src/features/settings/components/settings-restorer.tsx
@@ -5,14 +5,22 @@ import { useTheme } from "next-themes";
 import { type ReactElement, useEffect } from "react";
 import { updateLocale, updateTheme } from "@/app/(app)/settings/actions";
 import {
+  buildSyncCookieValue,
+  USER_SYNCED_COOKIE,
+  USER_SYNCED_MAX_AGE,
+} from "@/auth/sync-cookie";
+import {
   getLocaleCookie,
   setLocaleCookie,
 } from "@/features/settings/locale-cookie";
 import { isLocale, type Locale } from "@/i18n/config";
 import { isTheme, type Theme } from "@/lib/theme";
 
-/** Sync locale between cookie and DB. Returns true if a page refresh is needed. */
-function syncLocale(dbLocale: Locale): boolean {
+/** Sync locale between cookie and DB. Returns the resolved locale and whether a refresh is needed. */
+function syncLocale(dbLocale: Locale): {
+  locale: Locale;
+  needsRefresh: boolean;
+} {
   const cookieLocale = getLocaleCookie();
 
   if (!cookieLocale) {
@@ -22,7 +30,7 @@ function syncLocale(dbLocale: Locale): boolean {
     // Always refresh: the server may have negotiated a different locale via
     // Accept-Language (e.g., user chose "en" but browser sends "fr"). The
     // cookie won't take effect until the next request.
-    return true;
+    return { locale: dbLocale, needsRefresh: true };
   }
 
   if (isLocale(cookieLocale) && cookieLocale !== dbLocale) {
@@ -30,32 +38,49 @@ function syncLocale(dbLocale: Locale): boolean {
     updateLocale(cookieLocale).catch(() => {
       // Still offline — will retry on next mount
     });
+    return { locale: cookieLocale, needsRefresh: false };
   }
 
-  return false;
+  return { locale: dbLocale, needsRefresh: false };
 }
 
-/** Sync theme between localStorage/next-themes and DB. */
-function syncTheme(dbTheme: Theme, setTheme: (theme: string) => void): void {
+/** Sync theme between localStorage/next-themes and DB. Returns the resolved theme. */
+function syncTheme(dbTheme: Theme, setTheme: (theme: string) => void): Theme {
   const storedTheme = localStorage.getItem("theme");
 
   if (!storedTheme || storedTheme === "system") {
     if (dbTheme !== "system") {
       setTheme(dbTheme);
     }
-    return;
+    return dbTheme;
   }
 
   if (isTheme(storedTheme) && storedTheme !== dbTheme) {
     updateTheme(storedTheme).catch(() => {
       // Still offline — will retry on next mount
     });
+    return storedTheme;
   }
+
+  return dbTheme;
+}
+
+/** Sets the user-synced cookie with the resolved settings. */
+function setUserSyncedCookie(
+  userId: string,
+  locale: Locale,
+  theme: Theme
+): void {
+  const secure = location.protocol === "https:" ? ";secure" : "";
+
+  // biome-ignore lint/suspicious/noDocumentCookie: document.cookie is the standard API for setting cookies client-side
+  document.cookie = `${USER_SYNCED_COOKIE}=${buildSyncCookieValue(userId, locale, theme)};path=/;max-age=${USER_SYNCED_MAX_AGE};samesite=lax${secure}`;
 }
 
 interface SettingsRestorerProps {
   dbLocale: Locale;
   dbTheme: Theme;
+  userId: string;
 }
 
 /**
@@ -71,9 +96,13 @@ interface SettingsRestorerProps {
  *    The user changed the setting while offline and the server action failed.
  *    Syncs local → DB so the preference persists across devices.
  *
+ * After syncing, sets the `user-synced` cookie so subsequent page loads can
+ * skip the DB upsert in `getOrEnsureUserSettings()`.
+ *
  * Runs once on mount — after that, LocaleSelector / ThemeSelector manage changes.
  */
 export function SettingsRestorer({
+  userId,
   dbLocale,
   dbTheme,
 }: SettingsRestorerProps): ReactElement | null {
@@ -82,8 +111,10 @@ export function SettingsRestorer({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: runs once on mount — props are stable from server render, setTheme is stable from next-themes
   useEffect(() => {
-    const needsRefresh = syncLocale(dbLocale);
-    syncTheme(dbTheme, setTheme);
+    const { locale: resolvedLocale, needsRefresh } = syncLocale(dbLocale);
+    const resolvedTheme = syncTheme(dbTheme, setTheme);
+
+    setUserSyncedCookie(userId, resolvedLocale, resolvedTheme);
 
     if (needsRefresh) {
       router.refresh();


### PR DESCRIPTION
## Summary

- Add a `user-synced` cookie sentinel that caches the authenticated user's locale/theme settings after the first successful `ensureUserExists()` call
- On subsequent page loads, `getOrEnsureUserSettings()` returns cached settings from the cookie without touching the database — **reducing authenticated page loads from 2 DB queries to 0**
- Cookie is invalidated when the user changes settings (locale/theme) and expires after 7 days for periodic re-validation
- Eliminates duplicate `auth.getSession()` calls by threading the pre-fetched session through the call chain
- Derives `SessionData` type from Neon Auth's return type to stay in sync with library updates
- UUID format validation + locale/theme type guards on cookie parse for defense-in-depth

### Cookie lifecycle
| Event | Behavior |
|---|---|
| First login | No cookie → full DB upsert → SettingsRestorer sets cookie |
| Subsequent loads | Cookie hit → 0 DB queries |
| Settings change | Server action deletes cookie → next load re-reads from DB |
| Sign out + new user | userId mismatch → falls through to DB upsert |
| Cookie expires (7d) | Periodic re-validation via DB upsert |

Closes #63

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes (0 issues)
- [x] `pnpm test:run` — 665/665 tests pass
- [x] 4 review passes with 9 reviewer agents (typescript, security, node-api) — 5 findings found and fixed, final pass clean
- [ ] Manual: sign in → first load hits DB → subsequent navigations skip DB → change locale → next load re-reads from DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)