### PR TITLE
fix: add timeZone to next-intl config

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -81,6 +81,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
   return {
     locale,
     messages: imported.default,
+    timeZone: "UTC",
   };
 });
 


### PR DESCRIPTION
## Summary
- Adds `timeZone: "UTC"` to the `getRequestConfig` return in `src/i18n/request.ts`
- Silences the `ENVIRONMENT_FALLBACK` warning from next-intl about missing timezone configuration
- Prevents potential markup mismatches between server and client when date/time formatting is added later

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test:run` — all 667 tests pass
- [ ] `pnpm dev` — confirm `ENVIRONMENT_FALLBACK` warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)