### PR TITLE
fix: exclude banned users from cleanup cron hard-delete

### DIFF
--- a/src/app/api/cron/cleanup/route.test.ts
+++ b/src/app/api/cron/cleanup/route.test.ts
@@ -236,6 +236,60 @@ describe("GET /api/cron/cleanup", () => {
       }
     });
 
+    it("excludes banned users from pre-pass tombstoning", async () => {
+      vi.stubEnv("CRON_SECRET", "test-cron-secret");
+      vi.stubEnv("DATABASE_URL", "postgres://test");
+      vi.resetModules();
+      const { GET } = await import("./route");
+
+      mockQuery.mockResolvedValue({ rowCount: 0 });
+
+      await GET(createRequest("Bearer test-cron-secret"));
+
+      const calls = mockQuery.mock.calls.map((call) => call[0] as string);
+      const updateCalls = calls.filter((q) => q.startsWith("UPDATE"));
+      expect(updateCalls.length).toBeGreaterThan(0);
+      for (const sql of updateCalls) {
+        expect(sql).toContain("banned_at IS NULL");
+      }
+    });
+
+    it("excludes banned users from user hard-delete", async () => {
+      vi.stubEnv("CRON_SECRET", "test-cron-secret");
+      vi.stubEnv("DATABASE_URL", "postgres://test");
+      vi.resetModules();
+      const { GET } = await import("./route");
+
+      mockQuery.mockResolvedValue({ rowCount: 0 });
+
+      await GET(createRequest("Bearer test-cron-secret"));
+
+      const calls = mockQuery.mock.calls.map((call) => call[0] as string);
+      const userDeleteQuery = calls.at(-1);
+      expect(userDeleteQuery).toContain('DELETE FROM "users"');
+      expect(userDeleteQuery).toContain("banned_at IS NULL");
+    });
+
+    it("does not filter by banned_at in per-table hard-deletes", async () => {
+      vi.stubEnv("CRON_SECRET", "test-cron-secret");
+      vi.stubEnv("DATABASE_URL", "postgres://test");
+      vi.resetModules();
+      const { GET } = await import("./route");
+
+      mockQuery.mockResolvedValue({ rowCount: 0 });
+
+      await GET(createRequest("Bearer test-cron-secret"));
+
+      const calls = mockQuery.mock.calls.map((call) => call[0] as string);
+      const mainDeletes = calls.filter(
+        (q) => q.includes("DELETE") && !q.includes('"users"')
+      );
+      expect(mainDeletes.length).toBeGreaterThan(0);
+      for (const sql of mainDeletes) {
+        expect(sql).not.toContain("banned_at");
+      }
+    });
+
     it("continues main cleanup when a pre-pass UPDATE fails", async () => {
       vi.stubEnv("CRON_SECRET", "test-cron-secret");
       vi.stubEnv("DATABASE_URL", "postgres://test");

--- a/src/app/api/cron/cleanup/route.ts
+++ b/src/app/api/cron/cleanup/route.ts
@@ -82,13 +82,18 @@ interface CleanupClient {
  * Without this, hard-deleting the user row would CASCADE-delete
  * children without creating tombstones, leaving orphaned rows in
  * PowerSync offline clients.
+ *
+ * Note: Banned users (banned_at IS NOT NULL) are excluded. Their data
+ * accumulates intentionally to preserve the ban record for audit and
+ * re-registration blocking. Admin intervention is required to purge
+ * a banned user's data.
  */
 async function tombstoneOrphanedChildren(client: CleanupClient): Promise<void> {
   for (const table of USER_OWNED_TABLES) {
     try {
       const quotedTable = quoteId(table);
       await client.query(
-        `UPDATE ${quotedTable} SET deleted_at = NOW(), updated_at = NOW() WHERE user_id IN (SELECT id FROM "users" WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '1 day' * $1) AND deleted_at IS NULL`,
+        `UPDATE ${quotedTable} SET deleted_at = NOW(), updated_at = NOW() WHERE user_id IN (SELECT id FROM "users" WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '1 day' * $1 AND banned_at IS NULL) AND deleted_at IS NULL`,
         [RETENTION_DAYS]
       );
     } catch (prePassError: unknown) {
@@ -154,7 +159,7 @@ async function cleanupUsers(
         `NOT EXISTS (SELECT 1 FROM ${quoteId(t)} WHERE user_id = "users".id AND deleted_at IS NOT NULL)`
     ).join(" AND ");
     const result = await client.query(
-      `WITH to_delete AS (SELECT id FROM "users" WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '1 day' * $1 AND ${childChecks} LIMIT 10000) DELETE FROM "users" WHERE id IN (SELECT id FROM to_delete)`,
+      `WITH to_delete AS (SELECT id FROM "users" WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '1 day' * $1 AND banned_at IS NULL AND ${childChecks} LIMIT 10000) DELETE FROM "users" WHERE id IN (SELECT id FROM to_delete)`,
       [RETENTION_DAYS]
     );
     results.users = result.rowCount ?? 0;


### PR DESCRIPTION
## Summary

- Add `AND banned_at IS NULL` to the pre-pass tombstoning and user hard-delete queries in the cleanup cron, so banned+soft-deleted users are preserved for audit, re-registration blocking, and moderation history
- Add JSDoc documenting the intentional data accumulation trade-off for banned users
- Add 3 tests: pre-pass ban exclusion, user DELETE ban exclusion, and a negative test confirming per-table DELETEs remain ban-unaware

Closes #114

## Test plan

- [x] `pnpm test:run src/app/api/cron/cleanup/route.test.ts` — 24/24 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] Three review passes confirmed no remaining issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)