### PR TITLE
docs: fix documentation inaccuracies found by codebase audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ pnpm db:migrate     # Apply pending migrations to Neon
 pnpm db:studio      # Open Drizzle Studio GUI
 pnpm i18n:check     # Validate all locales have matching keys
 pnpm docs:generate  # Regenerate llms.txt files from docs/
+pnpm email:dev      # Start React Email dev server (port 3030)
 pnpm screenshots    # Regenerate PWA manifest screenshots (dev server must be running)
 pnpm setup          # Initial project setup
 ```
@@ -62,7 +63,7 @@ Requires Node 24.x and pnpm >= 10.
 
 ### Route Groups
 
-- `src/app/(app)/` — authenticated routes (dashboard, settings, feature modules). Protected by `proxy.ts`. Dynamic (server-rendered on demand).
+- `src/app/(app)/` — authenticated routes (dashboard, repertoire, settings, account, feature modules). Protected by `proxy.ts`. Dynamic (server-rendered on demand). Notable non-module routes: `/repertoire` (trick CRUD — fully implemented, lives outside the module registry), `/account/[path]` (Neon Auth account management via `AccountView`).
 - `src/app/(marketing)/[locale]/` — public pages (landing, FAQ, privacy). URL-based locale routing with `generateStaticParams` for all 7 locales. Statically generated at build time (21 pages). Bare paths (`/`, `/faq`, `/privacy`) are 302-redirected by proxy to locale-prefixed versions.
 - `src/app/auth/` — sign-in / sign-up pages. Dynamic (reads `NEXT_LOCALE` cookie for locale-aware rendering). Authenticated users are redirected to `/dashboard`.
 - `src/app/api/` — API route handlers (PowerSync upload, auth, unsubscribe, etc.).
@@ -185,7 +186,7 @@ Type safety is a first-class concern. All code must be rigorously typed.
 - **Read path**: Neon → PowerSync Cloud → client SQLite → `useQuery()` → React component
 - **Conflict resolution**: Last-write-wins with `updated_at` timestamps
 - **Deletion**: Soft-delete with `deleted_at` tombstone, 30-day hard-delete cleanup
-- **Connector allowlists**: New synced tables MUST be added to `SYNCED_TABLE_NAMES` and `SYNCED_COLUMNS` in `src/sync/connector.ts` — unlisted tables/columns are silently rejected
+- **Connector allowlists**: New synced tables MUST be added to `SYNCED_TABLE_NAMES` and `SYNCED_COLUMNS` in `src/sync/queries.ts` — unlisted tables/columns are silently rejected
 - **Mutation scoping**: The connector forces the authenticated `user_id` on all writes server-side — never trusted from the client
 - **Error semantics**: 4xx responses are permanent (mutation dropped); 5xx/network errors trigger PowerSync retry
 

--- a/docs/route-structure.md
+++ b/docs/route-structure.md
@@ -35,6 +35,7 @@ Marketing pages use URL-based locale routing for SEO. Each page is statically ge
 | Path | Page | Module | Description |
 |---|---|---|---|
 | `/dashboard` | Dashboard | -- | Home with module grid and quick stats |
+| `/repertoire` | Repertoire | -- | Trick CRUD with tags, filtering, and search |
 | `/improve` | Improve | Improve | Practice session logging and history |
 | `/train` | Train | Train | Goal setting, drills, streaks |
 | `/plan` | Plan | Plan | Setlist builder |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,43 +66,23 @@ The following are excluded from coverage metrics (configured in `vitest.config.m
 
 ## Test Utilities
 
-### Test Factories (Planned)
+### Test Factories
 
-```typescript
-// src/test/factories.ts
-function createTrick(overrides?: Partial<Trick>): Trick {
-  return {
-    id: crypto.randomUUID() as TrickId,
-    name: "Ambitious Card",
-    category: "card",
-    difficulty: 3,
-    ...overrides,
-  };
-}
-```
+`src/test/factories.ts` provides `createTestUser()`, `createTestTrick()`, `createTestSetlist()`, `createTestTag()`, `createTestTrickTag()`, `createTestPracticeSession()`, `createTestPerformance()`, `createTestItem()`, `createTestGoal()`, and more. Each returns a fully-typed entity with sensible defaults and deterministic IDs.
 
-### Mock Providers (Planned)
+### Mock Providers
 
