### PR TITLE
feat: add "Made with ❤ in Paris 🇫🇷" to footer and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,7 @@ Contributions are welcome. Please review the [documentation](docs/) to understan
 - **Documentation**: [docs/](docs/)
 - **MemDeck**: [memdeck.org](https://memdeck.org/) -- a companion project for memorized deck work
 - **GitHub**: [github.com/julienroussel/tml](https://github.com/julienroussel/tml)
+
+---
+
+<p align="center">Made with ❤ in Paris 🇫🇷</p>

--- a/src/app/(marketing)/[locale]/layout.test.tsx
+++ b/src/app/(marketing)/[locale]/layout.test.tsx
@@ -89,6 +89,12 @@ describe("MarketingLayout", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the made-in line", async () => {
+    render(await MarketingLayout(defaultProps));
+
+    expect(screen.getByText("footer.madeIn")).toBeInTheDocument();
+  });
+
   it("renders the skip-to-content link", async () => {
     render(await MarketingLayout(defaultProps));
 

--- a/src/app/(marketing)/[locale]/layout.tsx
+++ b/src/app/(marketing)/[locale]/layout.tsx
@@ -79,6 +79,7 @@ export default async function MarketingLayout({
             <p className="text-muted-foreground text-sm">
               {tFooter("copyright", { year: new Date().getFullYear() })}
             </p>
+            <p className="text-muted-foreground text-sm">{tFooter("madeIn")}</p>
             <nav aria-label={tCommon("footerLinks")} className="flex gap-4">
               <Link
                 className="text-muted-foreground text-sm transition-colors hover:text-foreground"

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -190,7 +190,8 @@
     "memDeck": "MemDeck",
     "memDeckSrOnly": "(öffnet in einem neuen Tab)",
     "gitHub": "GitHub",
-    "gitHubSrOnly": "(öffnet in einem neuen Tab)"
+    "gitHubSrOnly": "(öffnet in einem neuen Tab)",
+    "madeIn": "Made with ❤ in Paris 🇫🇷"
   },
   "auth": {
     "SIGN_IN": "Anmelden",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -190,7 +190,8 @@
     "memDeck": "MemDeck",
     "memDeckSrOnly": "(opens in a new tab)",
     "gitHub": "GitHub",
-    "gitHubSrOnly": "(opens in a new tab)"
+    "gitHubSrOnly": "(opens in a new tab)",
+    "madeIn": "Made with ❤ in Paris 🇫🇷"
   },
   "auth": {
     "SIGN_IN": "Sign In",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -190,7 +190,8 @@
     "memDeck": "MemDeck",
     "memDeckSrOnly": "(se abre en una pestaña nueva)",
     "gitHub": "GitHub",
-    "gitHubSrOnly": "(se abre en una pestaña nueva)"
+    "gitHubSrOnly": "(se abre en una pestaña nueva)",
+    "madeIn": "Hecho con ❤ en París 🇫🇷"
   },
   "auth": {
     "SIGN_IN": "Iniciar sesión",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -190,7 +190,8 @@
     "memDeck": "MemDeck",
     "memDeckSrOnly": "(s'ouvre dans un nouvel onglet)",
     "gitHub": "GitHub",
-    "gitHubSrOnly": "(s'ouvre dans un nouvel onglet)"
+    "gitHubSrOnly": "(s'ouvre dans un nouvel onglet)",
+    "madeIn": "Fait avec ❤ à Paris 🇫🇷"
   },
   "auth": {
     "SIGN_IN": "Connexion",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -190,7 +190,8 @@
     "memDeck": "MemDeck",
     "memDeckSrOnly": "(si apre in una nuova scheda)",
     "gitHub": "GitHub",
-    "gitHubSrOnly": "(si apre in una nuova scheda)"
+    "gitHubSrOnly": "(si apre in una nuova scheda)",
+    "madeIn": "Fatto con ❤ a Parigi 🇫🇷"
   },
   "auth": {
     "SIGN_IN": "Accedi",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -190,7 +190,8 @@
     "memDeck": "MemDeck",
     "memDeckSrOnly": "(opent in een nieuw tabblad)",
     "gitHub": "GitHub",
-    "gitHubSrOnly": "(opent in een nieuw tabblad)"
+    "gitHubSrOnly": "(opent in een nieuw tabblad)",
+    "madeIn": "Gemaakt met ❤ in Parijs 🇫🇷"
   },
   "auth": {
     "SIGN_IN": "Inloggen",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -190,7 +190,8 @@
     "memDeck": "MemDeck",
     "memDeckSrOnly": "(abre num novo separador)",
     "gitHub": "GitHub",
-    "gitHubSrOnly": "(abre num novo separador)"
+    "gitHubSrOnly": "(abre num novo separador)",
+    "madeIn": "Feito com ❤ em Paris 🇫🇷"
   },
   "auth": {
     "SIGN_IN": "Iniciar sessão",


### PR DESCRIPTION
## Summary

- Add localized `footer.madeIn` i18n key across all 7 locale files (en, fr, es, pt, it, de, nl)
- Render the translated "Made with ❤ in Paris 🇫🇷" line below the copyright in the marketing footer
- Add corresponding test in the layout test suite
- Append a centered tagline at the bottom of README.md

Closes #126

## Test plan

- [x] `pnpm i18n:check` — all locales have matching keys
- [x] `pnpm lint` — no lint errors
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm test:run` — all 807 tests pass
- [ ] CI passes on this PR
- [ ] Visual check: visit `/en`, `/fr`, `/es` etc. and confirm footer text renders

🤖 Generated with [Claude Code](https://claude.ai/code)