### PR TITLE
test: add error boundary integration tests for dashboard page

### DIFF
--- a/src/app/error.integration.test.tsx
+++ b/src/app/error.integration.test.tsx
@@ -1,0 +1,210 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ErrorPage from "@/app/error";
+import { TestErrorBoundary } from "@/test/error-boundary";
+
+/**
+ * Creates a component controlled by a mutable flag.
+ * React 19 concurrent rendering retries synchronously after a throw,
+ * so a render-count approach is unreliable. Use `shouldThrow.current`
+ * to control behaviour explicitly.
+ */
+function createThrowingComponent(shouldThrow: {
+  current: boolean;
+}): () => ReactElement {
+  return function ThrowingComponent(): ReactElement {
+    if (shouldThrow.current) {
+      throw new Error("Simulated render error");
+    }
+    return <div data-testid="recovered-content">Recovered</div>;
+  };
+}
+
+describe("Dashboard error boundary integration", () => {
+  beforeEach(() => {
+    // biome-ignore lint/suspicious/noEmptyBlockStatements: suppress console.error output during tests
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders error heading when child component throws", () => {
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "errors.somethingWrong" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders error description when child component throws", () => {
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    expect(screen.getByText("errors.unexpectedError")).toBeInTheDocument();
+  });
+
+  it("renders retry button when child component throws", () => {
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole("button", { name: "errors.tryAgain" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders alert role for screen readers", () => {
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("retry re-renders children after error is cleared", async () => {
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "errors.somethingWrong" })
+    ).toBeInTheDocument();
+
+    flag.current = false;
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "errors.tryAgain" })
+    );
+
+    expect(screen.getByTestId("recovered-content")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "errors.somethingWrong" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("retry shows error again if component still throws", async () => {
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "errors.tryAgain" })
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "errors.somethingWrong" })
+    ).toBeInTheDocument();
+  });
+
+  it("sets document.title when error is caught and restores it after recovery", async () => {
+    document.title = "Dashboard | The Magic Lab";
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    expect(document.title).toBe("Error | The Magic Lab");
+
+    flag.current = false;
+    await userEvent.click(
+      screen.getByRole("button", { name: "errors.tryAgain" })
+    );
+
+    expect(document.title).toBe("Dashboard | The Magic Lab");
+  });
+
+  it("moves focus to the main element when boundary catches", () => {
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    const main = screen.getByRole("main");
+    expect(main).toHaveAttribute("tabindex", "-1");
+    expect(document.activeElement).toBe(main);
+  });
+
+  it("restores document.title when boundary unmounts while still in error state", () => {
+    document.title = "Dashboard | The Magic Lab";
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    const { unmount } = render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    expect(document.title).toBe("Error | The Magic Lab");
+    unmount();
+    expect(document.title).toBe("Dashboard | The Magic Lab");
+  });
+
+  it("handles error with digest property through boundary", () => {
+    function DigestThrower(): ReactElement {
+      throw Object.assign(new Error("digest error"), {
+        digest: "NEXT_DIGEST_abc",
+      });
+    }
+
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <DigestThrower />
+      </TestErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "errors.somethingWrong" })
+    ).toBeInTheDocument();
+  });
+
+  it("logs error to console when boundary catches", () => {
+    const flag = { current: true };
+    const Throwing = createThrowingComponent(flag);
+    render(
+      <TestErrorBoundary errorComponent={ErrorPage}>
+        <Throwing />
+      </TestErrorBoundary>
+    );
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Simulated render error" })
+    );
+  });
+});

--- a/src/test/error-boundary.tsx
+++ b/src/test/error-boundary.tsx
@@ -1,0 +1,48 @@
+import { Component, type ComponentType, type ReactNode } from "react";
+
+interface ErrorComponentProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+interface TestErrorBoundaryProps {
+  children: ReactNode;
+  errorComponent: ComponentType<ErrorComponentProps>;
+}
+
+interface TestErrorBoundaryState {
+  error: (Error & { digest?: string }) | null;
+}
+
+/**
+ * Test-only error boundary that renders the provided error component on catch.
+ * Mirrors Next.js error.tsx behaviour: passes `error` and `reset` props.
+ * React mandates a class component for error boundaries.
+ */
+class TestErrorBoundary extends Component<
+  TestErrorBoundaryProps,
+  TestErrorBoundaryState
+> {
+  state: TestErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(
+    error: Error
+  ): Partial<TestErrorBoundaryState> {
+    return { error };
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.error) {
+      const ErrorComponent = this.props.errorComponent;
+      return <ErrorComponent error={this.state.error} reset={this.reset} />;
+    }
+    return this.props.children;
+  }
+}
+
+export type { ErrorComponentProps };
+export { TestErrorBoundary };


### PR DESCRIPTION
## Summary

- Add integration tests that render the real `error.tsx` inside a `TestErrorBoundary`, verifying the user-facing error UI when a page component throws
- Add reusable `TestErrorBoundary` class component in `src/test/` that mirrors Next.js error boundary behaviour
- Uses a mutable flag pattern (not a render counter) to handle React 19 concurrent rendering retries

**11 tests covering:** error UI rendering, retry recovery, retry re-error, `document.title` lifecycle, focus management, digest propagation, and console logging.

Closes #57

## Test plan

- [x] `pnpm test:run` — all 735 tests pass (11 new)
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint` — no lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>