### PR TITLE
fix: add ban check to cookie cache fast path in getOrEnsureUserSettings

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -31,28 +31,32 @@ export default async function AppLayout({
   // Pass the pre-fetched session to avoid a duplicate auth.getSession() call.
   // Uses a cookie cache to skip the DB upsert on repeat page loads.
   // Falls through to ensureUserExists() when the cookie is absent or stale.
+  // Both paths verify ban status — null means banned or unexpected DB issue.
   const settings = await getOrEnsureUserSettings(session);
 
-  // Unconditional ban check — required because getOrEnsureUserSettings()
-  // has a cookie cache fast path that skips the DB entirely. On the cold
-  // path (no cache) this is redundant with ensureUserExists(), but the
-  // simplicity of always checking outweighs one extra lightweight query.
-  if (await isUserBanned(session.user.id)) {
-    return (
-      <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
-        <ShieldAlert className="h-16 w-16 text-destructive" />
-        <h1 className="font-semibold text-2xl">Account Suspended</h1>
-        <p className="max-w-md text-muted-foreground">
-          Your account has been suspended. If you believe this is a mistake,
-          please contact support.
-        </p>
-        <form action="/api/auth/sign-out" method="post">
-          <Button type="submit" variant="outline">
-            Sign Out
-          </Button>
-        </form>
-      </main>
-    );
+  if (!settings) {
+    // Confirm ban status to show the appropriate UI. On the fast path,
+    // isUserBanned() already ran inside getOrEnsureUserSettings(); this
+    // second call only fires for the (rare) banned-user case.
+    if (await isUserBanned(session.user.id)) {
+      return (
+        <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+          <ShieldAlert className="h-16 w-16 text-destructive" />
+          <h1 className="font-semibold text-2xl">Account Suspended</h1>
+          <p className="max-w-md text-muted-foreground">
+            Your account has been suspended. If you believe this is a mistake,
+            please contact support.
+          </p>
+          <form action="/api/auth/sign-out" method="post">
+            <Button type="submit" variant="outline">
+              Sign Out
+            </Button>
+          </form>
+        </main>
+      );
+    }
+    // Non-ban null (e.g., upsert returned zero rows). Redirect as fallback.
+    redirect("/auth/sign-in");
   }
 
   // Locale restoration from DB is handled client-side by LocaleRestorer

--- a/src/auth/ensure-user.test.ts
+++ b/src/auth/ensure-user.test.ts
@@ -76,6 +76,11 @@ vi.mock("@/auth/server", () => ({
   },
 }));
 
+const mockIsUserBanned = vi.fn().mockResolvedValue(false);
+vi.mock("@/auth/ban-check", () => ({
+  isUserBanned: mockIsUserBanned,
+}));
+
 describe("ensureUserExists", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -565,6 +570,44 @@ describe("getOrEnsureUserSettings", () => {
     const result = await getOrEnsureUserSettings();
 
     expect(result).toBeNull();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns null on fast path when user is banned", async () => {
+    const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {},
+        user: { id: uuid, email: "test@example.com", name: "Test User" },
+      },
+    });
+    mockCookieGet.mockReturnValue({ value: `${uuid}|fr|dark` });
+    mockIsUserBanned.mockResolvedValue(true);
+
+    const { getOrEnsureUserSettings } = await import("@/auth/ensure-user");
+    const result = await getOrEnsureUserSettings();
+
+    expect(result).toBeNull();
+    expect(mockIsUserBanned).toHaveBeenCalledWith(uuid);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns settings on fast path when user is not banned", async () => {
+    const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {},
+        user: { id: uuid, email: "test@example.com", name: "Test User" },
+      },
+    });
+    mockCookieGet.mockReturnValue({ value: `${uuid}|fr|dark` });
+    mockIsUserBanned.mockResolvedValue(false);
+
+    const { getOrEnsureUserSettings } = await import("@/auth/ensure-user");
+    const result = await getOrEnsureUserSettings();
+
+    expect(result).toEqual({ locale: "fr", theme: "dark" });
+    expect(mockIsUserBanned).toHaveBeenCalledWith(uuid);
     expect(mockInsert).not.toHaveBeenCalled();
   });
 });

--- a/src/auth/ensure-user.ts
+++ b/src/auth/ensure-user.ts
@@ -10,6 +10,7 @@ import { defaultLocale, isLocale } from "@/i18n/config";
 import { sendWelcomeEmail } from "@/lib/email";
 import type { Theme } from "@/lib/theme";
 import { isTheme } from "@/lib/theme";
+import { isUserBanned } from "./ban-check";
 import { auth } from "./server";
 import { parseSyncCookie, USER_SYNCED_COOKIE } from "./sync-cookie";
 
@@ -175,7 +176,7 @@ export async function ensureUserExists(
  * Returns user settings, using a cookie cache to avoid per-request DB upserts.
  *
  * Fast path: If the `user-synced` cookie exists and its userId matches the
- * current session, returns cached locale/theme without touching the database.
+ * current session, returns cached locale/theme after a lightweight ban check.
  *
  * Slow path: Falls through to `ensureUserExists()` for the full DB upsert
  * (first login, different user, expired/malformed cookie).
@@ -198,6 +199,11 @@ export async function getOrEnsureUserSettings(
   if (syncCookie) {
     const parsed = parseSyncCookie(syncCookie);
     if (parsed && parsed.userId === session.user.id) {
+      // Cookie cache only stores locale/theme — always verify ban status
+      // against the database to enforce authorization.
+      if (await isUserBanned(session.user.id)) {
+        return null;
+      }
       return { locale: parsed.locale, theme: parsed.theme };
     }
   }


### PR DESCRIPTION
## Summary

- Add `isUserBanned()` check to the cookie cache fast path in `getOrEnsureUserSettings()` so banned users get `null` instead of cached settings
- Restructure app layout to only call `isUserBanned()` when settings is `null`, eliminating a redundant DB query for non-banned users on every request
- Add 2 new tests covering banned and non-banned fast path cases

Closes #112

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (25/25 in ensure-user.test.ts)
- [ ] Verify banned user sees "Account Suspended" UI (manual)
- [ ] Verify non-banned user loads normally with cookie fast path (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)