### PR TITLE
test: add coverage for repertoire feature hooks and components

### DIFF
--- a/docs/diagrams/route-map.md
+++ b/docs/diagrams/route-map.md
@@ -1,6 +1,6 @@
 # Route Map
 
-<!-- Last verified: 2026-04-02 -->
+<!-- Last verified: 2026-04-03 -->
 
 ## Route Structure
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1000,7 +1000,7 @@ Source: docs/diagrams/route-map.md
 
 # Route Map
 
-<!-- Last verified: 2026-04-02 -->
+<!-- Last verified: 2026-04-03 -->
 
 ## Route Structure
 

--- a/src/features/repertoire/components/category-combobox.test.tsx
+++ b/src/features/repertoire/components/category-combobox.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { CategoryCombobox } from "./category-combobox";
 
 // cmdk uses ResizeObserver and scrollIntoView internally when the popover opens
@@ -32,6 +32,10 @@ const defaultProps = {
 };
 
 describe("CategoryCombobox", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders without crashing", () => {
     render(<CategoryCombobox {...defaultProps} />);
     expect(screen.getByRole("combobox")).toBeInTheDocument();
@@ -107,5 +111,45 @@ describe("CategoryCombobox", () => {
     expect(
       screen.getByRole("combobox", { name: "Category" })
     ).toBeInTheDocument();
+  });
+
+  it("calls onChange when selecting an option from the list", async () => {
+    const onChange = vi.fn();
+    render(<CategoryCombobox {...defaultProps} onChange={onChange} />);
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getByText("Cards"));
+    expect(onChange).toHaveBeenCalledWith("Cards");
+  });
+
+  it("shows custom value option when search doesn't match any option", async () => {
+    render(<CategoryCombobox {...defaultProps} />);
+    await userEvent.click(screen.getByRole("combobox"));
+    // After opening, there are two combobox roles: the trigger button and the CommandInput
+    const allComboboxes = screen.getAllByRole("combobox");
+    // The CommandInput is the input element (last in DOM order)
+    const commandInput = allComboboxes.at(-1);
+    if (!commandInput) {
+      throw new Error("Expected CommandInput combobox to exist");
+    }
+    await userEvent.type(commandInput, "NewCategory");
+    expect(
+      screen.getByText("repertoire.combobox.useCustom (value: NewCategory)")
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange with custom value when custom option is clicked", async () => {
+    const onChange = vi.fn();
+    render(<CategoryCombobox {...defaultProps} onChange={onChange} />);
+    await userEvent.click(screen.getByRole("combobox"));
+    const allComboboxes = screen.getAllByRole("combobox");
+    const commandInput = allComboboxes.at(-1);
+    if (!commandInput) {
+      throw new Error("Expected CommandInput combobox to exist");
+    }
+    await userEvent.type(commandInput, "NewCategory");
+    await userEvent.click(
+      screen.getByText("repertoire.combobox.useCustom (value: NewCategory)")
+    );
+    expect(onChange).toHaveBeenCalledWith("NewCategory");
   });
 });

--- a/src/features/repertoire/components/repertoire-view.test.tsx
+++ b/src/features/repertoire/components/repertoire-view.test.tsx
@@ -1,14 +1,27 @@
-import { render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TagId, TrickId } from "@/db/types";
-import type { TrickFormValues } from "../schema";
-import type { ParsedTag, ParsedTrick, TrickWithTags } from "../types";
+import type { ParsedTrick, TrickWithTags } from "../types";
 import { RepertoireView } from "./repertoire-view";
+import type { TrickDeleteDialogProps } from "./trick-delete-dialog";
+import type { TrickFiltersProps } from "./trick-filters";
+import type { TrickFormSheetProps } from "./trick-form-sheet";
 
 // Mock PowerSync — useQuery is used both directly in RepertoireView and in hooks
 vi.mock("@powersync/react", () => ({
-  useQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  useQuery: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+  })),
   usePowerSync: vi.fn(() => ({ execute: vi.fn() })),
 }));
 
@@ -74,19 +87,10 @@ vi.mock("../hooks/use-trick-effect-types", () => ({
 }));
 
 // TrickFormSheet mock — exposes callbacks for testing
