### PR TITLE
fix(e2e): enable PWA offline tests against localhost production build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,39 @@ jobs:
           NEON_AUTH_COOKIE_SECRET: ci-dummy-secret-that-is-at-least-32-characters-long
           EMAIL_HMAC_SECRET: ci-dummy-hmac-secret-at-least-32-characters-long
           DATABASE_URL: postgresql://unused:unused@localhost:5432/unused
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm exec playwright --version)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Run PWA E2E tests
+        run: pnpm exec playwright test --project=pwa
+        env:
+          PLAYWRIGHT_SKIP_BUILD: "1"
+          NEON_AUTH_BASE_URL: http://localhost:4000
+          NEON_AUTH_COOKIE_SECRET: ci-dummy-secret-that-is-at-least-32-characters-long
+          EMAIL_HMAC_SECRET: ci-dummy-hmac-secret-at-least-32-characters-long
+          DATABASE_URL: postgresql://unused:unused@localhost:5432/unused
+
+      - name: Upload PWA test report
+        if: '!cancelled()'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: pwa-playwright-report-${{ github.sha }}
+          path: playwright-report/
+          retention-days: 30

--- a/e2e/pwa-offline.spec.ts
+++ b/e2e/pwa-offline.spec.ts
@@ -1,56 +1,137 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
-// These tests require a production build served over HTTPS — the service worker
-// caches /_next/static/* assets which are unstable in dev mode. In CI they run
-// against Vercel preview deployments (production build + HTTPS). Locally, skip
-// unless BASE_URL points to a deployed target.
+// These tests run in the "pwa" Playwright project which only exists when
+// BASE_URL is not set (i.e., running against localhost with a production build).
+// They are excluded from Vercel preview runs where Deployment Protection
+// interferes with SW activation (clients.claim() never completes).
 //
 // NOTE: Full offline-navigation tests (verifying SW serves cached pages when
-// offline) are not feasible in Playwright because:
-// 1. Chromium's Network.emulateNetworkConditions bypasses SW fetch events
-// 2. Vercel Deployment Protection's bypass header interferes with clients.claim()
-// These are tested by verifying the SW activates and correct caches exist.
+// offline) are not feasible in Playwright because Chromium's
+// Network.emulateNetworkConditions bypasses SW fetch events entirely, and
+// page.route() does not intercept requests handled by Service Workers.
+// Instead, we verify the SW activates and populates the correct caches.
+
+/**
+ * Manually register and wait for the service worker to activate.
+ *
+ * The app's SW registration lives in push-notifications.tsx (authenticated
+ * layout only), so the marketing landing page doesn't trigger it.
+ * Tests call navigator.serviceWorker.register() directly.
+ */
+async function registerAndActivateSW(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const reg = await navigator.serviceWorker.register("/sw.js", {
+      scope: "/",
+      updateViaCache: "none",
+    });
+
+    const sw = reg.installing ?? reg.waiting ?? reg.active;
+    if (!sw) {
+      throw new Error("No SW found after registration");
+    }
+    if (sw.state === "activated") {
+      return;
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error(`SW stuck in "${sw.state}" state`)),
+        15_000
+      );
+      sw.addEventListener("statechange", () => {
+        if (sw.state === "activated") {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    });
+  });
+}
+
+/**
+ * Wait for the SW to become the page's controller via clients.claim().
+ */
+async function waitForController(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    if (navigator.serviceWorker.controller) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("SW controller not claimed within 15 s")),
+        15_000
+      );
+      navigator.serviceWorker.addEventListener(
+        "controllerchange",
+        () => {
+          clearTimeout(timeout);
+          resolve();
+        },
+        { once: true }
+      );
+    });
+  });
+}
 
 test.describe("PWA offline resilience", () => {
-  // SW activation fails on Vercel preview deployments — deployment protection
-  // interferes with the SW script fetch and/or clients.claim(). Tracked in #94.
-  test.skip(
-    true,
-    "SW activation blocked by Vercel deployment protection — see #94"
-  );
-
   test("service worker registers and activates", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator("main#main-content")).toBeVisible();
 
-    // Wait for the SW to reach the "activated" state
-    const swState = await page.waitForFunction(
-      async () => {
-        const reg = await navigator.serviceWorker.getRegistration();
-        return reg?.active ? "activated" : null;
-      },
-      { timeout: 15_000 }
-    );
+    await registerAndActivateSW(page);
 
-    expect(await swState.jsonValue()).toBe("activated");
+    // After activate, clients.claim() should make the SW the controller
+    await waitForController(page);
+
+    const hasController = await page.evaluate(
+      () => navigator.serviceWorker.controller != null
+    );
+    expect(hasController).toBe(true);
   });
 
   test("expected caches are created", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator("main#main-content")).toBeVisible();
 
