### PR TITLE
fix: add CHECK constraint on tricks.duration column (0-7200)

### DIFF
--- a/docs/diagrams/route-map.md
+++ b/docs/diagrams/route-map.md
@@ -1,6 +1,6 @@
 # Route Map
 
-<!-- Last verified: 2026-04-01 -->
+<!-- Last verified: 2026-04-02 -->
 
 ## Route Structure
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1000,7 +1000,7 @@ Source: docs/diagrams/route-map.md
 
 # Route Map
 
-<!-- Last verified: 2026-04-01 -->
+<!-- Last verified: 2026-04-02 -->
 
 ## Route Structure
 

--- a/src/db/migrations/0016_tricks_duration_check_constraint.sql
+++ b/src/db/migrations/0016_tricks_duration_check_constraint.sql
@@ -1,0 +1,4 @@
+-- tricks.duration: 0-7200 seconds (nullable)
+ALTER TABLE "tricks" ADD CONSTRAINT "tricks_duration_range"
+  CHECK ("duration" BETWEEN 0 AND 7200) NOT VALID;--> statement-breakpoint
+ALTER TABLE "tricks" VALIDATE CONSTRAINT "tricks_duration_range";

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1774505976152,
       "tag": "0015_gifted_firebrand",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1775111777730,
+      "tag": "0016_tricks_duration_check_constraint",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add database-level `CHECK ("duration" BETWEEN 0 AND 7200)` constraint on the `tricks` table as defense-in-depth alongside existing client-side Zod validation (`.min(0).max(7200)`)
- Uses the established `NOT VALID` + `VALIDATE CONSTRAINT` two-step pattern to avoid table locks during migration
- Migration already applied to Neon — this PR ships the migration file and journal entry

Closes #145

## Test plan

- [x] `pnpm db:migrate` succeeds (already applied)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:run` passes (1172 tests)
- [x] `pnpm docs:generate` produces only expected date bump
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)