### PR TITLE
fix: add DB-level CHECK constraints for users.role, locale, and theme

### DIFF
--- a/src/db/migrations/0013_users_locale_theme_check_constraints.sql
+++ b/src/db/migrations/0013_users_locale_theme_check_constraints.sql
@@ -1,0 +1,21 @@
+-- Migration 0013: CHECK constraints for users.role, users.locale, and users.theme
+--
+-- Defense-in-depth: these text-enum columns are validated at the TypeScript
+-- level by Drizzle's text({ enum: [...] }) and at runtime by isLocale() /
+-- isTheme(), but no DB-level constraint existed. A buggy direct SQL write
+-- could insert invalid values.
+
+-- users.role: must be one of the 2 supported roles
+ALTER TABLE users ADD CONSTRAINT users_role_valid
+  CHECK (role IN ('user','admin')) NOT VALID;--> statement-breakpoint
+ALTER TABLE users VALIDATE CONSTRAINT users_role_valid;--> statement-breakpoint
+
+-- users.locale: must be one of the 7 supported locales
+ALTER TABLE users ADD CONSTRAINT users_locale_valid
+  CHECK (locale IN ('en','fr','es','pt','it','de','nl')) NOT VALID;--> statement-breakpoint
+ALTER TABLE users VALIDATE CONSTRAINT users_locale_valid;--> statement-breakpoint
+
+-- users.theme: must be one of the 3 supported themes
+ALTER TABLE users ADD CONSTRAINT users_theme_valid
+  CHECK (theme IN ('light','dark','system')) NOT VALID;--> statement-breakpoint
+ALTER TABLE users VALIDATE CONSTRAINT users_theme_valid;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1774502400002,
       "tag": "0012_glorious_wonder_man",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1774502400003,
+      "tag": "0013_users_locale_theme_check_constraints",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -10,11 +10,6 @@ export const users = pgTable("users", {
   role: text({ enum: ["user", "admin"] })
     .default("user")
     .notNull(),
-  // TODO: locale and theme enums are TypeScript-only — add DB-level CHECK
-  // constraints in a future migration. Locale values: en, fr, es, pt, it, de,
-  // nl. Theme values: light, dark, system. TypeScript enums provide
-  // compile-time safety, but runtime data integrity depends on
-  // application-level validation in isLocale() and isTheme().
   locale: text({ enum: locales }).default("en").notNull(),
   theme: text({ enum: ["light", "dark", "system"] })
     .default("system")


### PR DESCRIPTION
## Summary
- Add migration 0013 with DB-level `CHECK` constraints for `users.role`, `users.locale`, and `users.theme` columns
- Uses the established `NOT VALID` + `VALIDATE CONSTRAINT` two-step pattern from migration 0009
- Remove resolved TODO comment from `src/db/schema/users.ts`

These text-enum columns were only validated at the TypeScript level. A direct SQL write could insert invalid values — `role` is especially sensitive since it controls admin authorization.

## Test plan
- [x] `pnpm lint` — passes
- [x] `pnpm typecheck` — passes
- [x] `pnpm test:run` — 735/735 tests pass
- [x] `pnpm db:migrate` — migration applied successfully to Neon

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)