-let capturedFormSheetProps: {
-  onSubmit?: (data: TrickFormValues) => void;
-  onOpenChange?: (open: boolean) => void;
-  onToggleTag?: (tagId: TagId) => void;
-  onCreateTag?: (name: string) => Promise<TagId>;
-  open?: boolean;
-  trick?: ParsedTrick | null;
-  selectedTagIds?: TagId[];
-  availableTags?: ParsedTag[];
-} = {};
+let capturedFormSheetProps: Partial<TrickFormSheetProps> = {};
 
 vi.mock("./trick-form-sheet", () => ({
-  TrickFormSheet: (props: typeof capturedFormSheetProps) => {
+  TrickFormSheet: (props: TrickFormSheetProps) => {
     capturedFormSheetProps = props;
     return (
       <div data-open={String(props.open)} data-testid="trick-form-sheet" />
@@ -95,15 +99,10 @@ vi.mock("./trick-form-sheet", () => ({
 }));
 
 // TrickDeleteDialog mock — exposes callbacks for testing
-let capturedDeleteDialogProps: {
-  onConfirm?: () => void;
-  onOpenChange?: (open: boolean) => void;
-  open?: boolean;
-  trickName?: string | null;
-} = {};
+let capturedDeleteDialogProps: Partial<TrickDeleteDialogProps> = {};
 
 vi.mock("./trick-delete-dialog", () => ({
-  TrickDeleteDialog: (props: typeof capturedDeleteDialogProps) => {
+  TrickDeleteDialog: (props: TrickDeleteDialogProps) => {
     capturedDeleteDialogProps = props;
     return (
       <div data-open={String(props.open)} data-testid="trick-delete-dialog">
@@ -121,7 +120,9 @@ vi.mock("./trick-delete-dialog", () => ({
   },
 }));
 
-// TrickList mock — exposes edit/delete callbacks
+// TrickList mock — exposes edit/delete callbacks and captures tricks for assertions
+let capturedTrickListTricks: TrickWithTags[] = [];
+
 vi.mock("./trick-list", () => ({
   TrickList: ({
     tricks,
@@ -131,29 +132,32 @@ vi.mock("./trick-list", () => ({
     tricks: TrickWithTags[];
     onEdit: (id: TrickId) => void;
     onDelete: (id: TrickId) => void;
-  }) => (
-    <div data-testid="trick-list">
-      {tricks.map((trick) => (
-        <div key={trick.id}>
-          <span>{trick.name}</span>
-          <button
-            data-testid={`edit-${trick.id}`}
-            onClick={() => onEdit(trick.id)}
-            type="button"
-          >
-            Edit
-          </button>
-          <button
-            data-testid={`delete-${trick.id}`}
-            onClick={() => onDelete(trick.id)}
-            type="button"
-          >
-            Delete
-          </button>
-        </div>
-      ))}
-    </div>
-  ),
+  }) => {
+    capturedTrickListTricks = tricks;
+    return (
+      <div data-testid="trick-list">
+        {tricks.map((trick) => (
+          <div key={trick.id}>
+            <span>{trick.name}</span>
+            <button
+              data-testid={`edit-${trick.id}`}
+              onClick={() => onEdit(trick.id)}
+              type="button"
+            >
+              Edit
+            </button>
+            <button
+              data-testid={`delete-${trick.id}`}
+              onClick={() => onDelete(trick.id)}
+              type="button"
+            >
+              Delete
+            </button>
+          </div>
+        ))}
+      </div>
+    );
+  },
 }));
 
 vi.mock("./trick-empty-state", () => ({
@@ -163,6 +167,60 @@ vi.mock("./trick-empty-state", () => ({
     </button>
   ),
 }));
+
+// TrickFilters mock — renders the search input (existing tests rely on it) and
+// exposes onSortChange via a test button so we can cover the sort handler.
+let capturedFiltersProps: Partial<TrickFiltersProps> = {};
+
+vi.mock("./trick-filters", () => ({
+  TrickFilters: (props: TrickFiltersProps) => {
+    capturedFiltersProps = props;
+    return (
+      <div>
+        <input
+          aria-label="repertoire.searchPlaceholder"
+          onChange={(e) => props.onSearchChange(e.target.value)}
+          type="search"
+          value={props.search}
+        />
+      </div>
+    );
+  },
+}));
+
+// Ensure fake timers are always cleaned up even if a test throws
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+
+  // Reset hook mocks to defaults so no test leaks state
+  const { useQuery } = await import("@powersync/react");
+  const { useTricks } = await import("../hooks/use-tricks");
+  const { useTrick } = await import("../hooks/use-trick");
+
+  vi.mocked(useQuery).mockReturnValue({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+  });
+  vi.mocked(useTricks).mockReturnValue({
+    tricks: [],
+    error: null,
+    isLoading: false,
+  });
+  vi.mocked(useTrick).mockReturnValue({ trick: null, isLoading: false });
+
+  // Restore mutation mock defaults (clearAllMocks strips implementations)
+  mockCreateTrick.mockResolvedValue("new-trick-id");
+  mockUpdateTrick.mockResolvedValue(undefined);
+  mockDeleteTrick.mockResolvedValue(undefined);
+
+  capturedFormSheetProps = {};
+  capturedDeleteDialogProps = {};
+  capturedFiltersProps = {};
+  capturedTrickListTricks = [];
+});
 
 const ADD_TRICK_PATTERN = /repertoire.addTrick/i;
 
@@ -214,7 +272,7 @@ describe("RepertoireView", () => {
 
   it("renders trick list when tricks are available", async () => {
     const { useTricks } = await import("../hooks/use-tricks");
-    vi.mocked(useTricks).mockReturnValueOnce({
+    vi.mocked(useTricks).mockReturnValue({
       tricks: [makeTrick("trick-1", "Card Warp")],
       error: null,
       isLoading: false,
@@ -264,8 +322,14 @@ describe("RepertoireView", () => {
       "data-open",
       "true"
     );
-    // onOpenChange(false) exercises the handler — just verify it doesn't throw
-    expect(() => capturedFormSheetProps.onOpenChange?.(false)).not.toThrow();
+    // onOpenChange(false) exercises the close handler
+    act(() => {
+      capturedFormSheetProps.onOpenChange?.(false);
+    });
+    expect(screen.getByTestId("trick-form-sheet")).toHaveAttribute(
+      "data-open",
+      "false"
+    );
   });
 
   it("calls createTrick on form submit for a new trick", async () => {
@@ -294,12 +358,19 @@ describe("RepertoireView", () => {
       videoUrl: "",
       notes: "",
     });
-    expect(mockCreateTrick).toHaveBeenCalled();
+    expect(mockCreateTrick).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "New Trick", status: "new" }),
+      []
+    );
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("repertoire.trickCreated");
+    });
   });
 
   it("opens edit sheet when edit button is clicked on a trick", async () => {
     const { useTricks } = await import("../hooks/use-tricks");
-    vi.mocked(useTricks).mockReturnValueOnce({
+    vi.mocked(useTricks).mockReturnValue({
       tricks: [makeTrick("trick-edit-1", "Silk Production")],
       error: null,
       isLoading: false,
@@ -313,7 +384,7 @@ describe("RepertoireView", () => {
 
   it("opens delete dialog when delete button is clicked", async () => {
     const { useTricks } = await import("../hooks/use-tricks");
-    vi.mocked(useTricks).mockReturnValueOnce({
+    vi.mocked(useTricks).mockReturnValue({
       tricks: [makeTrick("trick-del-1", "Vanish")],
       error: null,
       isLoading: false,
@@ -326,7 +397,7 @@ describe("RepertoireView", () => {
 
   it("calls deleteTrick when delete is confirmed", async () => {
     const { useTricks } = await import("../hooks/use-tricks");
-    vi.mocked(useTricks).mockReturnValueOnce({
+    vi.mocked(useTricks).mockReturnValue({
       tricks: [makeTrick("trick-del-2", "Coin Vanish")],
       error: null,
       isLoading: false,
@@ -336,11 +407,15 @@ describe("RepertoireView", () => {
     await userEvent.click(screen.getByTestId("delete-trick-del-2"));
     await userEvent.click(screen.getByTestId("confirm-delete"));
     expect(mockDeleteTrick).toHaveBeenCalledWith("trick-del-2");
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("repertoire.trickDeleted");
+    });
   });
 
   it("closes delete dialog via onOpenChange(false)", async () => {
     const { useTricks } = await import("../hooks/use-tricks");
-    vi.mocked(useTricks).mockReturnValueOnce({
+    vi.mocked(useTricks).mockReturnValue({
       tricks: [makeTrick("trick-close-1", "Some Trick")],
       error: null,
       isLoading: false,
@@ -349,8 +424,14 @@ describe("RepertoireView", () => {
     render(<RepertoireView />);
     await userEvent.click(screen.getByTestId("delete-trick-close-1"));
     expect(screen.getByTestId("confirm-delete")).toBeInTheDocument();
-    // onOpenChange(false) exercises the handler — just verify it doesn't throw
-    expect(() => capturedDeleteDialogProps.onOpenChange?.(false)).not.toThrow();
+    // onOpenChange(false) exercises the close handler
+    act(() => {
+      capturedDeleteDialogProps.onOpenChange?.(false);
+    });
+    expect(screen.getByTestId("trick-delete-dialog")).toHaveAttribute(
+      "data-open",
+      "false"
+    );
   });
 
   it("toggles a tag via onToggleTag without throwing", async () => {
@@ -359,14 +440,17 @@ describe("RepertoireView", () => {
     await userEvent.click(
       screen.getByRole("button", { name: ADD_TRICK_PATTERN })
     );
-    // Toggle a tag — exercises handleToggleTag code path
-    expect(() =>
-      capturedFormSheetProps.onToggleTag?.("tag-1" as TagId)
-    ).not.toThrow();
+    // Toggle a tag — exercises handleToggleTag add path
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.("tag-1" as TagId);
+    });
+    expect(capturedFormSheetProps.selectedTagIds).toEqual(["tag-1"]);
+
     // Toggle again to remove — exercises the filter branch
-    expect(() =>
-      capturedFormSheetProps.onToggleTag?.("tag-1" as TagId)
-    ).not.toThrow();
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.("tag-1" as TagId);
+    });
+    expect(capturedFormSheetProps.selectedTagIds).toEqual([]);
   });
 
   it("calls updateTrick when submitting the form in edit mode", async () => {
@@ -411,14 +495,10 @@ describe("RepertoireView", () => {
       expect.any(Array),
       expect.any(Array)
     );
-
-    // Reset
-    vi.mocked(useTricks).mockReturnValue({
-      tricks: [],
-      error: null,
-      isLoading: false,
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("repertoire.trickUpdated");
     });
-    vi.mocked(useTrick).mockReturnValue({ trick: null, isLoading: false });
   });
 
   it("calls createTag via onCreateTag handler", async () => {
@@ -434,17 +514,280 @@ describe("RepertoireView", () => {
     expect(mockCreateTag).toHaveBeenCalledWith("Beginner");
   });
 
-  it("shows no results message when filters are active but no tricks found", async () => {
+  it("updates search input value when user types", async () => {
     render(<RepertoireView />);
-    // Type in the search box to activate filters
     await userEvent.type(
       screen.getByRole("searchbox", { name: "repertoire.searchPlaceholder" }),
       "nonexistent"
     );
-    // After debounce, no results message should appear
-    // (debounced, so we check the search input is correct)
     expect(
       screen.getByRole("searchbox", { name: "repertoire.searchPlaceholder" })
     ).toHaveValue("nonexistent");
+  });
+
+  it("computes tagsDirty correctly when editing a trick with changed tags", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const { useQuery } = await import("@powersync/react");
+
+    // Set up a trick with an existing tag
+    vi.mocked(useQuery).mockReturnValue({
+      data: [
+        {
+          trick_id: "trick-tags-1",
+          tag_id: "tag-existing",
+          tag_name: "Existing",
+          color: null,
+        },
+      ],
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+    });
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [makeTrick("trick-tags-1", "Tagged Trick")],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick: makeTrick("trick-tags-1", "Tagged Trick"),
+      isLoading: false,
+    });
+
+    render(<RepertoireView />);
+
+    // Open edit mode — preloads tag-existing into selectedTagIds
+    await userEvent.click(screen.getByTestId("edit-trick-tags-1"));
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    // Toggle tag-existing (remove it) — exercises the filter branch (243-244)
+    // and marks tags as dirty via selectedTagIds.some(...) (line 156)
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.("tag-existing" as TagId);
+    });
+
+    // Toggle a new tag (add it) — exercises the spread branch
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.("tag-new" as TagId);
+    });
+
+    // At this point tagsDirty should be true and selectedTagIds differs from original
+    // Submit to exercise the removeTagIds.filter callback (line 195)
+    await capturedFormSheetProps.onSubmit?.({
+      name: "Tagged Trick",
+      status: "new",
+      description: "",
+      category: "",
+      effectType: "",
+      difficulty: null,
+      duration: null,
+      performanceType: null,
+      angleSensitivity: null,
+      props: "",
+      music: "",
+      languages: [],
+      isCameraFriendly: null,
+      isSilent: null,
+      source: "",
+      videoUrl: "",
+      notes: "",
+    });
+
+    expect(mockUpdateTrick).toHaveBeenCalledWith(
+      "trick-tags-1",
+      expect.any(Object),
+      ["tag-new"],
+      ["tag-existing"]
+    );
+  });
+
+  it("updates sort when a valid sort value is provided via onSortChange", () => {
+    render(<RepertoireView />);
+    act(() => {
+      capturedFiltersProps.onSortChange?.("name-asc");
+    });
+    expect(capturedFiltersProps.sort).toBe("name-asc");
+  });
+
+  it("ignores invalid sort values via onSortChange", () => {
+    render(<RepertoireView />);
+    // Set a valid sort first
+    act(() => {
+      capturedFiltersProps.onSortChange?.("name-asc");
+    });
+    // Trigger with an invalid value — exercises the guard branch that does nothing
+    act(() => {
+      capturedFiltersProps.onSortChange?.("invalid-sort");
+    });
+    // Sort should remain unchanged since invalid values are rejected
+    expect(capturedFiltersProps.sort).toBe("name-asc");
+  });
+
+  it("shows no-results message when search is active after debounce", async () => {
+    vi.useFakeTimers();
+
+    render(<RepertoireView />);
+
+    const searchBox = screen.getByRole("searchbox", {
+      name: "repertoire.searchPlaceholder",
+    });
+
+    searchBox.focus();
+
+    // Directly call onSearchChange on TrickFilters via the rendered search input
+    fireEvent.change(searchBox, { target: { value: "nonexistent" } });
+
+    // Advance past the 300ms debounce
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "repertoire.noResults"
+    );
+  });
+
+  it("enriches tricks with tags from trick_tags join query", async () => {
+    const { useQuery } = await import("@powersync/react");
+    const { useTricks } = await import("../hooks/use-tricks");
+
+    vi.mocked(useQuery).mockReturnValue({
+      data: [
+        {
+          trick_id: "t1",
+          tag_id: "tag-a",
+          tag_name: "Cards",
+          color: "#ff0000",
+        },
+        { trick_id: "t1", tag_id: "tag-b", tag_name: "Easy", color: null },
+      ],
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+    });
+
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [makeTrick("t1", "Card Trick")],
+      error: null,
+      isLoading: false,
+    });
+
+    render(<RepertoireView />);
+
+    expect(screen.getByTestId("trick-list")).toBeInTheDocument();
+    expect(screen.getByText("Card Trick")).toBeInTheDocument();
+    expect(capturedTrickListTricks[0]?.tags).toEqual([
+      { id: "tag-a", name: "Cards", color: "#ff0000" },
+      { id: "tag-b", name: "Easy", color: null },
+    ]);
+  });
+
+  it("does nothing when confirm delete is called with no pending trick", async () => {
+    render(<RepertoireView />);
+    // Call onConfirm before any trick is marked for deletion (deletingTrickId is null)
+    await expect(
+      capturedDeleteDialogProps.onConfirm?.()
+    ).resolves.toBeUndefined();
+    expect(mockDeleteTrick).not.toHaveBeenCalled();
+  });
+
+  it("shows error toast when delete fails", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [makeTrick("trick-del-fail", "Rope Trick")],
+      error: null,
+      isLoading: false,
+    });
+    mockDeleteTrick.mockRejectedValueOnce(new Error("delete failed"));
+
+    render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId("delete-trick-del-fail"));
+    await userEvent.click(screen.getByTestId("confirm-delete"));
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("repertoire.deleteFailed");
+    });
+  });
+
+  it("shows error toast when trick creation fails", async () => {
+    mockCreateTrick.mockRejectedValueOnce(new Error("fail"));
+
+    render(<RepertoireView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_TRICK_PATTERN })
+    );
+
+    await capturedFormSheetProps.onSubmit?.({
+      name: "Failing Trick",
+      status: "new",
+      description: "",
+      category: "",
+      effectType: "",
+      difficulty: null,
+      duration: null,
+      performanceType: null,
+      angleSensitivity: null,
+      props: "",
+      music: "",
+      languages: [],
+      isCameraFriendly: null,
+      isSilent: null,
+      source: "",
+      videoUrl: "",
+      notes: "",
+    });
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("repertoire.saveFailed");
+    });
+  });
+
+  it("shows error toast when trick update fails", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [makeTrick("trick-fail-upd", "Coin Warp")],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick: makeTrick("trick-fail-upd", "Coin Warp"),
+      isLoading: false,
+    });
+    mockUpdateTrick.mockRejectedValueOnce(new Error("update failed"));
+
+    render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId("edit-trick-fail-upd"));
+
+    await capturedFormSheetProps.onSubmit?.({
+      name: "Coin Warp",
+      status: "learning",
+      description: "",
+      category: "",
+      effectType: "",
+      difficulty: null,
+      duration: null,
+      performanceType: null,
+      angleSensitivity: null,
+      props: "",
+      music: "",
+      languages: [],
+      isCameraFriendly: null,
+      isSilent: null,
+      source: "",
+      videoUrl: "",
+      notes: "",
+    });
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("repertoire.saveFailed");
+    });
   });
 });

--- a/src/features/repertoire/components/tag-picker.test.tsx
+++ b/src/features/repertoire/components/tag-picker.test.tsx
@@ -1,9 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { TagId } from "@/db/types";
 import type { ParsedTag } from "../types";
 import { TagPicker } from "./tag-picker";
+
+const CREATE_TAG_PATTERN = /repertoire\.tagPicker\.create/;
 
 // cmdk uses ResizeObserver and scrollIntoView internally
 beforeAll(() => {
@@ -36,6 +38,10 @@ const makeTag = (id: string, name: string, color?: string): ParsedTag => ({
 });
 
 describe("TagPicker", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders without crashing", () => {
     render(
       <TagPicker
@@ -193,7 +199,7 @@ describe("TagPicker", () => {
     );
     expect(onCreateTag).toHaveBeenCalledWith("MyNewTag");
     // Wait for the async create to complete
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(onToggleTag).toHaveBeenCalledWith(newTagId);
     });
   });
@@ -227,5 +233,110 @@ describe("TagPicker", () => {
     expect(
       screen.getByRole("list", { name: "repertoire.tagPicker.selectedTags" })
     ).toBeInTheDocument();
+  });
+
+  it("does not allow selecting more tags when maxTags limit is reached", async () => {
+    const onToggleTag = vi.fn();
+    const tags = [makeTag("t1", "Cards"), makeTag("t2", "Coins")];
+    render(
+      <TagPicker
+        availableTags={tags}
+        maxTags={1}
+        onCreateTag={vi.fn()}
+        onToggleTag={onToggleTag}
+        selectedTagIds={["t1" as TagId]}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "repertoire.tagPicker.search" })
+    );
+    // "Coins" is unselected but atLimit is true — the CommandItem is disabled
+    // Clicking a disabled cmdk item does not fire onSelect
+    const coinsItem = screen.getByText("Coins");
+    await userEvent.click(coinsItem);
+    expect(onToggleTag).not.toHaveBeenCalled();
+  });
+
+  it("shows error toast when tag creation fails", async () => {
+    const { toast } = await import("sonner");
+    const onCreateTag = vi.fn().mockRejectedValue(new Error("fail"));
+    render(
+      <TagPicker
+        availableTags={[]}
+        onCreateTag={onCreateTag}
+        onToggleTag={vi.fn()}
+        selectedTagIds={[]}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "repertoire.tagPicker.search" })
+    );
+    const input = screen.getByRole("combobox");
+    await userEvent.type(input, "FailTag");
+    await userEvent.click(
+      screen.getByText("repertoire.tagPicker.create (name: FailTag)")
+    );
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "repertoire.tagPicker.createFailed"
+      );
+    });
+  });
+
+  it("hides create option when search exactly matches existing tag name", async () => {
+    const tags = [makeTag("t1", "Beginner")];
+    render(
+      <TagPicker
+        availableTags={tags}
+        onCreateTag={vi.fn()}
+        onToggleTag={vi.fn()}
+        selectedTagIds={[]}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "repertoire.tagPicker.search" })
+    );
+    const input = screen.getByRole("combobox");
+    await userEvent.type(input, "Beginner");
+    expect(screen.queryByText(CREATE_TAG_PATTERN)).not.toBeInTheDocument();
+  });
+
+  it("calls onToggleTag when clicking an unselected tag in the picker", async () => {
+    const onToggleTag = vi.fn();
+    const tags = [makeTag("t1", "Cards")];
+    render(
+      <TagPicker
+        availableTags={tags}
+        onCreateTag={vi.fn()}
+        onToggleTag={onToggleTag}
+        selectedTagIds={[]}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "repertoire.tagPicker.search" })
+    );
+    await userEvent.click(screen.getByText("Cards"));
+    expect(onToggleTag).toHaveBeenCalledWith("t1");
+  });
+
+  it("allows deselecting a tag when maxTags limit is reached", async () => {
+    const onToggleTag = vi.fn();
+    const tags = [makeTag("t1", "Cards"), makeTag("t2", "Coins")];
+    render(
+      <TagPicker
+        availableTags={tags}
+        maxTags={1}
+        onCreateTag={vi.fn()}
+        onToggleTag={onToggleTag}
+        selectedTagIds={["t1" as TagId]}
+      />
+    );
+    // Remove "Cards" via the badge remove button — this deselects an already-selected tag
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "repertoire.tagPicker.remove (name: Cards)",
+      })
+    );
+    expect(onToggleTag).toHaveBeenCalledWith("t1");
   });
 });

