### PR TITLE
feat: add deleted_at column to users table for soft-delete consistency

### DIFF
--- a/src/app/(app)/settings/actions.test.ts
+++ b/src/app/(app)/settings/actions.test.ts
@@ -29,7 +29,12 @@ vi.mock("@/auth/server", () => ({
 }));
 
 vi.mock("@/db/schema/users", () => ({
-  users: { id: "id", locale: "locale", theme: "theme" },
+  users: {
+    id: "id",
+    locale: "locale",
+    theme: "theme",
+    deletedAt: "deleted_at",
+  },
 }));
 
 const mockUpdateReturning = vi.fn().mockResolvedValue([{ id: "test-user" }]);
@@ -144,6 +149,14 @@ describe("settings server actions", () => {
 
       expect(mockCookieDelete).not.toHaveBeenCalled();
     });
+
+    it("returns error when user is soft-deleted", async () => {
+      mockUpdateReturning.mockResolvedValueOnce([]);
+
+      const { updateLocale } = await import("./actions");
+      const result = await updateLocale("fr");
+      expect(result).toEqual({ success: false, error: "User not found" });
+    });
   });
 
   describe("updateTheme", () => {
@@ -231,6 +244,14 @@ describe("settings server actions", () => {
 
       expect(mockCookieDelete).not.toHaveBeenCalled();
     });
+
+    it("returns error when user is soft-deleted", async () => {
+      mockUpdateReturning.mockResolvedValueOnce([]);
+
+      const { updateTheme } = await import("./actions");
+      const result = await updateTheme("dark");
+      expect(result).toEqual({ success: false, error: "User not found" });
+    });
   });
 
   describe("getUserSettings", () => {
@@ -295,6 +316,14 @@ describe("settings server actions", () => {
       const { getUserSettings } = await import("./actions");
       await getUserSettings();
       expect(mockSelect).not.toHaveBeenCalled();
+    });
+
+    it("returns null when user is soft-deleted", async () => {
+      mockSelectLimit.mockResolvedValueOnce([]);
+
+      const { getUserSettings } = await import("./actions");
+      const result = await getUserSettings();
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import "server-only";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { cookies } from "next/headers";
 import { auth } from "@/auth/server";
 import { USER_SYNCED_COOKIE } from "@/auth/sync-cookie";
@@ -36,7 +36,7 @@ export async function updateLocale(locale: string): Promise<ActionResult> {
     const rows = await db
       .update(users)
       .set({ locale })
-      .where(eq(users.id, session.user.id))
+      .where(and(eq(users.id, session.user.id), isNull(users.deletedAt)))
       .returning({ id: users.id });
 
     if (rows.length === 0) {
@@ -76,7 +76,7 @@ export async function updateTheme(theme: string): Promise<ActionResult> {
     const rows = await db
       .update(users)
       .set({ theme })
-      .where(eq(users.id, session.user.id))
+      .where(and(eq(users.id, session.user.id), isNull(users.deletedAt)))
       .returning({ id: users.id });
 
     if (rows.length === 0) {
@@ -114,7 +114,7 @@ export async function getUserSettings(): Promise<{
     const [row] = await db
       .select({ locale: users.locale, theme: users.theme })
       .from(users)
-      .where(eq(users.id, session.user.id))
+      .where(and(eq(users.id, session.user.id), isNull(users.deletedAt)))
       .limit(1);
 
     if (!row) {

--- a/src/app/api/cron/cleanup/route.test.ts
+++ b/src/app/api/cron/cleanup/route.test.ts
@@ -125,7 +125,7 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
-      // 9 DELETE queries (no transaction wrapping)
+      // 9 pre-pass UPDATEs + 9 main DELETEs + 1 user DELETE = 19 queries
       mockQuery.mockResolvedValue({ rowCount: 2 });
 
       const response = await GET(createRequest("Bearer test-cron-secret"));
@@ -133,15 +133,16 @@ describe("GET /api/cron/cleanup", () => {
       expect(response.status).toBe(200);
       const body = await response.json();
       expect(body.success).toBe(true);
-      expect(body.totalDeleted).toBe(18); // 9 tables x 2 rows each
+      // 9 main tables + 1 user delete = 10 results, each with rowCount 2
+      expect(body.totalDeleted).toBe(20);
 
       expect(body.errorsCount).toBe(0);
       // No internal table names should be exposed
       expect(body.deleted).toBeUndefined();
       expect(body.errors).toBeUndefined();
 
-      // 9 DELETEs (no BEGIN/COMMIT — independent per-table deletes)
-      expect(mockQuery).toHaveBeenCalledTimes(9);
+      // 9 pre-pass UPDATEs + 9 main DELETEs + 1 user DELETE
+      expect(mockQuery).toHaveBeenCalledTimes(19);
     });
 
     it("handles tables with zero deleted rows", async () => {
@@ -186,8 +187,14 @@ describe("GET /api/cron/cleanup", () => {
       await GET(createRequest("Bearer test-cron-secret"));
 
       const calls = mockQuery.mock.calls.map((call) => call[0] as string);
-      const junctionIndex = calls.findIndex((q) => q.includes("item_tricks"));
-      const parentIndex = calls.findIndex((q) => q.includes('"tricks"'));
+      // Skip pre-pass UPDATEs (first 9), find DELETEs in the main loop
+      const deleteQueries = calls.filter((q) => q.includes("DELETE"));
+      const junctionIndex = deleteQueries.findIndex((q) =>
+        q.includes("item_tricks")
+      );
+      const parentIndex = deleteQueries.findIndex((q) =>
+        q.includes('"tricks"')
+      );
       expect(junctionIndex).toBeLessThan(parentIndex);
     });
 
@@ -208,6 +215,42 @@ describe("GET /api/cron/cleanup", () => {
       // Verify retention days is passed as a parameter
       const firstDeleteParams = mockQuery.mock.calls[0]?.[1] as unknown[];
       expect(firstDeleteParams).toContain(30);
+    });
+
+    it("issues UPDATE tombstone queries for user-owned tables before DELETEs", async () => {
+      vi.stubEnv("CRON_SECRET", "test-cron-secret");
+      vi.stubEnv("DATABASE_URL", "postgres://test");
+      vi.resetModules();
+      const { GET } = await import("./route");
+
+      mockQuery.mockResolvedValue({ rowCount: 0 });
+
+      await GET(createRequest("Bearer test-cron-secret"));
+
+      const calls = mockQuery.mock.calls.map((call) => call[0] as string);
+      const updateCalls = calls.filter((q) => q.startsWith("UPDATE"));
+      expect(updateCalls).toHaveLength(9);
+      for (const sql of updateCalls) {
+        expect(sql).toContain("SET deleted_at = NOW()");
+        expect(sql).toContain("INTERVAL '1 day' * $1");
+      }
+    });
+
+    it("continues main cleanup when a pre-pass UPDATE fails", async () => {
+      vi.stubEnv("CRON_SECRET", "test-cron-secret");
+      vi.stubEnv("DATABASE_URL", "postgres://test");
+      vi.resetModules();
+      const { GET } = await import("./route");
+
+      // First pre-pass UPDATE fails, rest succeed
+      mockQuery
+        .mockRejectedValueOnce(new Error("pre-pass failure"))
+        .mockResolvedValue({ rowCount: 0 });
+
+      const response = await GET(createRequest("Bearer test-cron-secret"));
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.success).toBe(true);
     });
 
     it("releases the client and ends the pool after success", async () => {
@@ -232,7 +275,10 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
-      // First DELETE fails, remaining 8 succeed
+      // 9 pre-pass UPDATEs succeed, first main DELETE fails, rest succeed
+      for (let i = 0; i < 9; i++) {
+        mockQuery.mockResolvedValueOnce({ rowCount: 0 }); // pre-pass
+      }
       mockQuery
         .mockRejectedValueOnce(new Error("DB connection lost"))
         .mockResolvedValue({ rowCount: 1 });
@@ -242,8 +288,8 @@ describe("GET /api/cron/cleanup", () => {
       expect(response.status).toBe(200);
       const body = await response.json();
       expect(body.success).toBe(true);
-      // First table failed, 8 succeeded with 1 row each
-      expect(body.totalDeleted).toBe(8);
+      // First main table failed, 8 main + 1 user succeeded with 1 row each
+      expect(body.totalDeleted).toBe(9);
       expect(body.errorsCount).toBe(1);
       // No internal table names should be exposed
       expect(body.deleted).toBeUndefined();
@@ -256,6 +302,10 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
+      // 9 pre-pass UPDATEs succeed, then first main DELETE throws a string
+      for (let i = 0; i < 9; i++) {
+        mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+      }
       mockQuery
         .mockRejectedValueOnce("string error")
         .mockResolvedValue({ rowCount: 0 });
@@ -290,6 +340,10 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
+      // 9 pre-pass UPDATEs succeed, then first main DELETE fails
+      for (let i = 0; i < 9; i++) {
+        mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+      }
       mockQuery
         .mockRejectedValueOnce(new Error("Disk full"))
         .mockResolvedValue({ rowCount: 0 });
@@ -300,23 +354,93 @@ describe("GET /api/cron/cleanup", () => {
       expect(mockEnd).toHaveBeenCalledTimes(1);
     });
 
+    it("includes NOT EXISTS child checks in the user cleanup query", async () => {
+      vi.stubEnv("CRON_SECRET", "test-cron-secret");
+      vi.stubEnv("DATABASE_URL", "postgres://test");
+      vi.resetModules();
+      const { GET } = await import("./route");
+
+      mockQuery.mockResolvedValue({ rowCount: 0 });
+
+      await GET(createRequest("Bearer test-cron-secret"));
+
+      const calls = mockQuery.mock.calls.map((call) => call[0] as string);
+      // Last query is the user cleanup DELETE
+      const userDeleteQuery = calls.at(-1);
+      expect(userDeleteQuery).toContain('DELETE FROM "users"');
+      expect(userDeleteQuery).toContain("NOT EXISTS");
+      for (const table of [
+        "goals",
+        "item_tricks",
+        "items",
+        "performances",
+        "practice_session_tricks",
+        "practice_sessions",
+        "routine_tricks",
+        "routines",
+        "tricks",
+      ]) {
+        expect(userDeleteQuery).toContain(`"${table}"`);
+      }
+    });
+
+    it("reports error when user cleanup fails without crashing", async () => {
+      vi.stubEnv("CRON_SECRET", "test-cron-secret");
+      vi.stubEnv("DATABASE_URL", "postgres://test");
+      vi.resetModules();
+      const { GET } = await import("./route");
+
+      // All pre-pass (9) + main DELETEs (9) succeed, user DELETE fails
+      for (let i = 0; i < 18; i++) {
+        mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+      }
+      mockQuery.mockRejectedValueOnce(new Error("FK violation"));
+
+      const response = await GET(createRequest("Bearer test-cron-secret"));
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.errorsCount).toBe(1);
+    });
+
+    it("returns success false when all cleanup operations fail", async () => {
+      vi.stubEnv("CRON_SECRET", "test-cron-secret");
+      vi.stubEnv("DATABASE_URL", "postgres://test");
+      vi.resetModules();
+      const { GET } = await import("./route");
+
+      // All queries fail
+      mockQuery.mockRejectedValue(new Error("DB down"));
+
+      const response = await GET(createRequest("Bearer test-cron-secret"));
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.success).toBe(false);
+      expect(body.totalDeleted).toBe(0);
+      expect(body.errorsCount).toBeGreaterThan(0);
+    });
+
     it("processes all tables even when errors occur mid-batch", async () => {
       vi.stubEnv("CRON_SECRET", "test-cron-secret");
       vi.stubEnv("DATABASE_URL", "postgres://test");
       vi.resetModules();
       const { GET } = await import("./route");
 
-      // First DELETE succeeds, second fails, rest succeed
+      // 9 pre-pass UPDATEs succeed, first main DELETE succeeds,
+      // second fails, rest succeed
+      for (let i = 0; i < 9; i++) {
+        mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+      }
       mockQuery
-        .mockResolvedValueOnce({ rowCount: 1 }) // first DELETE
-        .mockRejectedValueOnce(new Error("Disk full")) // second DELETE
-        .mockResolvedValue({ rowCount: 0 }); // remaining DELETEs
+        .mockResolvedValueOnce({ rowCount: 1 }) // first main DELETE
+        .mockRejectedValueOnce(new Error("Disk full")) // second main DELETE
+        .mockResolvedValue({ rowCount: 0 }); // remaining DELETEs + user
 
       const response = await GET(createRequest("Bearer test-cron-secret"));
 
       expect(response.status).toBe(200);
-      // All 9 tables are attempted despite the mid-batch error
-      expect(mockQuery).toHaveBeenCalledTimes(9);
+      // 9 pre-pass + 9 main DELETEs + 1 user DELETE = 19 total queries
+      expect(mockQuery).toHaveBeenCalledTimes(19);
     });
   });
 });

--- a/src/app/api/cron/cleanup/route.ts
+++ b/src/app/api/cron/cleanup/route.ts
@@ -34,7 +34,12 @@ function verifySecret(header: string | null, secret: string): boolean {
   return timingSafeEqual(Buffer.from(header), Buffer.from(expected));
 }
 
-/** Tables in deletion order — junctions first, then parents. */
+/** Tables in deletion order — junctions first, then parents.
+ *  Users are handled separately (see user cleanup below).
+ *
+ *  Note: user_preferences and push_subscriptions are intentionally omitted —
+ *  they lack deleted_at columns and are cleaned up via CASCADE when the
+ *  owning user row is hard-deleted. */
 const TABLES_IN_ORDER = [
   "item_tricks",
   "routine_tricks",
@@ -47,7 +52,120 @@ const TABLES_IN_ORDER = [
   "tricks",
 ] as const satisfies readonly SyncedTableName[];
 
+/** User-owned tables whose rows need tombstones before a user is
+ *  hard-deleted. When a user is soft-deleted, their children may not
+ *  have been individually soft-deleted. The pre-pass sets deleted_at on
+ *  non-tombstoned children so PowerSync can sync the deletions to
+ *  offline clients. These children will be hard-deleted on a future
+ *  cron run after their own retention period expires. */
+const USER_OWNED_TABLES = [
+  "goals",
+  "item_tricks",
+  "items",
+  "performances",
+  "practice_session_tricks",
+  "practice_sessions",
+  "routine_tricks",
+  "routines",
+  "tricks",
+] as const satisfies readonly SyncedTableName[];
+
 const RETENTION_DAYS = 30;
+
+interface CleanupClient {
+  query(sql: string, params?: unknown[]): Promise<{ rowCount: number | null }>;
+}
+
+/**
+ * Pre-pass: soft-delete children of users who are past the retention
+ * window but whose children were never individually soft-deleted.
+ * Without this, hard-deleting the user row would CASCADE-delete
+ * children without creating tombstones, leaving orphaned rows in
+ * PowerSync offline clients.
+ */
+async function tombstoneOrphanedChildren(client: CleanupClient): Promise<void> {
+  for (const table of USER_OWNED_TABLES) {
+    try {
+      const quotedTable = quoteId(table);
+      await client.query(
+        `UPDATE ${quotedTable} SET deleted_at = NOW(), updated_at = NOW() WHERE user_id IN (SELECT id FROM "users" WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '1 day' * $1) AND deleted_at IS NULL`,
+        [RETENTION_DAYS]
+      );
+    } catch (prePassError: unknown) {
+      const message =
+        prePassError instanceof Error
+          ? prePassError.message
+          : String(prePassError);
+      console.error(
+        `Pre-pass soft-delete failed for table "${table}":`,
+        message
+      );
+    }
+  }
+}
+
+/**
+ * Main cleanup: hard-delete rows from synced tables that have been
+ * soft-deleted for longer than the retention period.
+ */
+async function cleanupSyncedTables(
+  client: CleanupClient,
+  results: Record<string, number>,
+  errors: Record<string, string>
+): Promise<void> {
+  for (const table of TABLES_IN_ORDER) {
+    try {
+      // SAFETY: `table` is from TABLES_IN_ORDER (compile-time constant).
+      // RETENTION_DAYS is parameterized via $1. LIMIT prevents long queries.
+      const quotedTable = quoteId(table);
+      const result = await client.query(
+        `WITH to_delete AS (SELECT id FROM ${quotedTable} WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '1 day' * $1 LIMIT 10000) DELETE FROM ${quotedTable} WHERE id IN (SELECT id FROM to_delete)`,
+        [RETENTION_DAYS]
+      );
+      results[table] = result.rowCount ?? 0;
+    } catch (tableError: unknown) {
+      // FK violations are expected when junction rows survive due to LIMIT.
+      // Log and continue — these parents will be cleaned next run.
+      const message =
+        tableError instanceof Error ? tableError.message : String(tableError);
+      console.error(`Cleanup failed for table "${table}":`, message);
+      errors[table] = "cleanup_failed";
+      results[table] = 0;
+    }
+  }
+}
+
+/**
+ * Hard-delete user rows only when ALL their tombstoned children have
+ * already been hard-deleted. Checks for surviving tombstoned rows
+ * (deleted_at IS NOT NULL) rather than all rows, so the NOT EXISTS
+ * subqueries can leverage the idx_*_deleted_at partial indexes instead
+ * of falling back to sequential scans on the partial user_id indexes
+ * (which exclude soft-deleted rows).
+ */
+async function cleanupUsers(
+  client: CleanupClient,
+  results: Record<string, number>,
+  errors: Record<string, string>
+): Promise<void> {
+  try {
+    const childChecks = USER_OWNED_TABLES.map(
+      (t) =>
+        `NOT EXISTS (SELECT 1 FROM ${quoteId(t)} WHERE user_id = "users".id AND deleted_at IS NOT NULL)`
+    ).join(" AND ");
+    const result = await client.query(
+      `WITH to_delete AS (SELECT id FROM "users" WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '1 day' * $1 AND ${childChecks} LIMIT 10000) DELETE FROM "users" WHERE id IN (SELECT id FROM to_delete)`,
+      [RETENTION_DAYS]
+    );
+    results.users = result.rowCount ?? 0;
+  } catch (userError: unknown) {
+    const message =
+      userError instanceof Error ? userError.message : String(userError);
+    console.error('Cleanup failed for table "users":', message);
+    errors.users = "cleanup_failed";
+    results.users = 0;
+  }
+}
 
 // Vercel Cron Jobs invoke route handlers via GET requests.
 // This route performs DELETE mutations despite being a GET handler.
@@ -78,33 +196,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const client = await pool.connect();
     try {
-      // Each table DELETE runs independently — no wrapping transaction.
-      // With LIMIT 10000 and NO ACTION FKs, a single transaction would
-      // ROLLBACK entirely if surviving junction rows block a parent DELETE.
-      // Independent deletes let junction rows drain first; parents whose
-      // children are still present survive until the next cron run.
-      for (const table of TABLES_IN_ORDER) {
-        try {
-          // SAFETY: `table` is from TABLES_IN_ORDER (compile-time constant).
-          // RETENTION_DAYS is parameterized via $1. LIMIT prevents long queries.
-          const quotedTable = quoteId(table);
-          const result = await client.query(
-            `WITH to_delete AS (SELECT id FROM ${quotedTable} WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '1 day' * $1 LIMIT 10000) DELETE FROM ${quotedTable} WHERE id IN (SELECT id FROM to_delete)`,
-            [RETENTION_DAYS]
-          );
-          results[table] = result.rowCount ?? 0;
-        } catch (tableError: unknown) {
-          // FK violations are expected when junction rows survive due to LIMIT.
-          // Log and continue — these parents will be cleaned next run.
-          const message =
-            tableError instanceof Error
-              ? tableError.message
-              : String(tableError);
-          console.error(`Cleanup failed for table "${table}":`, message);
-          errors[table] = "cleanup_failed";
-          results[table] = 0;
-        }
-      }
+      await tombstoneOrphanedChildren(client);
+      await cleanupSyncedTables(client, results, errors);
+      await cleanupUsers(client, results, errors);
 
       const totalDeleted = Object.values(results).reduce((a, b) => a + b, 0);
 
@@ -115,9 +209,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       });
 
       const errorsCount = Object.keys(errors).length;
+      const resultCount = Object.keys(results).length;
+      const allFailed = resultCount > 0 && errorsCount === resultCount;
 
       return NextResponse.json({
-        success: true,
+        success: !allFailed,
         totalDeleted,
         errorsCount,
       });

--- a/src/auth/ensure-user.test.ts
+++ b/src/auth/ensure-user.test.ts
@@ -51,6 +51,7 @@ vi.mock("@/db/schema/users", () => ({
     id: "id",
     email: { name: "email" },
     displayName: { name: "display_name" },
+    deletedAt: { name: "deleted_at" },
     locale: "locale",
     theme: "theme",
     updatedAt: "updated_at",

--- a/src/auth/ensure-user.ts
+++ b/src/auth/ensure-user.ts
@@ -84,11 +84,18 @@ export async function ensureUserExists(
         set: {
           email,
           displayName,
+          // Clear soft-delete on re-login so a user who deleted their
+          // account can seamlessly re-activate by signing in again.
+          // TODO: This unconditionally reactivates ANY soft-deleted user.
+          // When implementing admin bans or moderation, add a check
+          // (e.g., deactivation_reason or banned_at) to prevent banned
+          // users from self-reactivating via login.
+          deletedAt: null,
           // users.email.name / users.displayName.name are Drizzle's public
           // Column.name property, returning the raw SQL column identifier
           // (e.g., "email", "display_name"). Safe for sql.raw() because
           // column names are simple ASCII identifiers defined in our schema.
-          updatedAt: sql`CASE WHEN ${users.email} IS DISTINCT FROM EXCLUDED.${sql.raw(`"${users.email.name}"`)} OR ${users.displayName} IS DISTINCT FROM EXCLUDED.${sql.raw(`"${users.displayName.name}"`)} THEN NOW() ELSE ${users.updatedAt} END`,
+          updatedAt: sql`CASE WHEN ${users.email} IS DISTINCT FROM EXCLUDED.${sql.raw(`"${users.email.name}"`)} OR ${users.displayName} IS DISTINCT FROM EXCLUDED.${sql.raw(`"${users.displayName.name}"`)} OR ${users.deletedAt} IS DISTINCT FROM EXCLUDED.${sql.raw(`"${users.deletedAt.name}"`)} THEN NOW() ELSE ${users.updatedAt} END`,
         },
       })
       .returning({

--- a/src/db/migrations/0011_faithful_toro.sql
+++ b/src/db/migrations/0011_faithful_toro.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_users_deleted_at" ON "users" ("deleted_at") WHERE "deleted_at" IS NOT NULL;

--- a/src/db/migrations/meta/0011_snapshot.json
+++ b/src/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1660 @@
+{
+  "id": "1405a1b3-935c-465f-ab32-aa440603ecea",
+  "prevId": "b018c62e-88ad-4e3d-9cbe-3c7b840eb9a0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_value": {
+          "name": "target_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "goals_user_id_idx": {
+          "name": "goals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "goals_trick_id_idx": {
+          "name": "goals_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goals_trick_id_tricks_id_fk": {
+          "name": "goals_trick_id_tricks_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_tricks": {
+      "name": "item_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "item_tricks_user_id_idx": {
+          "name": "item_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tricks_item_id_idx": {
+          "name": "item_tricks_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tricks_trick_id_idx": {
+          "name": "item_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tricks_item_trick_idx": {
+          "name": "item_tricks_item_trick_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_tricks_user_id_users_id_fk": {
+          "name": "item_tricks_user_id_users_id_fk",
+          "tableFrom": "item_tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_tricks_item_id_items_id_fk": {
+          "name": "item_tricks_item_id_items_id_fk",
+          "tableFrom": "item_tricks",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "item_tricks_trick_id_tricks_id_fk": {
+          "name": "item_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "item_tricks",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "items_user_id_idx": {
+          "name": "items_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "items_user_id_users_id_fk": {
+          "name": "items_user_id_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.performances": {
+      "name": "performances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_size": {
+          "name": "audience_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_type": {
+          "name": "audience_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "performances_user_id_idx": {
+          "name": "performances_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "performances_routine_id_idx": {
+          "name": "performances_routine_id_idx",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "performances_user_id_date_idx": {
+          "name": "performances_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "performances_user_id_users_id_fk": {
+          "name": "performances_user_id_users_id_fk",
+          "tableFrom": "performances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "performances_routine_id_routines_id_fk": {
+          "name": "performances_routine_id_routines_id_fk",
+          "tableFrom": "performances",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_session_tricks": {
+      "name": "practice_session_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_session_tricks_user_id_idx": {
+          "name": "practice_session_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_tricks_practice_session_id_idx": {
+          "name": "practice_session_tricks_practice_session_id_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_tricks_trick_id_idx": {
+          "name": "practice_session_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_tricks_session_trick_idx": {
+          "name": "practice_session_tricks_session_trick_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_session_tricks_user_id_users_id_fk": {
+          "name": "practice_session_tricks_user_id_users_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "practice_session_tricks_practice_session_id_practice_sessions_id_fk": {
+          "name": "practice_session_tricks_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "practice_session_tricks_trick_id_tricks_id_fk": {
+          "name": "practice_session_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_sessions": {
+      "name": "practice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_sessions_user_id_idx": {
+          "name": "practice_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_id_date_idx": {
+          "name": "practice_sessions_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_sessions_user_id_users_id_fk": {
+          "name": "practice_sessions_user_id_users_id_fk",
+          "tableFrom": "practice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine_tricks": {
+      "name": "routine_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_notes": {
+          "name": "transition_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "routine_tricks_user_id_idx": {
+          "name": "routine_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_tricks_routine_id_idx": {
+          "name": "routine_tricks_routine_id_idx",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_tricks_trick_id_idx": {
+          "name": "routine_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_tricks_routine_position_idx": {
+          "name": "routine_tricks_routine_position_idx",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine_tricks_user_id_users_id_fk": {
+          "name": "routine_tricks_user_id_users_id_fk",
+          "tableFrom": "routine_tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_tricks_routine_id_routines_id_fk": {
+          "name": "routine_tricks_routine_id_routines_id_fk",
+          "tableFrom": "routine_tricks",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routine_tricks_trick_id_tricks_id_fk": {
+          "name": "routine_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "routine_tricks",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routines": {
+      "name": "routines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_duration_minutes": {
+          "name": "estimated_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "routines_user_id_idx": {
+          "name": "routines_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routines_user_id_users_id_fk": {
+          "name": "routines_user_id_users_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tricks": {
+      "name": "tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tricks_user_id_idx": {
+          "name": "tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tricks_user_id_users_id_fk": {
+          "name": "tricks_user_id_users_id_fk",
+          "tableFrom": "tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "push_enabled": {
+          "name": "push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "practice_reminder_time": {
+          "name": "practice_reminder_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_reminder_days": {
+          "name": "practice_reminder_days",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_summary_enabled": {
+          "name": "weekly_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1774502400000,
       "tag": "0010_deleted_at_partial_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1774291595008,
+      "tag": "0011_faithful_toro",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -26,4 +26,5 @@ export const users = pgTable("users", {
     .defaultNow()
     .notNull()
     .$onUpdate(() => sql`NOW()`),
+  deletedAt: timestamp("deleted_at", { withTimezone: true }),
 });

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -32,6 +32,7 @@ function createTestUser(overrides?: Partial<NewUser>): User {
     theme: "system",
     createdAt: new Date(),
     updatedAt: new Date(),
+    deletedAt: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Add `deleted_at` column to users table with migration and partial index, aligning with the project's soft-delete convention used by all other entity tables
- Guard settings server actions with `isNull(users.deletedAt)` to prevent soft-deleted users from reading/modifying settings
- Clear `deletedAt` on re-login upsert for self-reactivation (with TODO for admin ban distinction — tracked in #102)
- Refactor cleanup cron into 3 phases: tombstone orphaned children → hard-delete synced tables → hard-delete users (only when all children are gone)
- Optimize `NOT EXISTS` subqueries to use `deleted_at IS NOT NULL` for partial index efficiency
- Return `success: false` from cron when all operations fail

## Test plan

- [x] `pnpm lint` passes (0 issues)
- [x] `pnpm test:run` passes (673/673 tests)
- [x] Migration applied to Neon (`pnpm db:migrate` — already run)
- [x] `pnpm docs:generate` — docs regenerated
- [x] 5 review passes (database, security, typescript, testing, node-api) — all clean
- [ ] Verify settings page works after deployment (locale/theme selectors)
- [ ] Verify cron job runs successfully (check Vercel Cron logs after deploy)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)