### PR TITLE
ci: add Neon preview branch cleanup on PR close

### DIFF
--- a/.github/workflows/neon-branch-cleanup.yml
+++ b/.github/workflows/neon-branch-cleanup.yml
@@ -1,0 +1,24 @@
+name: Cleanup Neon preview branch
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete Neon preview branch
+        continue-on-error: true
+        run: npx neonctl@2.22.0 branches delete "$BRANCH_NAME" --project-id "$PROJECT_ID"
+        env:
+          BRANCH_NAME: preview/${{ github.head_ref }}
+          PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## Summary

- Add GitHub Action workflow that deletes Neon preview database branches when PRs are closed/merged
- Solves the lazy cleanup problem: the Neon-managed Vercel integration only cleans up branches on the *next* preview deploy, so stale branches accumulate during quiet periods (e.g. the dependabot branch that lingered >7 days)
- Uses `neonctl` directly with env vars (not the third-party composite action) to prevent script injection via crafted branch names

## Security

- `permissions: {}` — zero GitHub token access
- Fork PRs skipped via `if:` guard (no preview branch exists, no secret access)
- `github.head_ref` passed through `env:` block, never interpolated into shell
- `neonctl` pinned to exact version `2.22.0`
- `concurrency` group prevents redundant runs

## Setup required

After merging, add these to the GitHub repository settings:
- **Secret**: `NEON_API_KEY` (generate at Neon Console > Account Settings > API Keys)
- **Variable**: `NEON_PROJECT_ID` = `snowy-wind-99317396`

## Test plan

- [ ] Add `NEON_API_KEY` secret and `NEON_PROJECT_ID` variable to GitHub repo settings
- [ ] Open and close a test PR — verify the Neon preview branch is deleted in the Neon Console
- [ ] Verify the workflow skips gracefully for PRs that have no preview branch (e.g. docs-only PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)