### PR TITLE
fix: correct non-monotonic timestamps in migration journal

### DIFF
--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -26,14 +26,14 @@
     {
       "idx": 3,
       "version": "7",
-      "when": 1773657128371,
+      "when": 1773872400001,
       "tag": "0003_worried_screwball",
       "breakpoints": true
     },
     {
       "idx": 4,
       "version": "7",
-      "when": 1773696393683,
+      "when": 1773872400002,
       "tag": "0004_small_ezekiel_stane",
       "breakpoints": true
     },
@@ -47,7 +47,7 @@
     {
       "idx": 6,
       "version": "7",
-      "when": 1773872305136,
+      "when": 1774070400001,
       "tag": "0006_wakeful_nemesis",
       "breakpoints": true
     },
@@ -61,7 +61,7 @@
     {
       "idx": 8,
       "version": "7",
-      "when": 1774037051824,
+      "when": 1774243200001,
       "tag": "0008_crazy_roulette",
       "breakpoints": true
     },


### PR DESCRIPTION
## Summary

- Fixed 4 non-monotonic `when` timestamps in `_journal.json` (entries 0003, 0004, 0006, 0008) that caused drizzle-orm to silently skip tracking migrations 0006 and 0008
- Backfilled the 2 missing tracking rows in `drizzle.__drizzle_migrations` on both Neon branches (`main` and `dev/julien`)
- Updated `created_at` values for entries 0003 and 0004 on both branches to match the corrected journal

## Test plan

- [x] Verified both Neon branches now have 14/14 migration tracking rows with monotonically increasing timestamps
- [x] `pnpm db:migrate` completes successfully with nothing to apply
- [x] `pnpm db:generate` reports "No schema changes, nothing to migrate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)