-    // Wait for SW to activate
-    await page.waitForFunction(
-      async () => {
-        const reg = await navigator.serviceWorker.getRegistration();
-        return reg?.active != null;
-      },
-      { timeout: 15_000 }
-    );
+    await registerAndActivateSW(page);
+    await waitForController(page);
 
-    // SW's activate handler creates the expected caches
+    // Navigate so the SW fetch handler intercepts requests and populates caches
+    await page.goto("/");
+    await expect(page.locator("main#main-content")).toBeVisible();
+
     const cacheNames = await page.evaluate(() => caches.keys());
     expect(cacheNames).toContain("static-v1");
     expect(cacheNames).toContain("pages-v1");
+  });
+
+  test("static assets are cached after navigation", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("main#main-content")).toBeVisible();
+
+    await registerAndActivateSW(page);
+    await waitForController(page);
+
+    // Navigate again — SW fetch handler intercepts and caches the response
+    await page.goto("/");
+    await expect(page.locator("main#main-content")).toBeVisible();
+
+    const cacheInfo = await page.evaluate(async () => {
+      const staticCache = await caches.open("static-v1");
+      const pagesCache = await caches.open("pages-v1");
+      const staticKeys = await staticCache.keys();
+      const pagesKeys = await pagesCache.keys();
+      return {
+        staticCount: staticKeys.length,
+        pagesCount: pagesKeys.length,
+        hasNextStatic: staticKeys.some((r) =>
+          new URL(r.url).pathname.startsWith("/_next/static/")
+        ),
+      };
+    });
+
+    expect(cacheInfo.staticCount).toBeGreaterThan(0);
+    expect(cacheInfo.pagesCount).toBeGreaterThan(0);
+    expect(cacheInfo.hasNextStatic).toBe(true);
   });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,18 @@ const hasVercelBypass = !!(
   process.env.BASE_URL && process.env.VERCEL_AUTOMATION_BYPASS_SECRET
 );
 
+// In CI, PLAYWRIGHT_SKIP_BUILD reuses the .next/ output from an earlier step.
+// Without it, build + start from scratch. Locally, use the Turbopack dev server.
+function webServerCommand(): string {
+  if (!process.env.CI) {
+    return "pnpm dev";
+  }
+  if (process.env.PLAYWRIGHT_SKIP_BUILD) {
+    return "pnpm start";
+  }
+  return "pnpm build && pnpm start";
+}
+
 export default defineConfig({
   testDir: "./e2e",
   globalSetup: "./e2e/global-setup.ts",
@@ -36,11 +48,11 @@ export default defineConfig({
       name: "setup",
       testMatch: /auth\.setup\.ts/,
     },
-    // Unauthenticated tests — smoke, auth redirects, PWA
+    // Unauthenticated tests — smoke, auth redirects
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
-      testIgnore: /settings-.*\.spec\.ts/,
+      testIgnore: /settings-.*\.spec\.ts|pwa-offline\.spec\.ts/,
     },
     // Authenticated tests — settings, locale, theme
     {
@@ -52,12 +64,24 @@ export default defineConfig({
       testMatch: /settings-.*\.spec\.ts/,
       dependencies: ["setup"],
     },
+    // PWA tests — SW registration, activation, cache verification.
+    // Only runs on localhost (production build); excluded from Vercel previews
+    // where Deployment Protection blocks SW activation.
+    ...(process.env.BASE_URL
+      ? []
+      : [
+          {
+            name: "pwa",
+            use: { ...devices["Desktop Chrome"] },
+            testMatch: /pwa-offline\.spec\.ts/,
+          },
+        ]),
   ],
   // When BASE_URL is set (e.g., Vercel preview), skip the local dev server
   webServer: process.env.BASE_URL
     ? undefined
     : {
-        command: process.env.CI ? "pnpm build && pnpm start" : "pnpm dev",
+        command: webServerCommand(),
         url: "http://localhost:3000",
         reuseExistingServer: !process.env.CI,
       },


### PR DESCRIPTION
## Summary

- Enable the previously-skipped PWA E2E tests (`e2e/pwa-offline.spec.ts`) by running them against a localhost production build instead of Vercel preview deployments where Deployment Protection blocks SW activation
- Add a `pwa` Playwright project (only present when `BASE_URL` is not set) that manually registers the service worker and verifies activation, controller claim, cache creation, and static asset caching
- Add Playwright browser install, caching, and PWA E2E test step to `ci.yml` after the existing build step, reusing the `.next/` output via `PLAYWRIGHT_SKIP_BUILD`
- Upload test report artifact on failure for debugging

Closes #94

## Test plan

- [x] `pnpm exec playwright test --project=pwa` — all 3 tests pass locally
- [x] `pnpm lint` — clean
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test:run` — 665/665 pass
- [ ] CI passes (Playwright install + PWA E2E step runs successfully)
- [ ] Verify `pwa` project is excluded from Vercel preview runs (`e2e.yml` sets `BASE_URL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)