### PR TITLE
fix: correct migration journal timestamp to prevent silent skip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,8 @@ Type safety is a first-class concern. All code must be rigorously typed.
 
 **IMPORTANT — Single migration file rule**: The `@neondatabase/serverless` driver uses stateless HTTP requests. Each migration file runs as an independent HTTP call, so DDL changes from one migration (e.g., `ADD COLUMN`) are **not visible** to the next migration within the same `drizzle-kit migrate` run. **Never split dependent SQL across multiple migration files.** If a later statement references a column or object created earlier, it must be in the **same** migration file. Hand-written migrations (e.g., RLS policy updates) that depend on a generated migration must be appended to that migration file, not created as a separate file.
 
+**IMPORTANT — Journal timestamps must be monotonically increasing**: Drizzle-orm only applies migrations whose `when` timestamp (in `meta/_journal.json`) is greater than the last applied migration's `created_at`. If a new entry has a lower timestamp than a previous one, it will be **silently skipped**. After generating or hand-writing a migration, verify the new entry's `when` value is strictly greater than all previous entries.
+
 ## UI/Design Conventions
 
 - **Mobile-first**: Design for <768px first, then tablet (768-1024px), then desktop (>1024px)

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -82,7 +82,7 @@
     {
       "idx": 11,
       "version": "7",
-      "when": 1774291595008,
+      "when": 1774502400001,
       "tag": "0011_faithful_toro",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- Fix migration 0011 (`faithful_toro`) being silently skipped by drizzle-orm because its `when` timestamp in `_journal.json` was lower than migration 0010's
- Drizzle-orm only applies migrations whose `folderMillis` exceeds the last applied migration's `created_at` — out-of-order entries are silently ignored
- Add documentation in CLAUDE.md warning about this constraint

The DDL (`ALTER TABLE users ADD COLUMN deleted_at`) and journal entries have already been applied manually to both the `main` and `dev/julien` Neon branches.

## Test plan
- [x] `pnpm db:migrate` reports success with no pending migrations
- [x] `/dashboard` loads without error
- [ ] CI passes (lint, typecheck, tests, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)