### PR TITLE
fix: enforce ban on data access — block sync, mutations, and server actions

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,10 +1,13 @@
+import { ShieldAlert } from "lucide-react";
 import { redirect } from "next/navigation";
 import type { ReactElement, ReactNode } from "react";
+import { isUserBanned } from "@/auth/ban-check";
 import { getOrEnsureUserSettings } from "@/auth/ensure-user";
 import { auth } from "@/auth/server";
 import { AppSidebar } from "@/components/app-sidebar";
 import { HeaderTitle } from "@/components/header-title";
 import { SyncStatus } from "@/components/sync-status";
+import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import {
   SidebarInset,
@@ -29,6 +32,28 @@ export default async function AppLayout({
   // Uses a cookie cache to skip the DB upsert on repeat page loads.
   // Falls through to ensureUserExists() when the cookie is absent or stale.
   const settings = await getOrEnsureUserSettings(session);
+
+  // Unconditional ban check — required because getOrEnsureUserSettings()
+  // has a cookie cache fast path that skips the DB entirely. On the cold
+  // path (no cache) this is redundant with ensureUserExists(), but the
+  // simplicity of always checking outweighs one extra lightweight query.
+  if (await isUserBanned(session.user.id)) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+        <ShieldAlert className="h-16 w-16 text-destructive" />
+        <h1 className="font-semibold text-2xl">Account Suspended</h1>
+        <p className="max-w-md text-muted-foreground">
+          Your account has been suspended. If you believe this is a mistake,
+          please contact support.
+        </p>
+        <form action="/api/auth/sign-out" method="post">
+          <Button type="submit" variant="outline">
+            Sign Out
+          </Button>
+        </form>
+      </main>
+    );
+  }
 
   // Locale restoration from DB is handled client-side by LocaleRestorer
   // (rendered below). Server Components cannot reliably set cookies in

--- a/src/app/(app)/settings/actions.test.ts
+++ b/src/app/(app)/settings/actions.test.ts
@@ -15,6 +15,10 @@ const unauthenticatedSession: MockSession = {
 };
 
 vi.mock("server-only", () => ({}));
+const mockIsUserBanned = vi.fn().mockResolvedValue(false);
+vi.mock("@/auth/ban-check", () => ({
+  isUserBanned: (...args: unknown[]) => mockIsUserBanned(...args),
+}));
 
 const mockCookieDelete = vi.fn();
 const mockCookies = vi.fn().mockResolvedValue({ delete: mockCookieDelete });
@@ -61,8 +65,35 @@ describe("settings server actions", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    mockIsUserBanned.mockResolvedValue(false);
     mockUpdateReturning.mockResolvedValue([{ id: "test-user" }]);
     mockSelectLimit.mockResolvedValue([]);
+  });
+
+  describe("banned user rejection", () => {
+    it("updateLocale rejects banned users", async () => {
+      mockIsUserBanned.mockResolvedValueOnce(true);
+
+      const { updateLocale } = await import("./actions");
+      const result = await updateLocale("en");
+      expect(result).toEqual({ success: false, error: "Account suspended" });
+    });
+
+    it("updateTheme rejects banned users", async () => {
+      mockIsUserBanned.mockResolvedValueOnce(true);
+
+      const { updateTheme } = await import("./actions");
+      const result = await updateTheme("dark");
+      expect(result).toEqual({ success: false, error: "Account suspended" });
+    });
+
+    it("getUserSettings returns null for banned users", async () => {
+      mockIsUserBanned.mockResolvedValueOnce(true);
+
+      const { getUserSettings } = await import("./actions");
+      const result = await getUserSettings();
+      expect(result).toBeNull();
+    });
   });
 
   describe("updateLocale", () => {

--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -3,6 +3,7 @@
 import "server-only";
 import { and, eq, isNull } from "drizzle-orm";
 import { cookies } from "next/headers";
+import { isUserBanned } from "@/auth/ban-check";
 import { auth } from "@/auth/server";
 import { USER_SYNCED_COOKIE } from "@/auth/sync-cookie";
 import { getDb } from "@/db";
@@ -29,6 +30,10 @@ export async function updateLocale(locale: string): Promise<ActionResult> {
   const { data: session } = await auth.getSession();
   if (!session?.user?.id) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (await isUserBanned(session.user.id)) {
+    return { success: false, error: "Account suspended" };
   }
 
   try {
@@ -71,6 +76,10 @@ export async function updateTheme(theme: string): Promise<ActionResult> {
     return { success: false, error: "Not authenticated" };
   }
 
+  if (await isUserBanned(session.user.id)) {
+    return { success: false, error: "Account suspended" };
+  }
+
   try {
     const db = getDb();
     const rows = await db
@@ -106,6 +115,10 @@ export async function getUserSettings(): Promise<{
 } | null> {
   const { data: session } = await auth.getSession();
   if (!session?.user?.id) {
+    return null;
+  }
+
+  if (await isUserBanned(session.user.id)) {
     return null;
   }
 

--- a/src/app/actions.test.ts
+++ b/src/app/actions.test.ts
@@ -16,6 +16,10 @@ const unauthenticatedSession: MockSession = {
 };
 
 vi.mock("server-only", () => ({}));
+const mockIsUserBanned = vi.fn().mockResolvedValue(false);
+vi.mock("@/auth/ban-check", () => ({
+  isUserBanned: (...args: unknown[]) => mockIsUserBanned(...args),
+}));
 const mockCheckRateLimit = vi.fn().mockResolvedValue(false);
 vi.mock("@/lib/rate-limit", () => ({
   checkRateLimit: mockCheckRateLimit,
@@ -96,6 +100,7 @@ describe("server actions", () => {
     vi.unstubAllEnvs();
     mockReturning.mockResolvedValue([{ id: "test-uuid" }]);
     mockCheckRateLimit.mockResolvedValue(false);
+    mockIsUserBanned.mockResolvedValue(false);
     mockSelectWhere.mockResolvedValue([]);
   });
 
@@ -125,6 +130,34 @@ describe("server actions", () => {
       const { sendNotification } = await import("./actions");
       const result = await sendNotification("Hello");
       expect(result).toEqual({ success: false, error: "Not authenticated" });
+    });
+  });
+
+  describe("banned user rejection", () => {
+    it("subscribeUser rejects banned users", async () => {
+      mockIsUserBanned.mockResolvedValueOnce(true);
+
+      const { subscribeUser } = await import("./actions");
+      const result = await subscribeUser(validSubscription);
+      expect(result).toEqual({ success: false, error: "Account suspended" });
+    });
+
+    it("unsubscribeUser rejects banned users", async () => {
+      mockIsUserBanned.mockResolvedValueOnce(true);
+
+      const { unsubscribeUser } = await import("./actions");
+      const result = await unsubscribeUser(
+        "https://fcm.googleapis.com/push/abc"
+      );
+      expect(result).toEqual({ success: false, error: "Account suspended" });
+    });
+
+    it("sendNotification rejects banned users", async () => {
+      mockIsUserBanned.mockResolvedValueOnce(true);
+
+      const { sendNotification } = await import("./actions");
+      const result = await sendNotification("Hello");
+      expect(result).toEqual({ success: false, error: "Account suspended" });
     });
   });
 

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -3,6 +3,7 @@
 import "server-only";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import webpush from "web-push";
+import { isUserBanned } from "@/auth/ban-check";
 import { auth } from "@/auth/server";
 import { getDb } from "@/db";
 import { pushSubscriptions } from "@/db/schema/push-subscriptions";
@@ -75,6 +76,10 @@ export async function subscribeUser(
   const { data: session } = await auth.getSession();
   if (!session?.user) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (await isUserBanned(session.user.id)) {
+    return { success: false, error: "Account suspended" };
   }
 
   if (!sub?.endpoint || typeof sub.endpoint !== "string") {
@@ -152,6 +157,10 @@ export async function unsubscribeUser(endpoint: string): Promise<ActionResult> {
   const { data: session } = await auth.getSession();
   if (!session?.user) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (await isUserBanned(session.user.id)) {
+    return { success: false, error: "Account suspended" };
   }
 
   if (!endpoint?.startsWith("https://") || endpoint.length > 2048) {
@@ -258,6 +267,10 @@ export async function sendNotification(message: string): Promise<ActionResult> {
   const { data: session } = await auth.getSession();
   if (!session?.user) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (await isUserBanned(session.user.id)) {
+    return { success: false, error: "Account suspended" };
   }
 
   const trimmedMessage = message.trim();

--- a/src/app/api/auth/[...path]/route.test.ts
+++ b/src/app/api/auth/[...path]/route.test.ts
@@ -1,0 +1,135 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockGetSession = vi.fn();
+const mockIsUserBanned = vi.fn();
+
+const mockHandlerGET = vi.fn();
+const mockHandlerPOST = vi.fn();
+
+vi.mock("@/auth/ban-check", () => ({
+  isUserBanned: (...args: unknown[]) => mockIsUserBanned(...args),
+}));
+
+vi.mock("@/auth/server", () => ({
+  auth: {
+    getSession: mockGetSession,
+    handler: () => ({
+      GET: mockHandlerGET,
+      POST: mockHandlerPOST,
+    }),
+  },
+}));
+
+const HANDLER_RESPONSE = new Response(JSON.stringify({ ok: true }), {
+  status: 200,
+});
+
+beforeEach(() => {
+  mockHandlerGET.mockResolvedValue(HANDLER_RESPONSE);
+  mockHandlerPOST.mockResolvedValue(HANDLER_RESPONSE);
+  mockIsUserBanned.mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+function createGetRequest(path: string): NextRequest {
+  return new NextRequest(`https://themagiclab.app/api/auth/${path}`, {
+    method: "GET",
+  });
+}
+
+function createContext(pathSegments: string[]): {
+  params: Promise<{ path: string[] }>;
+} {
+  return { params: Promise.resolve({ path: pathSegments }) };
+}
+
+describe("GET /api/auth/[...path]", () => {
+  it("returns 403 when requesting /token and user is banned", async () => {
+    mockGetSession.mockResolvedValue({
+      data: { user: { id: "user-banned-123" } },
+    });
+    mockIsUserBanned.mockResolvedValue(true);
+    const { GET } = await import("./route");
+
+    const response = await GET(
+      createGetRequest("token"),
+      createContext(["token"])
+    );
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body).toEqual({ error: "Forbidden" });
+    expect(mockHandlerGET).not.toHaveBeenCalled();
+  });
+
+  it("delegates to handler when requesting /token and user is not banned", async () => {
+    mockGetSession.mockResolvedValue({
+      data: { user: { id: "user-good-456" } },
+    });
+    mockIsUserBanned.mockResolvedValue(false);
+    const { GET } = await import("./route");
+
+    const request = createGetRequest("token");
+    const context = createContext(["token"]);
+    const response = await GET(request, context);
+
+    expect(response).toBe(HANDLER_RESPONSE);
+    expect(mockIsUserBanned).toHaveBeenCalledWith("user-good-456");
+    expect(mockHandlerGET).toHaveBeenCalledWith(request, context);
+  });
+
+  it("delegates to handler without ban check for non-token paths", async () => {
+    const { GET } = await import("./route");
+
+    const request = createGetRequest("session");
+    const context = createContext(["session"]);
+    const response = await GET(request, context);
+
+    expect(response).toBe(HANDLER_RESPONSE);
+    expect(mockGetSession).not.toHaveBeenCalled();
+    expect(mockIsUserBanned).not.toHaveBeenCalled();
+    expect(mockHandlerGET).toHaveBeenCalledWith(request, context);
+  });
+
+  it("delegates to handler when requesting /token with no session", async () => {
+    mockGetSession.mockResolvedValue({ data: null });
+    const { GET } = await import("./route");
+
+    const request = createGetRequest("token");
+    const context = createContext(["token"]);
+    const response = await GET(request, context);
+
+    expect(response).toBe(HANDLER_RESPONSE);
+    expect(mockIsUserBanned).not.toHaveBeenCalled();
+    expect(mockHandlerGET).toHaveBeenCalledWith(request, context);
+  });
+
+  it("delegates to handler when session user has no id", async () => {
+    mockGetSession.mockResolvedValue({ data: { user: {} } });
+    const { GET } = await import("./route");
+
+    const request = createGetRequest("token");
+    const context = createContext(["token"]);
+    const response = await GET(request, context);
+
+    expect(response).toBe(HANDLER_RESPONSE);
+    expect(mockIsUserBanned).not.toHaveBeenCalled();
+    expect(mockHandlerGET).toHaveBeenCalledWith(request, context);
+  });
+});
+
+describe("POST /api/auth/[...path]", () => {
+  it("is exported directly from the handler without ban interception", async () => {
+    const { POST } = await import("./route");
+
+    // POST is the handler's POST function directly — no wrapper
+    expect(POST).toBe(mockHandlerPOST);
+  });
+});

--- a/src/app/api/auth/[...path]/route.ts
+++ b/src/app/api/auth/[...path]/route.ts
@@ -1,3 +1,27 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { isUserBanned } from "@/auth/ban-check";
 import { auth } from "@/auth/server";
 
-export const { GET, POST } = auth.handler();
+const handler = auth.handler();
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+): Promise<Response> {
+  const { path } = await context.params;
+
+  if (path[0] === "token") {
+    const { data: session } = await auth.getSession();
+    if (session?.user?.id && (await isUserBanned(session.user.id))) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+
+  return handler.GET(request, context);
+}
+
+// POST does not need a ban check: the token endpoint is GET-only (Neon Auth
+// API_ENDPOINTS.token.method === "GET"). POST paths (sign-in, refresh-token,
+// sign-out, etc.) don't issue PowerSync sync tokens. Banned users are blocked
+// at token retrieval (GET /token above) and by the proxy redirect in proxy.ts.
+export const { POST } = handler;

--- a/src/app/api/powersync/batch/route.test.ts
+++ b/src/app/api/powersync/batch/route.test.ts
@@ -4,6 +4,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 const mockGetSession = vi.fn();
+const mockIsUserBanned = vi.fn();
+
+vi.mock("@/auth/ban-check", () => ({
+  isUserBanned: (...args: unknown[]) => mockIsUserBanned(...args),
+}));
 
 vi.mock("@/auth/server", () => ({
   auth: { getSession: mockGetSession },
@@ -27,6 +32,8 @@ beforeEach(() => {
   });
   // BEGIN and COMMIT succeed by default
   mockClientQuery.mockResolvedValue({ rowCount: 0 });
+  // Non-banned by default
+  mockIsUserBanned.mockResolvedValue(false);
 });
 
 afterEach(() => {
@@ -117,6 +124,22 @@ describe("POST /api/powersync/batch", () => {
       const response = await POST(createRequest({ operations: [] }));
 
       expect(response.status).toBe(401);
+    });
+
+    it("returns 403 when user is banned", async () => {
+      authenticatedSession();
+      mockIsUserBanned.mockResolvedValue(true);
+      const { POST } = await import("./route");
+
+      const response = await POST(
+        createRequest({
+          operations: [putOp("tricks", "t-1", { name: "Card Trick" })],
+        })
+      );
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body).toEqual({ error: "Forbidden" });
     });
   });
 

--- a/src/app/api/powersync/batch/route.ts
+++ b/src/app/api/powersync/batch/route.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { Pool } from "@neondatabase/serverless";
 import { type NextRequest, NextResponse } from "next/server";
+import { isUserBanned } from "@/auth/ban-check";
 import { auth } from "@/auth/server";
 import type { SqlParam } from "@/sync/queries";
 import {
@@ -339,6 +340,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { data: session } = await auth.getSession();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // 403 is treated as a permanent error by the PowerSync connector —
+  // all queued mutations are dropped from the upload queue.
+  // This is intentional: banned users must not persist data changes.
+  if (await isUserBanned(session.user.id)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const contentType = request.headers.get("content-type");

--- a/src/auth/ban-check.test.ts
+++ b/src/auth/ban-check.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+
+vi.mock("@/db", () => ({
+  getDb: () => ({
+    select: mockSelect,
+  }),
+}));
+
+vi.mock("@/db/schema/users", () => ({
+  users: { id: "id", bannedAt: "banned_at" },
+}));
+
+beforeEach(() => {
+  mockSelect.mockReturnValue({ from: mockFrom });
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockWhere.mockReturnValue({ limit: mockLimit });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("isUserBanned", () => {
+  it("returns true when bannedAt is set", async () => {
+    mockLimit.mockResolvedValue([{ bannedAt: new Date("2026-01-15") }]);
+    const { isUserBanned } = await import("./ban-check");
+
+    const result = await isUserBanned("user-123");
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when bannedAt is null", async () => {
+    mockLimit.mockResolvedValue([{ bannedAt: null }]);
+    const { isUserBanned } = await import("./ban-check");
+
+    const result = await isUserBanned("user-123");
+
+    expect(result).toBe(false);
+    expect(mockWhere).toHaveBeenCalledOnce();
+  });
+
+  it("returns true when user does not exist (fail-closed)", async () => {
+    mockLimit.mockResolvedValue([]);
+    const { isUserBanned } = await import("./ban-check");
+
+    const result = await isUserBanned("nonexistent-user");
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true when DB query throws (fail-closed)", async () => {
+    mockLimit.mockRejectedValue(new Error("connection timeout"));
+    const { isUserBanned } = await import("./ban-check");
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const result = await isUserBanned("user-123");
+
+    expect(result).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Ban check failed, failing closed:",
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/src/auth/ban-check.ts
+++ b/src/auth/ban-check.ts
@@ -1,0 +1,34 @@
+import "server-only";
+import { eq } from "drizzle-orm";
+import { getDb } from "@/db";
+import { users } from "@/db/schema/users";
+
+/**
+ * Returns true if the given user is banned (bannedAt is non-null).
+ *
+ * Always queries the database — never trusts the cookie cache.
+ * Fails closed: returns true if the user row doesn't exist.
+ */
+export async function isUserBanned(userId: string): Promise<boolean> {
+  try {
+    const db = getDb();
+    const [row] = await db
+      .select({ bannedAt: users.bannedAt })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (!row) {
+      return true;
+    }
+
+    return row.bannedAt !== null;
+  } catch (error: unknown) {
+    // Fail closed: during transient DB outages, all users are treated as banned.
+    // This prioritizes security (preventing banned-user access) over availability.
+    // Acceptable because the layout and server actions also depend on DB access
+    // and would fail independently during an outage.
+    console.error("Ban check failed, failing closed:", error);
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #113 — Banned users with valid Neon Auth sessions could still sync data via PowerSync, submit mutations through the batch API, and execute server actions. The `bannedAt` check in `ensureUserExists()` only blocked settings restoration, not actual data access.

- Add shared `isUserBanned()` utility (`src/auth/ban-check.ts`) — always queries DB, fails closed on errors
- **Batch upload API**: return 403 (PowerSync connector treats as permanent error, drops queued mutations)
- **Auth token endpoint**: intercept GET `/token` to block sync credential issuance
- **App layout**: unconditional ban check, renders "Account Suspended" page with POST sign-out form
- **Server actions**: block all 6 actions (`subscribeUser`, `unsubscribeUser`, `sendNotification`, `updateLocale`, `updateTheme`, `getUserSettings`)
- 17 new tests across 5 test files

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm vitest run` — 127/127 affected tests pass
- [x] Three review passes (14 reviewer-runs) found and fixed all issues
- [ ] Verify banned user sees "Account Suspended" page (manual)
- [ ] Verify banned user cannot sync via PowerSync (manual)
- [ ] Verify banned user cannot submit mutations via batch API (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)