### PR TITLE
fix: restore marketing page logo size after Logo component extraction

### DIFF
--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -19,7 +19,12 @@ export default async function MarketingLayout({
           aria-label="Main navigation"
           className="mx-auto flex h-14 max-w-5xl items-center justify-between px-6"
         >
-          <Logo className="flex items-center gap-2" height={32} width={96} />
+          <Logo
+            className="flex items-center gap-2"
+            height={32}
+            imageClassName="h-8 w-auto"
+            width={96}
+          />
           <div className="flex items-center gap-2">
             <ThemeToggle />
             <MarketingAuthButtons />

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,11 +1,13 @@
 import Image from "next/image";
 import Link from "next/link";
 import type { ReactElement } from "react";
+import { cn } from "@/lib/utils";
 
 interface LogoProps {
   className?: string;
   height: number;
   href?: string;
+  imageClassName?: string;
   width: number;
 }
 
@@ -14,12 +16,13 @@ export function Logo({
   width,
   className,
   href = "/",
+  imageClassName = "h-auto w-full",
 }: LogoProps): ReactElement {
   return (
     <Link className={className} href={href}>
       <Image
         alt=""
-        className="block h-auto w-full dark:hidden"
+        className={cn("block dark:hidden", imageClassName)}
         height={height}
         loading="eager"
         src="/logo-light.svg"
@@ -27,7 +30,7 @@ export function Logo({
       />
       <Image
         alt=""
-        className="hidden h-auto w-full dark:block"
+        className={cn("hidden dark:block", imageClassName)}
         height={height}
         loading="eager"
         src="/logo-dark.svg"


### PR DESCRIPTION
## Summary

- The Logo component refactor (`3b61a73`) generalized image classes to `h-auto w-full`, which works for the sidebar but caused the marketing homepage logo to expand to fill its flex container
- Add an `imageClassName` prop to `Logo` so callers can override image sizing (defaults to `h-auto w-full` for backward compatibility)
- Pass `h-8 w-auto` from the marketing layout to restore the original 32px fixed-height behavior

## Test plan

- [ ] `pnpm dev` — verify marketing homepage logo is ~32px tall (matches original)
- [ ] Verify sidebar logo still fills the sidebar header correctly (uses default)
- [ ] `pnpm typecheck && pnpm lint && pnpm test:run` — all pass

🤖 Generated with [Claude Code](https://claude.ai/code)