--- a/src/features/repertoire/components/trick-card.test.tsx
+++ b/src/features/repertoire/components/trick-card.test.tsx
@@ -1,9 +1,41 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TagId, TrickId } from "@/db/types";
 import type { TrickWithTags } from "../types";
 import { formatDuration, getContrastColor, TrickCard } from "./trick-card";
+
+// DropdownMenu mock renders all content synchronously (always-visible) since Radix
+// portals don't work in jsdom. Tests verify callback wiring only — stopPropagation
+// and open/close behavior are NOT tested through this mock.
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    asChild: _asChild,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+    variant: _variant,
+  }: {
+    children: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    variant?: "default" | "destructive";
+  }) => (
+    <button onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+}));
 
 const CARD_WARP_PATTERN = /Card Warp/;
 const DURATION_PATTERN = /\d+[ms]/;
@@ -34,6 +66,10 @@ const makeTrick = (overrides: Partial<TrickWithTags> = {}): TrickWithTags => ({
 });
 
 describe("TrickCard", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders the trick name", () => {
     render(
       <TrickCard onDelete={vi.fn()} onEdit={vi.fn()} trick={makeTrick()} />
@@ -235,6 +271,32 @@ describe("TrickCard", () => {
     await userEvent.keyboard("{ArrowDown}");
     // The card's handleCardKeyDown should not have fired Enter or Space
     expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it("calls onEdit from dropdown menu Edit item", async () => {
+    const onEdit = vi.fn();
+    render(
+      <TrickCard onDelete={vi.fn()} onEdit={onEdit} trick={makeTrick()} />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "repertoire.cardActions" })
+    );
+    await userEvent.click(screen.getByText("repertoire.edit"));
+    expect(onEdit).toHaveBeenCalledWith("trick-1");
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDelete from dropdown menu Delete item", async () => {
+    const onDelete = vi.fn();
+    render(
+      <TrickCard onDelete={onDelete} onEdit={vi.fn()} trick={makeTrick()} />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "repertoire.cardActions" })
+    );
+    await userEvent.click(screen.getByText("repertoire.delete"));
+    expect(onDelete).toHaveBeenCalledWith("trick-1");
+    expect(onDelete).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/features/repertoire/components/trick-delete-dialog.tsx
+++ b/src/features/repertoire/components/trick-delete-dialog.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
-interface TrickDeleteDialogProps {
+export interface TrickDeleteDialogProps {
   onConfirm: () => void;
   onOpenChange: (open: boolean) => void;
   open: boolean;

--- a/src/features/repertoire/components/trick-difficulty.test.tsx
+++ b/src/features/repertoire/components/trick-difficulty.test.tsx
@@ -1,9 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TrickDifficulty } from "./trick-difficulty";
 
 describe("TrickDifficulty", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders in read-only mode without radiogroup role", () => {
     render(<TrickDifficulty value={3} />);
     expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
@@ -35,7 +39,11 @@ describe("TrickDifficulty", () => {
     const onChange = vi.fn();
     render(<TrickDifficulty onChange={onChange} value={2} />);
     const radios = screen.getAllByRole("radio");
-    await userEvent.click(radios[1] as HTMLElement);
+    const target = radios[1];
+    if (!(target instanceof HTMLElement)) {
+      throw new Error("Expected at least 2 radio elements");
+    }
+    await userEvent.click(target);
     expect(onChange).toHaveBeenCalledWith(null);
   });
 
@@ -43,7 +51,11 @@ describe("TrickDifficulty", () => {
     const onChange = vi.fn();
     render(<TrickDifficulty onChange={onChange} value={2} />);
     const radios = screen.getAllByRole("radio");
-    await userEvent.click(radios[4] as HTMLElement);
+    const target = radios[4];
+    if (!(target instanceof HTMLElement)) {
+      throw new Error("Expected at least 5 radio elements");
+    }
+    await userEvent.click(target);
     expect(onChange).toHaveBeenCalledWith(5);
   });
 
@@ -73,7 +85,11 @@ describe("TrickDifficulty", () => {
     const onChange = vi.fn();
     render(<TrickDifficulty onChange={onChange} value={2} />);
     const radios = screen.getAllByRole("radio");
-    await userEvent.type(radios[1] as HTMLElement, "{ArrowRight}");
+    const target = radios[1];
+    if (!(target instanceof HTMLElement)) {
+      throw new Error("Expected at least 2 radio elements");
+    }
+    await userEvent.type(target, "{ArrowRight}");
     expect(onChange).toHaveBeenCalledWith(3);
   });
 
@@ -81,7 +97,59 @@ describe("TrickDifficulty", () => {
     const onChange = vi.fn();
     render(<TrickDifficulty onChange={onChange} value={3} />);
     const radios = screen.getAllByRole("radio");
-    await userEvent.type(radios[2] as HTMLElement, "{Delete}");
+    const target = radios[2];
+    if (!(target instanceof HTMLElement)) {
+      throw new Error("Expected at least 3 radio elements");
+    }
+    await userEvent.type(target, "{Delete}");
     expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("handles ArrowLeft key to decrease difficulty", async () => {
+    const onChange = vi.fn();
+    render(<TrickDifficulty onChange={onChange} value={3} />);
+    const radios = screen.getAllByRole("radio");
+    const target = radios[2];
+    if (!(target instanceof HTMLElement)) {
+      throw new Error("Expected at least 3 radio elements");
+    }
+    await userEvent.type(target, "{ArrowLeft}");
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it("handles ArrowDown key to decrease difficulty", async () => {
+    const onChange = vi.fn();
+    render(<TrickDifficulty onChange={onChange} value={3} />);
+    const radios = screen.getAllByRole("radio");
+    const target = radios[2];
+    if (!(target instanceof HTMLElement)) {
+      throw new Error("Expected at least 3 radio elements");
+    }
+    await userEvent.type(target, "{ArrowDown}");
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it("ArrowLeft from value 1 clears to null", async () => {
+    const onChange = vi.fn();
+    render(<TrickDifficulty onChange={onChange} value={1} />);
+    const radios = screen.getAllByRole("radio");
+    const target = radios[0];
+    if (!(target instanceof HTMLElement)) {
+      throw new Error("Expected at least 1 radio element");
+    }
+    await userEvent.type(target, "{ArrowLeft}");
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("ArrowLeft with no selection selects difficulty 1", async () => {
+    const onChange = vi.fn();
+    render(<TrickDifficulty onChange={onChange} value={null} />);
+    const radios = screen.getAllByRole("radio");
+    const target = radios[0];
+    if (!(target instanceof HTMLElement)) {
+      throw new Error("Expected at least 1 radio element");
+    }
+    await userEvent.type(target, "{ArrowLeft}");
+    expect(onChange).toHaveBeenCalledWith(1);
   });
 });

--- a/src/features/repertoire/components/trick-filters.tsx
+++ b/src/features/repertoire/components/trick-filters.tsx
@@ -15,7 +15,7 @@ import { STATUS_CONFIG, TRICK_STATUSES } from "../constants";
 /** Sentinel value representing "all" (no filter). */
 const ALL = "__all__";
 
-interface TrickFiltersProps {
+export interface TrickFiltersProps {
   categories: string[];
   category: string | null;
   onCategoryChange: (value: string | null) => void;

--- a/src/features/repertoire/components/trick-form-sheet.test.tsx
+++ b/src/features/repertoire/components/trick-form-sheet.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TrickId } from "@/db/types";
 import type { ParsedTrick } from "../types";
 import { TrickFormSheet } from "./trick-form-sheet";
@@ -56,6 +56,11 @@ const defaultProps = {
 };
 
 describe("TrickFormSheet", () => {
+  // restoreAllMocks (not clearAllMocks) because vi.spyOn on window.confirm needs full restore
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders without crashing when open with no trick (add mode)", () => {
     render(<TrickFormSheet {...defaultProps} />);
     expect(screen.getByText("repertoire.addTrick")).toBeInTheDocument();
@@ -107,5 +112,56 @@ describe("TrickFormSheet", () => {
   it("renders the trick form", () => {
     render(<TrickFormSheet {...defaultProps} />);
     expect(screen.getByTestId("trick-form")).toBeInTheDocument();
+  });
+
+  it("cancel button shows confirm and closes when user confirms with dirty form", async () => {
+    const onOpenChange = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(
+      <TrickFormSheet
+        {...defaultProps}
+        onOpenChange={onOpenChange}
+        tagsDirty={true}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "repertoire.cancel" })
+    );
+    expect(window.confirm).toHaveBeenCalledWith("repertoire.unsavedChanges");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("cancel button shows confirm and stays open when user cancels with dirty form", async () => {
+    const onOpenChange = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(
+      <TrickFormSheet
+        {...defaultProps}
+        onOpenChange={onOpenChange}
+        tagsDirty={true}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "repertoire.cancel" })
+    );
+    expect(window.confirm).toHaveBeenCalledWith("repertoire.unsavedChanges");
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("cancel button does not show confirm when form is clean", async () => {
+    const onOpenChange = vi.fn();
+    vi.spyOn(window, "confirm");
+    render(
+      <TrickFormSheet
+        {...defaultProps}
+        onOpenChange={onOpenChange}
+        tagsDirty={false}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "repertoire.cancel" })
+    );
+    expect(window.confirm).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/src/features/repertoire/components/trick-form.test.tsx
+++ b/src/features/repertoire/components/trick-form.test.tsx
@@ -1,7 +1,11 @@
-import { render, screen } from "@testing-library/react";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { TagId } from "@/db/types";
 import { TrickForm } from "./trick-form";
+
+const REMOVE_LANGUAGE_PATTERN = /repertoire\.removeLanguage/;
+const VALIDATION_MESSAGE_PATTERN = /repertoire\.validation/;
 
 // cmdk (used by CategoryCombobox and TagPicker) requires these in jsdom
 beforeAll(() => {
@@ -39,6 +43,10 @@ const defaultProps = {
 };
 
 describe("TrickForm", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders without crashing", () => {
     render(<TrickForm {...defaultProps} />);
     expect(document.getElementById("test-trick-form")).toBeInTheDocument();
@@ -168,13 +176,247 @@ describe("TrickForm", () => {
     ).toBeInTheDocument();
   });
 
-  it("marks name field as required and shows validation on submit", () => {
-    const onSubmit = vi.fn();
-    render(<TrickForm {...defaultProps} onSubmit={onSubmit} />);
-    const form = document.getElementById("test-trick-form") as HTMLFormElement;
-    form.dispatchEvent(new Event("submit", { bubbles: true }));
-    // Zod validation prevents onSubmit from being called with empty name
-    // Just verify form doesn't crash
-    expect(form).toBeInTheDocument();
+  describe("section open/close helpers", () => {
+    it("opens show setup section when isCameraFriendly is true", () => {
+      render(
+        <TrickForm
+          {...defaultProps}
+          defaultValues={{ isCameraFriendly: true }}
+        />
+      );
+      // The isCameraFriendly switch is inside the show setup collapsible — visible when open
+      expect(
+        screen.getByText("repertoire.field.isCameraFriendly")
+      ).toBeInTheDocument();
+    });
+
+    it("opens show setup section when isSilent is true", () => {
+      render(
+        <TrickForm {...defaultProps} defaultValues={{ isSilent: true }} />
+      );
+      expect(screen.getByText("repertoire.field.isSilent")).toBeInTheDocument();
+    });
+
+    it("opens show setup section when languages are present", () => {
+      render(
+        <TrickForm
+          {...defaultProps}
+          defaultValues={{ languages: ["French"] }}
+        />
+      );
+      expect(screen.getByText("French")).toBeInTheDocument();
+    });
+
+    it("opens reference section when videoUrl is present", () => {
+      render(
+        <TrickForm
+          {...defaultProps}
+          defaultValues={{ videoUrl: "https://example.com" }}
+        />
+      );
+      const input = screen.getByRole("textbox", {
+        name: "repertoire.field.videoUrl",
+      });
+      expect(input).toHaveValue("https://example.com");
+    });
+  });
+
+  describe("form submission", () => {
+    it("calls onSubmit with form data when name is provided", async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<TrickForm {...defaultProps} onSubmit={onSubmit} />);
+
+      const nameInput = screen.getByRole("textbox", {
+        name: "repertoire.field.name",
+      });
+      await user.clear(nameInput);
+      await user.type(nameInput, "Test Trick");
+
+      const form = document.getElementById("test-trick-form");
+      if (!(form instanceof HTMLFormElement)) {
+        throw new Error("Expected #test-trick-form to be a <form> element");
+      }
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+        expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+          name: "Test Trick",
+        });
+      });
+    });
+
+    it("prevents submission when name is empty", async () => {
+      const onSubmit = vi.fn();
+      render(<TrickForm {...defaultProps} onSubmit={onSubmit} />);
+
+      const form = document.getElementById("test-trick-form");
+      if (!(form instanceof HTMLFormElement)) {
+        throw new Error("Expected #test-trick-form to be a <form> element");
+      }
+      fireEvent.submit(form);
+
+      // Wait for validation to complete (positive assertion first)
+      await waitFor(() => {
+        expect(
+          screen.getByText(VALIDATION_MESSAGE_PATTERN)
+        ).toBeInTheDocument();
+      });
+      // Then verify onSubmit was never called
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("LanguagesField", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const propsWithSetupOpen = {
+    availableTags: [],
+    formId: "test-trick-form",
+    onCreateTag: vi.fn(),
+    onSubmit: vi.fn(),
+    onToggleTag: vi.fn(),
+    selectedTagIds: [],
+    userCategories: [],
+    userEffectTypes: [],
+    defaultValues: { props: "x" },
+  };
+
+  it("adds a language on Enter key", async () => {
+    const user = userEvent.setup();
+    render(<TrickForm {...propsWithSetupOpen} />);
+
+    const input = screen.getByRole("textbox", {
+      name: "repertoire.field.languages",
+    });
+    await user.click(input);
+    await user.type(input, "French");
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByText("French")).toBeInTheDocument();
+  });
+
+  it("adds a language on comma key", async () => {
+    const user = userEvent.setup();
+    render(<TrickForm {...propsWithSetupOpen} />);
+
+    const input = screen.getByRole("textbox", {
+      name: "repertoire.field.languages",
+    });
+    await user.click(input);
+    await user.type(input, "Spanish,");
+
+    expect(screen.getByText("Spanish")).toBeInTheDocument();
+    expect(input).toHaveValue("");
+  });
+
+  it("prevents duplicate languages (case-insensitive)", async () => {
+    const user = userEvent.setup();
+    render(
+      <TrickForm
+        {...propsWithSetupOpen}
+        defaultValues={{ props: "x", languages: ["French"] }}
+      />
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "repertoire.field.languages",
+    });
+    await user.click(input);
+    await user.type(input, "french");
+    await user.keyboard("{Enter}");
+
+    const badges = screen.getAllByText("French");
+    expect(badges).toHaveLength(1);
+  });
+
+  it("removes last language on Backspace when input is empty", async () => {
+    const user = userEvent.setup();
+    render(
+      <TrickForm
+        {...propsWithSetupOpen}
+        defaultValues={{ props: "x", languages: ["French", "English"] }}
+      />
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "repertoire.field.languages",
+    });
+    await user.click(input);
+    await user.keyboard("{Backspace}");
+
+    expect(screen.queryByText("English")).not.toBeInTheDocument();
+    expect(screen.getByText("French")).toBeInTheDocument();
+  });
+
+  it("enforces max 10 languages limit", async () => {
+    const user = userEvent.setup();
+    render(
+      <TrickForm
+        {...propsWithSetupOpen}
+        defaultValues={{
+          props: "x",
+          languages: [
+            "L1",
+            "L2",
+            "L3",
+            "L4",
+            "L5",
+            "L6",
+            "L7",
+            "L8",
+            "L9",
+            "L10",
+          ],
+        }}
+      />
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "repertoire.field.languages",
+    });
+    await user.click(input);
+    await user.type(input, "Extra");
+    await user.keyboard("{Enter}");
+
+    expect(screen.queryByText("Extra")).not.toBeInTheDocument();
+  });
+
+  it("removes a specific language via remove button", async () => {
+    const user = userEvent.setup();
+    render(
+      <TrickForm
+        {...propsWithSetupOpen}
+        defaultValues={{ props: "x", languages: ["French"] }}
+      />
+    );
+
+    const removeButton = screen.getByRole("button", {
+      name: REMOVE_LANGUAGE_PATTERN,
+    });
+    await user.click(removeButton);
+
+    expect(screen.queryByText("French")).not.toBeInTheDocument();
+  });
+
+  it("ignores empty/whitespace input on Enter", async () => {
+    const user = userEvent.setup();
+    render(<TrickForm {...propsWithSetupOpen} />);
+
+    const input = screen.getByRole("textbox", {
+      name: "repertoire.field.languages",
+    });
+    await user.click(input);
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
+
+    // No language list should appear
+    expect(
+      screen.queryByRole("list", { name: "repertoire.field.languages" })
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Add ~35 new tests across 7 component test files to bring all repertoire components above the 80% coverage threshold
- Coverage improved: 80.2% → 96.2% stmts, 75.6% → 89.2% branches, 77.3% → 95.5% funcs
- Export `TrickDeleteDialogProps` and `TrickFiltersProps` for typed mock captures in tests

### Key areas covered
- LanguagesField chip-input (Enter, comma, Backspace, max limit, duplicate prevention)
- FormMessage i18n validation wrapper
- Section auto-open helpers
- ArrowLeft/ArrowDown keyboard nav for difficulty stars
- Dirty form confirm guard (window.confirm)
- buildTrickTagMap tag enrichment with tag assertion
- No-results state with debounce verification
- Error toasts for failed CRUD operations
- maxTags enforcement and tag creation error handling
- Custom combobox value creation
- Dropdown menu Edit/Delete callback wiring

### Test quality (from review passes)
- Centralized mock resets in afterEach
- Replaced unsafe `as` assertions with `instanceof` guards
- Fixed false-positive assertions
- Positive-first waitFor pattern for negative assertions

Closes #148

## Test plan

- [x] `pnpm lint` — passes
- [x] `pnpm typecheck` — passes
- [x] `pnpm test:run` — 1211/1211 tests pass (103 files)
- [x] All repertoire component files above 80% coverage threshold
- [x] Three review passes with zero remaining findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)