### PR TITLE
fix: harden root error boundary fallback and increase touch targets

### DIFF
--- a/src/app/(app)/account/error.tsx
+++ b/src/app/(app)/account/error.tsx
@@ -33,10 +33,10 @@ export default function AccountError({
         <p className="text-muted-foreground">{t("unexpectedError")}</p>
       </div>
       <div className="flex gap-2">
-        <Button onClick={reset} type="button">
+        <Button className="min-h-11" onClick={reset} type="button">
           {t("tryAgain")}
         </Button>
-        <Button asChild variant="outline">
+        <Button asChild className="min-h-11" variant="outline">
           <Link href="/dashboard">{tCommon("goToDashboard")}</Link>
         </Button>
       </div>

--- a/src/app/auth/error.tsx
+++ b/src/app/auth/error.tsx
@@ -34,10 +34,10 @@ export default function AuthError({
         <p className="text-muted-foreground">{t("authErrorDesc")}</p>
       </div>
       <div className="flex gap-2">
-        <Button onClick={reset} type="button">
+        <Button className="min-h-11" onClick={reset} type="button">
           {t("tryAgain")}
         </Button>
-        <Button asChild variant="outline">
+        <Button asChild className="min-h-11" variant="outline">
           <Link href="/">{t("goHome")}</Link>
         </Button>
       </div>

--- a/src/app/error.test.tsx
+++ b/src/app/error.test.tsx
@@ -124,6 +124,73 @@ describe("ErrorPage", () => {
     ).toBeInTheDocument();
   });
 
+  describe("fallback when messages are unavailable", () => {
+    let errorMessagesRef: typeof import("@/i18n/messages/errors-only").errorMessages;
+    let originalEn: (typeof errorMessagesRef)["en"];
+
+    beforeEach(async () => {
+      const mod = await import("@/i18n/messages/errors-only");
+      errorMessagesRef = mod.errorMessages;
+      originalEn = errorMessagesRef.en;
+      // @ts-expect-error — intentionally setting to undefined for runtime safety test
+      errorMessagesRef.en = undefined;
+      providerMock.mockClear();
+    });
+
+    afterEach(() => {
+      errorMessagesRef.en = originalEn;
+    });
+
+    it("renders hardcoded English strings when errorMessages returns undefined", () => {
+      render(<ErrorPage error={new Error("test")} reset={vi.fn()} />);
+
+      expect(
+        screen.getByRole("heading", { name: "Something went wrong" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("An unexpected error occurred.")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Try again" })
+      ).toBeInTheDocument();
+      expect(document.title).toBe("Error | The Magic Lab");
+    });
+
+    it("does not render NextIntlClientProvider in fallback mode", () => {
+      render(<ErrorPage error={new Error("test")} reset={vi.fn()} />);
+
+      expect(providerMock).not.toHaveBeenCalled();
+    });
+
+    it("calls reset via fallback retry button", async () => {
+      const reset = vi.fn();
+      render(<ErrorPage error={new Error("test")} reset={reset} />);
+      await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+      expect(reset).toHaveBeenCalledOnce();
+    });
+
+    it("falls back to English when a non-default locale has no messages", () => {
+      // Restore en so only fr is missing
+      errorMessagesRef.en = originalEn;
+      const originalFr = errorMessagesRef.fr;
+      // @ts-expect-error — intentionally setting to undefined for runtime safety test
+      errorMessagesRef.fr = undefined;
+      document.documentElement.lang = "fr";
+
+      try {
+        render(<ErrorPage error={new Error("test")} reset={vi.fn()} />);
+
+        expect(
+          screen.getByRole("heading", { name: "Something went wrong" })
+        ).toBeInTheDocument();
+        expect(providerMock).not.toHaveBeenCalled();
+      } finally {
+        errorMessagesRef.fr = originalFr;
+        document.documentElement.lang = "";
+      }
+    });
+  });
+
   describe("locale detection", () => {
     afterEach(() => {
       document.documentElement.lang = "";

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -7,14 +7,30 @@ import { Button } from "@/components/ui/button";
 import { defaultLocale, isLocale, type Locale } from "@/i18n/config";
 import { errorMessages } from "@/i18n/messages/errors-only";
 
-function ErrorContent({
+const FALLBACK = {
+  pageTitle: "Error | The Magic Lab",
+  somethingWrong: "Something went wrong",
+  unexpectedError: "An unexpected error occurred.",
+  tryAgain: "Try again",
+} as const;
+
+interface ErrorDisplayProps {
+  buttonLabel: string;
+  description: string;
+  error: Error & { digest?: string };
+  heading: string;
+  pageTitle: string;
+  reset: () => void;
+}
+
+function ErrorDisplay({
   error,
   reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}): ReactElement {
-  const t = useTranslations("errors");
+  pageTitle,
+  heading,
+  description,
+  buttonLabel,
+}: ErrorDisplayProps): ReactElement {
   const mainRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -24,11 +40,11 @@ function ErrorContent({
 
   useEffect(() => {
     const previousTitle = document.title;
-    document.title = t("pageTitle");
+    document.title = pageTitle;
     return () => {
       document.title = previousTitle;
     };
-  }, [t]);
+  }, [pageTitle]);
 
   return (
     <main
@@ -38,13 +54,34 @@ function ErrorContent({
       tabIndex={-1}
     >
       <div role="alert">
-        <h1 className="font-semibold text-xl">{t("somethingWrong")}</h1>
-        <p className="text-muted-foreground">{t("unexpectedError")}</p>
+        <h1 className="font-semibold text-xl">{heading}</h1>
+        <p className="text-muted-foreground">{description}</p>
       </div>
-      <Button onClick={reset} type="button">
-        {t("tryAgain")}
+      <Button className="min-h-11" onClick={reset} type="button">
+        {buttonLabel}
       </Button>
     </main>
+  );
+}
+
+function ErrorContent({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}): ReactElement {
+  const t = useTranslations("errors");
+
+  return (
+    <ErrorDisplay
+      buttonLabel={t("tryAgain")}
+      description={t("unexpectedError")}
+      error={error}
+      heading={t("somethingWrong")}
+      pageTitle={t("pageTitle")}
+      reset={reset}
+    />
   );
 }
 
@@ -52,6 +89,9 @@ function ErrorContent({
  * Root error boundary. Provides its own NextIntlClientProvider since
  * the root layout does not include one — intl providers live in the
  * route-group sub-layouts which may have been the source of the error.
+ *
+ * Falls back to hardcoded English strings if the locale messages fail
+ * to resolve (e.g., during early hydration errors or code-split races).
  */
 export default function ErrorPage({
   error,
@@ -68,12 +108,23 @@ export default function ErrorPage({
     return isLocale(lang) ? lang : defaultLocale;
   });
 
+  const messages = errorMessages[locale];
+
+  if (!messages) {
+    return (
+      <ErrorDisplay
+        buttonLabel={FALLBACK.tryAgain}
+        description={FALLBACK.unexpectedError}
+        error={error}
+        heading={FALLBACK.somethingWrong}
+        pageTitle={FALLBACK.pageTitle}
+        reset={reset}
+      />
+    );
+  }
+
   return (
-    <NextIntlClientProvider
-      locale={locale}
-      messages={errorMessages[locale]}
-      timeZone="UTC"
-    >
+    <NextIntlClientProvider locale={locale} messages={messages} timeZone="UTC">
       <ErrorContent error={error} reset={reset} />
     </NextIntlClientProvider>
   );

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -42,7 +42,7 @@ export default function GlobalError({
             </p>
           </div>
           <button
-            className="rounded-md bg-primary px-4 py-2 text-primary-foreground text-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="min-h-11 rounded-md bg-primary px-4 py-2 text-primary-foreground text-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             onClick={reset}
             type="button"
           >

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -19,7 +19,7 @@ export default async function NotFound(): Promise<ReactElement> {
     >
       <h1 className="font-semibold text-xl">{t("notFound")}</h1>
       <p className="text-muted-foreground">{t("notFoundDesc")}</p>
-      <Button asChild>
+      <Button asChild className="min-h-11">
         <Link href="/">{t("goHome")}</Link>
       </Button>
     </main>


### PR DESCRIPTION
## Summary

- **#141**: Root error boundary crashed with `MISSING_MESSAGE` when locale messages failed to resolve during early hydration. Added a hardcoded English fallback path that renders when `errorMessages[locale]` is falsy, ensuring the boundary never throws.
- **#137**: All error page buttons used the default 36px height, below the project's 44px minimum. Added `min-h-11` to every button across all 5 error pages.
- Extracted a shared `ErrorDisplay` presentational component to eliminate duplication between the i18n and fallback code paths.

Closes #141
Closes #137

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test:run` — 1145 tests pass (27 in error page suites, including 4 new fallback tests)
- [x] `pnpm build` — production build succeeds
- [ ] CI passes on this PR
- [ ] Manual: verify error pages render correctly with 44px+ touch targets
- [ ] Manual: break `errors-only.ts` export to confirm fallback renders

🤖 Generated with [Claude Code](https://claude.ai/claude-code)