### PR TITLE
fix: sync <html lang> with user locale before first paint

### DIFF
--- a/src/app/(marketing)/[locale]/layout.tsx
+++ b/src/app/(marketing)/[locale]/layout.tsx
@@ -47,10 +47,10 @@ export default async function MarketingLayout({
       >
         {tCommon("skipToContent")}
       </a>
-      {/* lang={locale} provides correct language context for this subtree.
-          The root <html lang="en"> is a trade-off for static generation —
-          the DynamicIntlProvider's useEffect syncs the correct lang on hydration
-          for app routes. Marketing pages use this div-level override instead. */}
+      {/* lang={locale} provides correct language context for non-JS crawlers
+          that don't execute the root layout's blocking lang script. The script
+          handles browser-based AT; this div-level attribute is a fallback for
+          pure-HTML consumers (e.g., RSS readers, search engine preview). */}
       <div className="relative flex min-h-screen flex-col" lang={locale}>
         <header className="sticky top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <nav

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Geist } from "next/font/google";
 import type { ReactElement, ReactNode } from "react";
 import { ServiceWorkerRegistration } from "@/components/sw-registration";
 import { ThemeProvider } from "@/components/theme-provider";
+import { LANG_SCRIPT } from "@/lib/lang-script";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -64,6 +65,10 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} antialiased`}>
+        {/* Sync <html lang> with the user's locale before first paint.
+            See src/lib/lang-script.ts for detection logic. */}
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: blocking inline script for a11y — same pattern as next-themes anti-flicker */}
+        <script dangerouslySetInnerHTML={{ __html: LANG_SCRIPT }} />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}
         </ThemeProvider>

--- a/src/i18n/client-provider.tsx
+++ b/src/i18n/client-provider.tsx
@@ -89,9 +89,10 @@ export function DynamicIntlProvider({
     switchLocale: (newLocale: Locale) => switchLocaleRef.current(newLocale),
   });
 
-  // Keep <html lang> in sync for app routes where locale comes from cookie,
-  // not from a URL segment. Marketing pages use <div lang={locale}> instead.
-  // Guard avoids unnecessary DOM mutation on marketing pages where lang already matches.
+  // Secondary sync: keeps <html lang> correct when the user switches
+  // locale client-side (e.g., via settings). The primary sync is the
+  // blocking inline script in the root layout (src/lib/lang-script.ts)
+  // which handles initial page load before hydration.
   useEffect(() => {
     if (document.documentElement.lang !== locale) {
       document.documentElement.lang = locale;

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -48,7 +48,7 @@ function cspDirectiveNames(
 const BASE_DIRECTIVES: CspDirectives = {
   "default-src": ["'self'"],
   // 'unsafe-inline' allows inline scripts (e.g., next-themes' ThemeProvider
-  // anti-flicker script injected in the root layout). A nonce-based policy
+  // anti-flicker script and the lang-detection script in the root layout). A nonce-based policy
   // would be more restrictive, but the root layout must stay static (no
   // headers() call) for marketing pages, so ThemeProvider cannot receive a
   // per-request nonce. React's default output escaping provides XSS protection.

--- a/src/lib/lang-script.test.ts
+++ b/src/lib/lang-script.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LANG_SCRIPT } from "./lang-script";
+
+/** Clear all jsdom cookies by expiring them. */
+function clearCookies(): void {
+  for (const pair of document.cookie.split(";")) {
+    const name = pair.split("=")[0]?.trim();
+    // biome-ignore lint/suspicious/noDocumentCookie: testing requires direct cookie manipulation
+    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+  }
+}
+
+/**
+ * Runs the lang-detection script in jsdom with a controlled URL and cookies.
+ * Each cookie must be set via a separate assignment (browser API constraint).
+ */
+function runScript(pathname: string, cookies: string[] = []): string {
+  document.documentElement.lang = "en";
+  Object.defineProperty(window, "location", {
+    value: { pathname },
+    writable: true,
+    configurable: true,
+  });
+  clearCookies();
+  for (const cookie of cookies) {
+    // biome-ignore lint/suspicious/noDocumentCookie: testing requires direct cookie manipulation
+    document.cookie = cookie;
+  }
+
+  // biome-ignore lint/security/noGlobalEval: intentional — testing the inline script string
+  eval(LANG_SCRIPT);
+  return document.documentElement.lang;
+}
+
+describe("LANG_SCRIPT", () => {
+  beforeEach(() => {
+    document.documentElement.lang = "en";
+  });
+
+  afterEach(() => {
+    clearCookies();
+  });
+
+  describe("marketing URL detection", () => {
+    it("sets lang from a root locale path", () => {
+      expect(runScript("/fr")).toBe("fr");
+    });
+
+    it("sets lang from a locale path with subpage", () => {
+      expect(runScript("/es/faq")).toBe("es");
+    });
+
+    it("handles all supported locales", () => {
+      for (const locale of ["en", "fr", "es", "pt", "it", "de", "nl"]) {
+        expect(runScript(`/${locale}`)).toBe(locale);
+      }
+    });
+
+    it("ignores an invalid two-letter path segment", () => {
+      expect(runScript("/xx")).toBe("en");
+    });
+
+    it("ignores a path segment longer than two letters", () => {
+      expect(runScript("/french")).toBe("en");
+    });
+  });
+
+  describe("NEXT_LOCALE cookie detection", () => {
+    it("sets lang from cookie on non-marketing paths", () => {
+      expect(runScript("/dashboard", ["NEXT_LOCALE=fr"])).toBe("fr");
+    });
+
+    it("ignores an invalid cookie locale", () => {
+      expect(runScript("/dashboard", ["NEXT_LOCALE=xx"])).toBe("en");
+    });
+
+    it("reads cookie among other cookies", () => {
+      expect(
+        runScript("/dashboard", ["theme=dark", "NEXT_LOCALE=de", "other=value"])
+      ).toBe("de");
+    });
+  });
+
+  describe("precedence and fallback", () => {
+    it("URL locale takes precedence over cookie", () => {
+      expect(runScript("/de", ["NEXT_LOCALE=fr"])).toBe("de");
+    });
+
+    it("keeps lang='en' when no locale signal exists", () => {
+      expect(runScript("/dashboard")).toBe("en");
+    });
+
+    it("keeps lang='en' for the root path with no cookie", () => {
+      expect(runScript("/")).toBe("en");
+    });
+  });
+});

--- a/src/lib/lang-script.ts
+++ b/src/lib/lang-script.ts
@@ -1,0 +1,17 @@
+import { locales } from "@/i18n/config";
+
+/**
+ * Blocking inline script that corrects `<html lang>` before first paint.
+ *
+ * Mirrors the next-themes anti-flicker pattern: runs synchronously in `<body>`
+ * before React hydration so screen readers and assistive technology announce
+ * the correct language from the very first frame.
+ *
+ * Detection order:
+ * 1. URL path segment (marketing pages: /fr, /es/faq, etc.)
+ * 2. NEXT_LOCALE cookie (app and auth pages)
+ * 3. Fallback: keep the SSR default ("en")
+ *
+ * @see https://github.com/julienroussel/tml/issues/124
+ */
+export const LANG_SCRIPT = `(function(){try{var v=[${locales.map((l) => `"${l}"`).join(",")}];var m=location.pathname.match(/^\\/([a-z]{2})(\\/|$)/);if(m&&v.indexOf(m[1])!==-1){document.documentElement.lang=m[1];return}var c=document.cookie.match(/(?:^|;\\s*)NEXT_LOCALE=([^;]*)/);if(c&&v.indexOf(c[1])!==-1){document.documentElement.lang=c[1]}}catch(e){}})()`;


### PR DESCRIPTION
## Summary

- Add a blocking inline script to the root layout that sets `document.documentElement.lang` before React hydration, fixing WCAG 3.1.1 compliance for non-English users
- Script detects locale from URL path (marketing pages) or `NEXT_LOCALE` cookie (app/auth pages), validated against the locale allowlist
- Mirrors the proven next-themes anti-flicker pattern — no CSP changes needed
- Existing workarounds (`<div lang={locale}>` and `useEffect` sync) kept as defense-in-depth with updated comments

Closes #124

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes (1160 tests including 11 new lang-script tests)
- [ ] Open `/fr` in browser → inspect `<html lang>` → should be `"fr"` immediately
- [ ] Open `/dashboard` with `NEXT_LOCALE=fr` cookie → `<html lang>` should be `"fr"`
- [ ] Open `/` with no cookie → `<html lang>` should remain `"en"`
- [ ] View source confirms SSR HTML still has `lang="en"` (expected — script corrects on client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)