### PR TITLE
chore: harden E2E suite and make it a required status check

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,9 @@ name: E2E
 on:
   deployment_status:
 
+env:
+  STATUS_CONTEXT: E2E Tests
+
 permissions:
   contents: read
 
@@ -21,7 +24,7 @@ jobs:
       github.event.deployment.environment == 'Preview' &&
       contains(github.event.deployment_status.target_url, 'jaro-labs')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -85,10 +88,33 @@ jobs:
           gh api "repos/${GITHUB_REPOSITORY}/statuses/${DEPLOY_SHA}" \
             -f state="$STATE" \
             -f target_url="$TARGET_URL" \
-            -f context="E2E Tests" \
+            -f context="$STATUS_CONTEXT" \
             -f description="Playwright E2E against Vercel preview"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_STATUS: ${{ job.status }}
+          DEPLOY_SHA: ${{ github.event.deployment.sha }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  e2e-skip:
+    name: E2E Tests (Skip)
+    permissions:
+      statuses: write
+    if: >-
+      github.event.deployment_status.state != 'success' ||
+      github.event.deployment.environment != 'Preview' ||
+      !contains(github.event.deployment_status.target_url, 'jaro-labs')
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Post skip status
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${DEPLOY_SHA}" \
+            -f state="success" \
+            -f target_url="$TARGET_URL" \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Skipped — not a matching preview deployment"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_SHA: ${{ github.event.deployment.sha }}
           TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,10 +34,13 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
+  maxFailures: process.env.CI ? 5 : undefined,
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? "html" : "list",
   use: {
     baseURL,
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
     trace: "on-first-retry",
     // Load Vercel bypass cookie if available (set by global-setup.ts)
     ...(hasVercelBypass && { storageState: BYPASS_STATE_PATH }),


### PR DESCRIPTION
## Summary

- Add `maxFailures: 5` and explicit `actionTimeout`/`navigationTimeout` to Playwright config to prevent cascading timeouts from blowing past the CI job limit
- Increase E2E job timeout from 10 to 15 minutes for retry headroom
- Add `e2e-skip` job that posts a success commit status when deployment conditions don't match, enabling `"E2E Tests"` to become a required branch protection rule
- Extract `STATUS_CONTEXT` env var to keep the context string in sync across both jobs

**Context:** E2E run [#23462262257](https://github.com/julienroussel/tml/actions/runs/23462262257) timed out because all authenticated tests failed (missing migration column) and `retries: 2` tripled execution time past the 10-minute limit. The root cause is fixed, but these structural changes prevent similar overruns.

## Test plan

- [ ] Verify `pnpm lint` and `pnpm typecheck` pass in CI
- [ ] After merge, confirm a Vercel preview deployment triggers the `e2e` job (not `e2e-skip`)
- [ ] Confirm a non-preview deployment triggers `e2e-skip` and posts a success status
- [ ] Verify `"E2E Tests"` is now a required status check on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)