### PR TITLE
feat: localize module registry labels and descriptions via next-intl

### DIFF
--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
 import { ModuleComingSoon } from "@/components/module-coming-soon";
-import { getModule } from "@/lib/modules";
 
-const mod = getModule("admin");
-
-export const metadata: Metadata = {
-  title: mod.label,
-  description: mod.description,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("admin");
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
 
 export default function AdminPage(): ReactElement {
   return <ModuleComingSoon slug="admin" />;

--- a/src/app/(app)/collect/page.tsx
+++ b/src/app/(app)/collect/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
 import { ModuleComingSoon } from "@/components/module-coming-soon";
-import { getModule } from "@/lib/modules";
 
-const mod = getModule("collect");
-
-export const metadata: Metadata = {
-  title: mod.label,
-  description: mod.description,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("collect");
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
 
 export default function CollectPage(): ReactElement {
   return <ModuleComingSoon slug="collect" />;

--- a/src/app/(app)/enhance/page.tsx
+++ b/src/app/(app)/enhance/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
 import { ModuleComingSoon } from "@/components/module-coming-soon";
-import { getModule } from "@/lib/modules";
 
-const mod = getModule("enhance");
-
-export const metadata: Metadata = {
-  title: mod.label,
-  description: mod.description,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("enhance");
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
 
 export default function EnhancePage(): ReactElement {
   return <ModuleComingSoon slug="enhance" />;

--- a/src/app/(app)/improve/page.tsx
+++ b/src/app/(app)/improve/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
 import { ModuleComingSoon } from "@/components/module-coming-soon";
-import { getModule } from "@/lib/modules";
 
-const mod = getModule("improve");
-
-export const metadata: Metadata = {
-  title: mod.label,
-  description: mod.description,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("improve");
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
 
 export default function ImprovePage(): ReactElement {
   return <ModuleComingSoon slug="improve" />;

--- a/src/app/(app)/perform/page.tsx
+++ b/src/app/(app)/perform/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
 import { ModuleComingSoon } from "@/components/module-coming-soon";
-import { getModule } from "@/lib/modules";
 
-const mod = getModule("perform");
-
-export const metadata: Metadata = {
-  title: mod.label,
-  description: mod.description,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("perform");
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
 
 export default function PerformPage(): ReactElement {
   return <ModuleComingSoon slug="perform" />;

--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
 import { ModuleComingSoon } from "@/components/module-coming-soon";
-import { getModule } from "@/lib/modules";
 
-const mod = getModule("plan");
-
-export const metadata: Metadata = {
-  title: mod.label,
-  description: mod.description,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("plan");
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
 
 export default function PlanPage(): ReactElement {
   return <ModuleComingSoon slug="plan" />;

--- a/src/app/(app)/train/page.tsx
+++ b/src/app/(app)/train/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
 import { ModuleComingSoon } from "@/components/module-coming-soon";
-import { getModule } from "@/lib/modules";
 
-const mod = getModule("train");
-
-export const metadata: Metadata = {
-  title: mod.label,
-  description: mod.description,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("train");
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
 
 export default function TrainPage(): ReactElement {
   return <ModuleComingSoon slug="train" />;

--- a/src/app/(marketing)/[locale]/page.tsx
+++ b/src/app/(marketing)/[locale]/page.tsx
@@ -36,6 +36,7 @@ export default async function Home({
   setRequestLocale(locale);
 
   const t = await getTranslations({ locale, namespace: "marketing" });
+  const tModules = await getTranslations({ locale });
   const modules = getMainModules();
 
   return (
@@ -174,12 +175,14 @@ export default async function Home({
                       <Icon className="size-6 text-muted-foreground" />
                     </div>
                     <div className="flex items-center gap-2">
-                      <h3 className="font-semibold">{mod.label}</h3>
+                      <h3 className="font-semibold">
+                        {tModules(`${mod.slug}.title`)}
+                      </h3>
                       <Badge variant="secondary">{t("comingSoon")}</Badge>
                     </div>
                   </div>
                   <p className="text-muted-foreground text-sm leading-relaxed">
-                    {mod.description}
+                    {tModules(`${mod.slug}.description`)}
                   </p>
                 </Link>
               );

--- a/src/components/app-sidebar.test.tsx
+++ b/src/components/app-sidebar.test.tsx
@@ -102,7 +102,7 @@ describe("AppSidebar", () => {
 
     const mainModules = getMainModules();
     for (const mod of mainModules) {
-      expect(screen.getByText(mod.label)).toBeInTheDocument();
+      expect(screen.getByText(`nav.${mod.slug}`)).toBeInTheDocument();
     }
 
     const navItems = screen.getAllByTestId("sidebar-nav-item");
@@ -119,7 +119,9 @@ describe("AppSidebar", () => {
 
     const adminModules = getAdminModules();
     for (const mod of adminModules) {
-      expect(screen.getAllByText(mod.label).length).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.getAllByText(`nav.${mod.slug}`).length
+      ).toBeGreaterThanOrEqual(1);
     }
 
     const navItems = screen.getAllByTestId("sidebar-nav-item");

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -57,7 +57,7 @@ export async function AppSidebar(): Promise<ReactElement> {
                   <SidebarNavItem
                     href={`/${mod.slug}`}
                     key={mod.slug}
-                    label={mod.label}
+                    label={t(mod.slug)}
                   >
                     <Icon />
                   </SidebarNavItem>
@@ -77,7 +77,7 @@ export async function AppSidebar(): Promise<ReactElement> {
                   <SidebarNavItem
                     href={`/${mod.slug}`}
                     key={mod.slug}
-                    label={mod.label}
+                    label={t(mod.slug)}
                   >
                     <Icon />
                   </SidebarNavItem>

--- a/src/components/dashboard-grid.test.tsx
+++ b/src/components/dashboard-grid.test.tsx
@@ -20,16 +20,12 @@ vi.mock("next/link", () => ({
 const MOCK_MODULES = [
   {
     slug: "improve" as const,
-    label: "Improve",
-    description: "Track practice",
     icon: Dumbbell,
     enabled: true,
     group: "main" as const,
   },
   {
     slug: "perform" as const,
-    label: "Perform",
-    description: "Log performances",
     icon: Star,
     enabled: false,
     group: "main" as const,
@@ -40,18 +36,20 @@ vi.mock("@/lib/modules", () => ({
   getMainModules: () => MOCK_MODULES,
 }));
 
-const IMPROVE_RE = /Improve/;
-const PERFORM_RE = /Perform/;
+const IMPROVE_RE = /improve/i;
+const PERFORM_RE = /perform/i;
 
 describe("DashboardGrid", () => {
-  it("renders a card for each main module", () => {
-    render(<DashboardGrid />);
+  it("renders a card for each main module", async () => {
+    const element = await DashboardGrid();
+    render(element);
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(2);
   });
 
-  it("links each card to the correct /{slug} href", () => {
-    render(<DashboardGrid />);
+  it("links each card to the correct /{slug} href", async () => {
+    const element = await DashboardGrid();
+    render(element);
     expect(screen.getByRole("link", { name: IMPROVE_RE })).toHaveAttribute(
       "href",
       "/improve"
@@ -62,27 +60,34 @@ describe("DashboardGrid", () => {
     );
   });
 
-  it("shows a 'Soon' badge only for disabled modules", () => {
-    render(<DashboardGrid />);
+  it("shows a coming-soon badge only for disabled modules", async () => {
+    const element = await DashboardGrid();
+    render(element);
     const performLink = screen.getByRole("link", { name: PERFORM_RE });
-    expect(within(performLink).getByText("Soon")).toBeInTheDocument();
+    expect(
+      within(performLink).getByText("common.comingSoon")
+    ).toBeInTheDocument();
     const improveLink = screen.getByRole("link", { name: IMPROVE_RE });
-    expect(within(improveLink).queryByText("Soon")).not.toBeInTheDocument();
+    expect(
+      within(improveLink).queryByText("common.comingSoon")
+    ).not.toBeInTheDocument();
   });
 
-  it("sets aria-label on disabled module links", () => {
-    render(<DashboardGrid />);
+  it("sets aria-label on disabled module links", async () => {
+    const element = await DashboardGrid();
+    render(element);
     expect(screen.getByRole("link", { name: PERFORM_RE })).toHaveAttribute(
       "aria-label",
-      "Perform (coming soon)"
+      "perform.title (common.comingSoon)"
     );
     const improveLink = screen.getByRole("link", { name: IMPROVE_RE });
     expect(improveLink).not.toHaveAttribute("aria-label");
   });
 
-  it("renders module descriptions", () => {
-    render(<DashboardGrid />);
-    expect(screen.getByText("Track practice")).toBeInTheDocument();
-    expect(screen.getByText("Log performances")).toBeInTheDocument();
+  it("renders module descriptions", async () => {
+    const element = await DashboardGrid();
+    render(element);
+    expect(screen.getByText("improve.description")).toBeInTheDocument();
+    expect(screen.getByText("perform.description")).toBeInTheDocument();
   });
 });

--- a/src/components/dashboard-grid.tsx
+++ b/src/components/dashboard-grid.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -9,18 +10,22 @@ import {
 } from "@/components/ui/card";
 import { getMainModules } from "@/lib/modules";
 
-export function DashboardGrid(): ReactElement {
+export async function DashboardGrid(): Promise<ReactElement> {
+  const t = await getTranslations();
   const mainModules = getMainModules();
   return (
     <nav aria-label="Modules">
       <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {mainModules.map((mod) => {
           const Icon = mod.icon;
+          const title = t(`${mod.slug}.title`);
           return (
             <li key={mod.slug}>
               <Link
                 aria-label={
-                  mod.enabled ? undefined : `${mod.label} (coming soon)`
+                  mod.enabled
+                    ? undefined
+                    : `${title} (${t("common.comingSoon")})`
                 }
                 className="rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 href={`/${mod.slug}`}
@@ -33,12 +38,16 @@ export function DashboardGrid(): ReactElement {
                       </div>
                       <div className="flex flex-1 flex-col gap-1">
                         <div className="flex items-center gap-2">
-                          <CardTitle>{mod.label}</CardTitle>
+                          <CardTitle>{title}</CardTitle>
                           {!mod.enabled && (
-                            <Badge variant="secondary">Soon</Badge>
+                            <Badge variant="secondary">
+                              {t("common.comingSoon")}
+                            </Badge>
                           )}
                         </div>
-                        <CardDescription>{mod.description}</CardDescription>
+                        <CardDescription>
+                          {t(`${mod.slug}.description`)}
+                        </CardDescription>
                       </div>
                     </div>
                   </CardHeader>

--- a/src/lib/modules.test.ts
+++ b/src/lib/modules.test.ts
@@ -29,8 +29,6 @@ describe("modules registry", () => {
   it("every module has required fields", () => {
     for (const mod of APP_MODULES) {
       expect(mod.slug).toBeTruthy();
-      expect(mod.label).toBeTruthy();
-      expect(mod.description).toBeTruthy();
       expect(mod.icon).toBeDefined();
       expect(typeof mod.enabled).toBe("boolean");
       expect(["main", "admin"]).toContain(mod.group);
@@ -60,7 +58,6 @@ describe("getModule", () => {
   it("returns the correct module by slug", () => {
     const mod = getModule("improve");
     expect(mod.slug).toBe("improve");
-    expect(mod.label).toBe("Improve");
   });
 
   it("throws for an invalid slug", () => {

--- a/src/lib/modules.ts
+++ b/src/lib/modules.ts
@@ -12,67 +12,51 @@ import {
 type ModuleGroup = "admin" | "main";
 
 interface AppModuleBase {
-  description: string;
   enabled: boolean;
   group: ModuleGroup;
   icon: LucideIcon;
-  label: string;
   slug: string;
 }
 
 const APP_MODULES = [
   {
     slug: "improve",
-    label: "Improve",
-    description: "Track practice sessions and refine your skills over time.",
     icon: Dumbbell,
     enabled: false,
     group: "main",
   },
   {
     slug: "train",
-    label: "Train",
-    description: "Set goals, run drills, and build muscle memory.",
     icon: ListChecks,
     enabled: false,
     group: "main",
   },
   {
     slug: "plan",
-    label: "Plan",
-    description: "Design setlists and show running orders.",
     icon: BookOpen,
     enabled: false,
     group: "main",
   },
   {
     slug: "perform",
-    label: "Perform",
-    description: "Log performances, track venues, and review feedback.",
     icon: Star,
     enabled: false,
     group: "main",
   },
   {
     slug: "enhance",
-    label: "Enhance",
-    description: "Discover insights and suggestions to elevate your magic.",
     icon: Sparkles,
     enabled: false,
     group: "main",
   },
   {
     slug: "collect",
-    label: "Collect",
-    description: "Manage your inventory of props, books, gimmicks, and more.",
     icon: Package,
     enabled: false,
     group: "main",
   },
   {
     slug: "admin",
-    label: "Admin",
-    description: "Application settings and administration.",
     icon: Settings,
     enabled: false,
     group: "admin",


### PR DESCRIPTION
## Summary

- Remove hardcoded English `label` and `description` from the module registry (`src/lib/modules.ts`) — translations already existed in all 7 locale files under `{slug}.title` and `{slug}.description` namespaces
- Update all consumers to use `getTranslations()` from next-intl instead of the hardcoded fields:
  - **DashboardGrid**: converted to async Server Component with root-namespace translator
  - **AppSidebar**: uses `t(mod.slug)` from `nav` namespace
  - **Marketing landing page**: added second root-namespace translator for module titles/descriptions
  - **7 module route pages**: replaced `export const metadata` with `generateMetadata()` using `getTranslations`
- Updated all corresponding tests

Closes #142

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test:run` — 1172/1172 tests pass
- [x] `pnpm build` — production build succeeds
- [ ] Verify dashboard, sidebar, and marketing page render correctly in English
- [ ] Verify at least one non-English locale (e.g., `/fr`) shows translated module names

🤖 Generated with [Claude Code](https://claude.com/claude-code)