-```typescript
-// src/test/render.tsx
-function renderWithProviders(ui: ReactElement, options?: RenderOptions) {
-  return render(ui, {
-    wrapper: ({ children }) => (
-      <ThemeProvider>
-        <PowerSyncProvider>{children}</PowerSyncProvider>
-      </ThemeProvider>
-    ),
-    ...options,
-  });
-}
-```
+`src/test/render.tsx` exports a custom `renderWithProviders()` wrapper that includes `NextIntlClientProvider` (locale `"en"`, UTC timezone). ThemeProvider and PowerSync are omitted by default — add them per-test when needed.
 
-### Common Mocks (Planned)
+### Common Mocks
 
-- `next/navigation` (useRouter, usePathname, useSearchParams)
-- `next/image` (renders as plain img)
-- PowerSync hooks (useQuery, useStatus)
-- Better Auth hooks (useSession)
+`src/test/mocks.tsx` activates mocks for:
+
+- `next/navigation` (useRouter, usePathname, useSearchParams, useParams, redirect, notFound)
+- `next/image` (renders as plain `<img>`)
+- `next/link` (renders as plain `<a>`)
+
+Importing the file activates all mocks via hoisted `vi.mock()` calls.
 
 ## Test Patterns
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -2057,6 +2057,7 @@ Marketing pages use URL-based locale routing for SEO. Each page is statically ge
 | Path | Page | Module | Description |
 |---|---|---|---|
 | `/dashboard` | Dashboard | -- | Home with module grid and quick stats |
+| `/repertoire` | Repertoire | -- | Trick CRUD with tags, filtering, and search |
 | `/improve` | Improve | Improve | Practice session logging and history |
 | `/train` | Train | Train | Goal setting, drills, streaks |
 | `/plan` | Plan | Plan | Setlist builder |
@@ -2341,43 +2342,23 @@ The following are excluded from coverage metrics (configured in `vitest.config.m
 
 ## Test Utilities
 
-### Test Factories (Planned)
+### Test Factories
 
-```typescript
-// src/test/factories.ts
-function createTrick(overrides?: Partial<Trick>): Trick {
-  return {
-    id: crypto.randomUUID() as TrickId,
-    name: "Ambitious Card",
-    category: "card",
-    difficulty: 3,
-    ...overrides,
-  };
-}
-```
+`src/test/factories.ts` provides `createTestUser()`, `createTestTrick()`, `createTestSetlist()`, `createTestTag()`, `createTestTrickTag()`, `createTestPracticeSession()`, `createTestPerformance()`, `createTestItem()`, `createTestGoal()`, and more. Each returns a fully-typed entity with sensible defaults and deterministic IDs.
 
-### Mock Providers (Planned)
+### Mock Providers
 
-```typescript
-// src/test/render.tsx
-function renderWithProviders(ui: ReactElement, options?: RenderOptions) {
-  return render(ui, {
-    wrapper: ({ children }) => (
-      <ThemeProvider>
-        <PowerSyncProvider>{children}</PowerSyncProvider>
-      </ThemeProvider>
-    ),
-    ...options,
-  });
-}
-```
+`src/test/render.tsx` exports a custom `renderWithProviders()` wrapper that includes `NextIntlClientProvider` (locale `"en"`, UTC timezone). ThemeProvider and PowerSync are omitted by default — add them per-test when needed.
 
-### Common Mocks (Planned)
+### Common Mocks
 
-- `next/navigation` (useRouter, usePathname, useSearchParams)
-- `next/image` (renders as plain img)
-- PowerSync hooks (useQuery, useStatus)
-- Better Auth hooks (useSession)
+`src/test/mocks.tsx` activates mocks for:
+
+- `next/navigation` (useRouter, usePathname, useSearchParams, useParams, redirect, notFound)
+- `next/image` (renders as plain `<img>`)
+- `next/link` (renders as plain `<a>`)
+
+Importing the file activates all mocks via hoisted `vi.mock()` calls.
 
 ## Test Patterns
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Add missing `pnpm email:dev` command, document `/repertoire` and `/account/[path]` routes in Route Groups, fix `SYNCED_TABLE_NAMES`/`SYNCED_COLUMNS` file location from `connector.ts` to `queries.ts`
- **docs/route-structure.md**: Add `/repertoire` to App Routes table
- **docs/testing.md**: Update test utilities section from "Planned" to actual implementations (factories, mocks, render wrapper all exist)
- **public/llms-full.txt**: Regenerated via `pnpm docs:generate`

All fixes were verified by 4 parallel audit agents that checked every claim against the actual codebase.

## Test plan

- [ ] `pnpm lint` passes (no code changes)
- [ ] `pnpm docs:generate` output matches committed `llms-full.txt`
- [ ] Verify CLAUDE.md route groups match actual `src/app/(app)/` contents
- [ ] Verify `SYNCED_TABLE_NAMES` is in `src/sync/queries.ts` (not `connector.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)