### PR TITLE
feat: replace unsafe-inline with hash-based CSP for inline scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,21 @@ name: CI
 on:
   push:
     branches: [main]
+  # WARNING: Do NOT change to pull_request_target. The dependabot steps below
+  # checkout github.head_ref and push with contents:write — under
+  # pull_request_target, a malicious fork PR could exploit that combination.
   pull_request:
     branches: [main]
 
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   ci:
     name: Lint, Type Check, Test & Build
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -35,7 +37,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: .next/cache
-          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('next.config.ts', 'src/**') }}
           restore-keys: |
             nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
             nextjs-${{ runner.os }}-
@@ -43,11 +45,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # On push events, github.event.pull_request is null so .user.login is
+      # empty — these conditions evaluate correctly (true for !=, false for ==).
+      - name: Update CSP hashes (dependabot)
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        run: pnpm hash:csp
+
       - name: Lint & format check
         run: pnpm lint
 
       - name: Type check
-        run: pnpm exec tsc --noEmit
+        run: pnpm typecheck
 
       - name: Run tests
         run: pnpm test:coverage -- --reporter=default --reporter=github-actions
@@ -64,7 +72,7 @@ jobs:
         run: pnpm i18n:check
 
       - name: Check migration drift
-        if: github.actor != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           pnpm db:generate
           git diff --exit-code src/db/migrations/
@@ -72,7 +80,7 @@ jobs:
           DATABASE_URL: postgresql://unused:unused@localhost:5432/unused
 
       - name: Check generated docs staleness
-        if: github.actor != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           pnpm docs:generate
           git diff --exit-code public/llms.txt public/llms-full.txt docs/diagrams/
@@ -120,3 +128,74 @@ jobs:
           name: pwa-playwright-report-${{ github.sha }}
           path: playwright-report/
           retention-days: 30
+
+  # Separate job with write permissions — keeps the CI job read-only.
+  # Runs only for dependabot PRs after CI passes.
+  dependabot-csp-commit:
+    name: Auto-commit CSP hashes (dependabot)
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    needs: ci
+    concurrency:
+      group: ${{ github.workflow }}-csp-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout validated PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate branch ref
+        run: |
+          if [[ ! "$HEAD_REF" =~ ^dependabot/[a-zA-Z0-9._/-]+$ ]]; then
+            echo "::error::Unexpected branch ref: $HEAD_REF"
+            exit 1
+          fi
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        # --ignore-scripts: security hardening for the write-permission job.
+        # Safe because next-themes ships pre-built dist/ in its npm package.
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Update CSP hashes
+        # Note: tsx executes project code (and transitive node_modules imports)
+        # with contents:write. This is accepted risk — mitigated by:
+        # pull_request trigger (no fork access), --ignore-scripts,
+        # git-add scoped to src/lib/csp.ts, and branch prefix validation.
+        run: pnpm hash:csp
+
+      - name: Commit and push
+        # The pushed commit uses GITHUB_TOKEN, which does not trigger a new
+        # CI run. This is accepted — the script only modifies two hash string
+        # literals, and the ci job already validated the build with updated
+        # hashes. The commit is also validated on merge to main.
+        #
+        # --force-with-lease compares the remote HEAD against EXPECTED_SHA.
+        # If dependabot force-pushes a rebase between CI passing and this
+        # job running, the push safely fails (no data loss). The next CI
+        # run on the rebased branch will re-run the hash update.
+        run: |
+          git diff --quiet src/lib/csp.ts && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/lib/csp.ts
+          git commit -m "chore: update CSP inline script hashes [#$PR_NUMBER]"
+          git push --force-with-lease="refs/heads/$HEAD_REF:$EXPECTED_SHA" origin "HEAD:refs/heads/$HEAD_REF"
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          EXPECTED_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/docs/csp-policy.md
+++ b/docs/csp-policy.md
@@ -10,7 +10,7 @@ CSP headers are constructed by the `buildCsp()` function in `src/lib/csp.ts` and
 
 ```
 default-src 'self';
-script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://va.vercel-scripts.com;
+script-src 'self' 'unsafe-inline' 'sha256-<LANG_SCRIPT>' 'sha256-<next-themes>' 'wasm-unsafe-eval' https://va.vercel-scripts.com;
 style-src 'self' 'unsafe-inline';
 img-src 'self' data: blob: https://lh3.googleusercontent.com;
 font-src 'self';
@@ -23,12 +23,15 @@ form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech;
 upgrade-insecure-requests
 ```
 
+_(Hash values abbreviated above — see `INLINE_SCRIPT_HASHES` in `src/lib/csp.ts` for actual values.)_
+
 ### Directive Breakdown
 
 | Directive | Value | Reason |
 |---|---|---|
 | `default-src` | `'self'` | Baseline: only same-origin resources |
-| `script-src` | `'self' 'unsafe-inline'` | `unsafe-inline` required for next-themes' ThemeProvider anti-flicker script in the root layout. The root layout must stay static (no `headers()` call) so a per-request nonce cannot be passed to ThemeProvider. React's default output escaping provides XSS protection. |
+| `script-src` | `'self' 'unsafe-inline'` | `'unsafe-inline'` is kept for CSP Level 1 backward compatibility. CSP Level 2+ browsers ignore it when hash sources are present. |
+| | `'sha256-...'` (x2) | SHA-256 hashes of the two inline scripts in the root layout: the locale detection script (`LANG_SCRIPT`) and the next-themes ThemeProvider anti-flicker script. Only these scripts are allowed to run inline. |
 | | `'wasm-unsafe-eval'` | Required by PowerSync WASM module |
 | | `https://va.vercel-scripts.com` | Vercel Analytics script |
 | `style-src` | `'self' 'unsafe-inline'` | Inline styles from CSS-in-JS and component libraries |
@@ -55,21 +58,19 @@ The CSP is built programmatically via a typed builder function:
 
 ```typescript
 // src/lib/csp.ts
-interface BuildCspOptions {
-  isDev: boolean;
-}
+const INLINE_SCRIPT_HASHES = [
+  "'sha256-<LANG_SCRIPT_hash>'",   // locale detection
+  "'sha256-<next-themes_hash>'",   // ThemeProvider anti-flicker
+] as const;
 
 const BASE_DIRECTIVES: CspDirectives = {
   "default-src": ["'self'"],
-  "script-src": ["'self'", "'unsafe-inline'", "'wasm-unsafe-eval'", "https://va.vercel-scripts.com"],
-  "connect-src": [
+  "script-src": [
     "'self'",
+    "'unsafe-inline'",
+    ...INLINE_SCRIPT_HASHES,
+    "'wasm-unsafe-eval'",
     "https://va.vercel-scripts.com",
-    "https://vitals.vercel-insights.com",
-    "https://*.powersync.journeyapps.com",
-    "wss://*.powersync.journeyapps.com",
-    "https://*.neonauth.c-2.eu-central-1.aws.neon.tech",
-    "https://*.apirest.c-2.eu-central-1.aws.neon.tech",
   ],
   // ... other directives
 };
@@ -89,11 +90,34 @@ function buildCsp(options: BuildCspOptions): string {
 }
 ```
 
+### Hash-Based Inline Script Policy
+
+The root layout contains two inline `<script>` tags:
+
+1. **Locale detection** (`src/lib/lang-script.ts`) — sets `<html lang>` before first paint for screen readers.
+2. **Theme anti-flicker** (injected by next-themes `ThemeProvider`) — applies the saved theme class before first paint to prevent a flash of the wrong theme.
+
+Both scripts are deterministic: their content is fixed for a given set of locales and ThemeProvider configuration. Their SHA-256 hashes are listed in `INLINE_SCRIPT_HASHES` in `src/lib/csp.ts`.
+
+**How it works:**
+
+- CSP Level 2+ browsers see hash sources in `script-src` and **ignore** `'unsafe-inline'` — only scripts matching a listed hash are allowed to execute inline.
+- CSP Level 1 browsers do not understand hash sources and fall back to `'unsafe-inline'`, which permits all inline scripts (same security as before).
+- This is the CSP spec's recommended migration path from `'unsafe-inline'` to hash-based allowlisting.
+
+**When to update hashes:**
+
+| Event | Action |
+|---|---|
+| `next-themes` upgraded | Run `pnpm hash:csp` — the anti-flicker script may have changed |
+| ThemeProvider props changed in `layout.tsx` | Run `pnpm hash:csp` — serialized params affect the script |
+| Locale added or removed | Run `pnpm hash:csp` — LANG_SCRIPT interpolates the locales array |
+
+The `pnpm hash:csp` command recomputes both hashes and updates `src/lib/csp.ts` in place. A test in `src/lib/csp.test.ts` verifies the hashes match the actual script content — stale hashes cause CI failure.
+
 ### Why No Nonce?
 
-A nonce-based CSP would be more restrictive than `'unsafe-inline'`, but the root layout's `ThemeProvider` (next-themes) injects an inline `<script>` for theme flash prevention. The root layout must stay static for marketing pages and cannot call `headers()` to read a per-request nonce. Including a nonce in the CSP would cause CSP Level 2+ browsers to ignore `'unsafe-inline'`, blocking the theme script on every page load.
-
-XSS protection relies on React's default output escaping rather than CSP nonces.
+A nonce-based CSP would be even more restrictive, but the root layout must stay static for marketing page generation and cannot call `headers()` to read a per-request nonce. Hash-based allowlisting provides equivalent security for deterministic scripts without requiring dynamic rendering.
 
 ### Environment-Aware Directives
 

--- a/docs/diagrams/route-map.md
+++ b/docs/diagrams/route-map.md
@@ -1,6 +1,6 @@
 # Route Map
 
-<!-- Last verified: 2026-04-06 -->
+<!-- Last verified: 2026-04-07 -->
 
 ## Route Structure
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,7 +25,7 @@ const nextConfig: NextConfig = {
           value: "max-age=63072000; includeSubDomains; preload",
         },
         // Content-Security-Policy is set dynamically per-request in proxy.ts
-        // with a nonce for script-src (see #44).
+        // with hash-based script-src (see #127).
       ],
     },
     {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "docs:generate": "tsx scripts/generate-docs.ts",
     "i18n:check": "tsx scripts/check-i18n.ts",
     "email:dev": "email dev --dir src/emails --port 3030",
-    "screenshots": "tsx scripts/generate-screenshots.ts"
+    "screenshots": "tsx scripts/generate-screenshots.ts",
+    "hash:csp": "tsx scripts/compute-csp-hashes.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "5.2.2",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -267,7 +267,7 @@ CSP headers are constructed by the `buildCsp()` function in `src/lib/csp.ts` and
 
 ```
 default-src 'self';
-script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://va.vercel-scripts.com;
+script-src 'self' 'unsafe-inline' 'sha256-<LANG_SCRIPT>' 'sha256-<next-themes>' 'wasm-unsafe-eval' https://va.vercel-scripts.com;
 style-src 'self' 'unsafe-inline';
 img-src 'self' data: blob: https://lh3.googleusercontent.com;
 font-src 'self';
@@ -280,12 +280,15 @@ form-action 'self' https://*.neonauth.c-2.eu-central-1.aws.neon.tech;
 upgrade-insecure-requests
 ```
 
+_(Hash values abbreviated above — see `INLINE_SCRIPT_HASHES` in `src/lib/csp.ts` for actual values.)_
+
 ### Directive Breakdown
 
 | Directive | Value | Reason |
 |---|---|---|
 | `default-src` | `'self'` | Baseline: only same-origin resources |
-| `script-src` | `'self' 'unsafe-inline'` | `unsafe-inline` required for next-themes' ThemeProvider anti-flicker script in the root layout. The root layout must stay static (no `headers()` call) so a per-request nonce cannot be passed to ThemeProvider. React's default output escaping provides XSS protection. |
+| `script-src` | `'self' 'unsafe-inline'` | `'unsafe-inline'` is kept for CSP Level 1 backward compatibility. CSP Level 2+ browsers ignore it when hash sources are present. |
+| | `'sha256-...'` (x2) | SHA-256 hashes of the two inline scripts in the root layout: the locale detection script (`LANG_SCRIPT`) and the next-themes ThemeProvider anti-flicker script. Only these scripts are allowed to run inline. |
 | | `'wasm-unsafe-eval'` | Required by PowerSync WASM module |
 | | `https://va.vercel-scripts.com` | Vercel Analytics script |
 | `style-src` | `'self' 'unsafe-inline'` | Inline styles from CSS-in-JS and component libraries |
@@ -312,21 +315,19 @@ The CSP is built programmatically via a typed builder function:
 
 ```typescript
 // src/lib/csp.ts
-interface BuildCspOptions {
-  isDev: boolean;
-}
+const INLINE_SCRIPT_HASHES = [
+  "'sha256-<LANG_SCRIPT_hash>'",   // locale detection
+  "'sha256-<next-themes_hash>'",   // ThemeProvider anti-flicker
+] as const;
 
 const BASE_DIRECTIVES: CspDirectives = {
   "default-src": ["'self'"],
-  "script-src": ["'self'", "'unsafe-inline'", "'wasm-unsafe-eval'", "https://va.vercel-scripts.com"],
-  "connect-src": [
+  "script-src": [
     "'self'",
+    "'unsafe-inline'",
+    ...INLINE_SCRIPT_HASHES,
+    "'wasm-unsafe-eval'",
     "https://va.vercel-scripts.com",
-    "https://vitals.vercel-insights.com",
-    "https://*.powersync.journeyapps.com",
-    "wss://*.powersync.journeyapps.com",
-    "https://*.neonauth.c-2.eu-central-1.aws.neon.tech",
-    "https://*.apirest.c-2.eu-central-1.aws.neon.tech",
   ],
   // ... other directives
 };
@@ -346,11 +347,34 @@ function buildCsp(options: BuildCspOptions): string {
 }
 ```
 
+### Hash-Based Inline Script Policy
+
+The root layout contains two inline `<script>` tags:
+
+1. **Locale detection** (`src/lib/lang-script.ts`) — sets `<html lang>` before first paint for screen readers.
+2. **Theme anti-flicker** (injected by next-themes `ThemeProvider`) — applies the saved theme class before first paint to prevent a flash of the wrong theme.
+
+Both scripts are deterministic: their content is fixed for a given set of locales and ThemeProvider configuration. Their SHA-256 hashes are listed in `INLINE_SCRIPT_HASHES` in `src/lib/csp.ts`.
+
+**How it works:**
+
+- CSP Level 2+ browsers see hash sources in `script-src` and **ignore** `'unsafe-inline'` — only scripts matching a listed hash are allowed to execute inline.
+- CSP Level 1 browsers do not understand hash sources and fall back to `'unsafe-inline'`, which permits all inline scripts (same security as before).
+- This is the CSP spec's recommended migration path from `'unsafe-inline'` to hash-based allowlisting.
+
+**When to update hashes:**
+
+| Event | Action |
+|---|---|
+| `next-themes` upgraded | Run `pnpm hash:csp` — the anti-flicker script may have changed |
+| ThemeProvider props changed in `layout.tsx` | Run `pnpm hash:csp` — serialized params affect the script |
+| Locale added or removed | Run `pnpm hash:csp` — LANG_SCRIPT interpolates the locales array |
+
+The `pnpm hash:csp` command recomputes both hashes and updates `src/lib/csp.ts` in place. A test in `src/lib/csp.test.ts` verifies the hashes match the actual script content — stale hashes cause CI failure.
+
 ### Why No Nonce?
 
-A nonce-based CSP would be more restrictive than `'unsafe-inline'`, but the root layout's `ThemeProvider` (next-themes) injects an inline `<script>` for theme flash prevention. The root layout must stay static for marketing pages and cannot call `headers()` to read a per-request nonce. Including a nonce in the CSP would cause CSP Level 2+ browsers to ignore `'unsafe-inline'`, blocking the theme script on every page load.
-
-XSS protection relies on React's default output escaping rather than CSP nonces.
+A nonce-based CSP would be even more restrictive, but the root layout must stay static for marketing page generation and cannot call `headers()` to read a per-request nonce. Hash-based allowlisting provides equivalent security for deterministic scripts without requiring dynamic rendering.
 
 ### Environment-Aware Directives
 
@@ -1000,7 +1024,7 @@ Source: docs/diagrams/route-map.md
 
 # Route Map
 
-<!-- Last verified: 2026-04-06 -->
+<!-- Last verified: 2026-04-07 -->
 
 ## Route Structure
 

--- a/scripts/compute-csp-hashes.test.ts
+++ b/scripts/compute-csp-hashes.test.ts
@@ -1,0 +1,232 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { THEME_PROVIDER_PROPS } from "../src/components/theme-provider";
+import { LANG_SCRIPT } from "../src/lib/lang-script";
+import {
+  extractAntiFlicker,
+  HASH_PATTERN,
+  replaceHashes,
+} from "./compute-csp-hashes";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sha256Base64(content: string): string {
+  return createHash("sha256").update(content, "utf-8").digest("base64");
+}
+
+const ROOT = resolve(import.meta.dirname, "..");
+const nextThemesPath = resolve(ROOT, "node_modules/next-themes/dist/index.mjs");
+const nextThemesSource = readFileSync(nextThemesPath, "utf-8");
+
+const BASE64_RE = /^[A-Za-z0-9+/=]{44}$/;
+const STARTS_WITH_QUOTE = /^"/;
+const ENDS_WITH_TRUE = /true$/;
+const SELF_INVOKE_START = /^\(function\(\)/;
+const SELF_INVOKE_END = /\)\(\)$/;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("compute-csp-hashes", () => {
+  describe("regex extraction", () => {
+    it("extracts a function from next-themes source", () => {
+      const fn = extractAntiFlicker(nextThemesSource);
+      expect(fn.length).toBeGreaterThan(0);
+    });
+
+    it("extraction contains localStorage pattern", () => {
+      const fn = extractAntiFlicker(nextThemesSource);
+      expect(fn).toContain("localStorage");
+    });
+
+    it("extraction contains document pattern", () => {
+      const fn = extractAntiFlicker(nextThemesSource);
+      expect(fn).toContain("document");
+    });
+
+    it("throws when regex does not match", () => {
+      expect(() => extractAntiFlicker("invalid source")).toThrow(
+        "Failed to extract anti-flicker function"
+      );
+    });
+  });
+
+  describe("hash output format", () => {
+    it("LANG_SCRIPT hash is valid base64", () => {
+      const hash = sha256Base64(LANG_SCRIPT);
+      expect(hash).toMatch(BASE64_RE);
+    });
+
+    it("theme script hash is valid base64", () => {
+      const mFunctionSource = extractAntiFlicker(nextThemesSource);
+
+      const params = JSON.stringify([
+        THEME_PROVIDER_PROPS.attribute,
+        "theme",
+        THEME_PROVIDER_PROPS.defaultTheme,
+        undefined,
+        ["light", "dark"],
+        undefined,
+        THEME_PROVIDER_PROPS.enableSystem,
+        true,
+      ]).slice(1, -1);
+
+      const themeScript = `(${mFunctionSource})(${params})`;
+      const hash = sha256Base64(themeScript);
+      expect(hash).toMatch(BASE64_RE);
+    });
+
+    it("LANG_SCRIPT hash is a 44-char SHA-256 base64 digest", () => {
+      const hash = sha256Base64(LANG_SCRIPT);
+      // SHA-256 = 32 bytes → 44 base64 chars (with padding)
+      expect(hash).toHaveLength(44);
+    });
+  });
+
+  describe("HASH_PATTERN regex", () => {
+    it("matches the actual csp.ts format", () => {
+      const cspPath = resolve(import.meta.dirname, "../src/lib/csp.ts");
+      const cspSource = readFileSync(cspPath, "utf-8");
+      expect(cspSource).toMatch(HASH_PATTERN);
+    });
+  });
+
+  describe("parameter serialization", () => {
+    // These tests validate the expected serialization format independently.
+    // The JSDOM-based test in src/lib/csp.test.ts is the authoritative hash
+    // correctness check (it renders the actual ThemeProvider and verifies).
+
+    it("uses class attribute from THEME_PROVIDER_PROPS", () => {
+      expect(THEME_PROVIDER_PROPS.attribute).toBe("class");
+    });
+
+    it("uses system as default theme from THEME_PROVIDER_PROPS", () => {
+      expect(THEME_PROVIDER_PROPS.defaultTheme).toBe("system");
+    });
+
+    it("has enableSystem true in THEME_PROVIDER_PROPS", () => {
+      expect(THEME_PROVIDER_PROPS.enableSystem).toBe(true);
+    });
+
+    it("serializes params array matching ThemeScript expectations", () => {
+      const params = JSON.stringify([
+        THEME_PROVIDER_PROPS.attribute,
+        "theme", // storageKey default
+        THEME_PROVIDER_PROPS.defaultTheme,
+        undefined, // forcedTheme
+        ["light", "dark"], // themes default
+        undefined, // value
+        THEME_PROVIDER_PROPS.enableSystem,
+        true, // enableColorScheme default
+      ]).slice(1, -1);
+
+      // Should contain all expected values as JSON-serialized fragments
+      expect(params).toContain('"class"');
+      expect(params).toContain('"theme"');
+      expect(params).toContain('"system"');
+      expect(params).toContain("null"); // undefined → null in JSON
+      expect(params).toContain('["light","dark"]');
+      expect(params).toContain("true");
+    });
+
+    it("params start and end correctly after slice(1,-1)", () => {
+      const params = JSON.stringify([
+        THEME_PROVIDER_PROPS.attribute,
+        "theme",
+        THEME_PROVIDER_PROPS.defaultTheme,
+        undefined,
+        ["light", "dark"],
+        undefined,
+        THEME_PROVIDER_PROPS.enableSystem,
+        true,
+      ]).slice(1, -1);
+
+      // After slicing the outer brackets, params should start with a quote (first element)
+      // and end with the last element's value
+      expect(params).toMatch(STARTS_WITH_QUOTE);
+      expect(params).toMatch(ENDS_WITH_TRUE);
+    });
+  });
+
+  describe("LANG_SCRIPT content", () => {
+    it("is a non-empty string", () => {
+      expect(typeof LANG_SCRIPT).toBe("string");
+      expect(LANG_SCRIPT.length).toBeGreaterThan(0);
+    });
+
+    it("is a self-invoking function", () => {
+      expect(LANG_SCRIPT).toMatch(SELF_INVOKE_START);
+      expect(LANG_SCRIPT).toMatch(SELF_INVOKE_END);
+    });
+
+    it("contains all supported locales", () => {
+      for (const locale of ["en", "fr", "es", "pt", "it", "de", "nl"]) {
+        expect(LANG_SCRIPT).toContain(`"${locale}"`);
+      }
+    });
+  });
+
+  describe("replaceHashes", () => {
+    // Use realistic 44-character base64 strings matching SHA-256 digest length.
+    const validSource = [
+      "const LANG_SCRIPT_HASH =",
+      "  \"'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='\";",
+      "const THEME_SCRIPT_HASH =",
+      "  \"'sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB='\";",
+    ].join("\n");
+
+    it("replaces hash values in valid source", () => {
+      const result = replaceHashes(
+        validSource,
+        "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=",
+        "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD="
+      );
+      expect(result).toContain("CCCCCCC");
+      expect(result).not.toContain("AAAAAAA");
+    });
+
+    it("produces output matching expected csp.ts format", () => {
+      const result = replaceHashes(
+        validSource,
+        "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=",
+        "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD="
+      );
+      const expected = [
+        "const LANG_SCRIPT_HASH =",
+        "  \"'sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC='\";",
+        "const THEME_SCRIPT_HASH =",
+        "  \"'sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD='\";",
+      ].join("\n");
+      expect(result).toBe(expected);
+    });
+
+    it("replacement output is re-matchable by HASH_PATTERN", () => {
+      const result = replaceHashes(
+        validSource,
+        "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=",
+        "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD="
+      );
+      expect(result).not.toBeNull();
+      expect(result).toMatch(HASH_PATTERN);
+    });
+
+    it("returns source unchanged when hashes already match", () => {
+      const result = replaceHashes(
+        validSource,
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="
+      );
+      expect(result).toBe(validSource);
+    });
+
+    it("returns null when pattern does not match", () => {
+      const result = replaceHashes("no hashes here", "abc", "def");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/scripts/compute-csp-hashes.ts
+++ b/scripts/compute-csp-hashes.ts
@@ -1,0 +1,159 @@
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { THEME_PROVIDER_PROPS } from "../src/components/theme-provider";
+import { LANG_SCRIPT } from "../src/lib/lang-script";
+
+// ---------------------------------------------------------------------------
+// Exported constants and helpers — used by both the script and its tests
+// ---------------------------------------------------------------------------
+
+// This regex targets the minified output of next-themes and is inherently
+// fragile — a version bump or bundler change may alter the variable names.
+// The script exits non-zero on mismatch, and the test in csp.test.ts
+// independently verifies hashes by rendering ThemeProvider in JSDOM.
+// If a next-themes update breaks this regex, update the pattern to match
+// the new minified structure and re-run: pnpm hash:csp
+export const ANTI_FLICKER_REGEX = /var M=([\s\S]*?);var b=/;
+
+export function extractAntiFlicker(source: string): string {
+  const match = source.match(ANTI_FLICKER_REGEX);
+  const fn = match?.[1];
+  if (!fn) {
+    throw new Error("Failed to extract anti-flicker function from next-themes");
+  }
+  return fn;
+}
+
+export const HASH_PATTERN =
+  /const LANG_SCRIPT_HASH =\n\s*"'sha256-[A-Za-z0-9+/=]+'";?\nconst THEME_SCRIPT_HASH =\n\s*"'sha256-[A-Za-z0-9+/=]+'";?/;
+
+export function replaceHashes(
+  source: string,
+  langHash: string,
+  themeHash: string
+): string | null {
+  if (!HASH_PATTERN.test(source)) {
+    return null;
+  }
+  // Use a functional replacer to avoid $-pattern substitution in replacement strings.
+  const updated = source.replace(
+    HASH_PATTERN,
+    () =>
+      `const LANG_SCRIPT_HASH =\n  "'sha256-${langHash}'";\nconst THEME_SCRIPT_HASH =\n  "'sha256-${themeHash}'";`
+  );
+  return updated === source ? source : updated;
+}
+
+// ---------------------------------------------------------------------------
+// CLI script — only runs when executed directly (not when imported by tests)
+// ---------------------------------------------------------------------------
+const isDirectRun = process.argv[1]?.endsWith("compute-csp-hashes.ts") ?? false;
+
+if (isDirectRun) {
+  const ROOT = resolve(import.meta.dirname, "..");
+  const nextThemesPkgRaw: unknown = JSON.parse(
+    readFileSync(
+      resolve(ROOT, "node_modules/next-themes/package.json"),
+      "utf-8"
+    )
+  );
+  if (
+    typeof nextThemesPkgRaw !== "object" ||
+    nextThemesPkgRaw === null ||
+    !("version" in nextThemesPkgRaw) ||
+    typeof nextThemesPkgRaw.version !== "string"
+  ) {
+    console.error("Could not read version from next-themes/package.json.");
+    process.exit(1);
+  }
+  console.log(`next-themes version: ${nextThemesPkgRaw.version}`);
+
+  function sha256Base64(content: string): string {
+    return createHash("sha256").update(content, "utf-8").digest("base64");
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. LANG_SCRIPT hash — imported directly from our own source
+  // -------------------------------------------------------------------------
+  const langHash = sha256Base64(LANG_SCRIPT);
+
+  // -------------------------------------------------------------------------
+  // 2. next-themes ThemeProvider anti-flicker script hash
+  //
+  // The ThemeProvider injects: `(${M.toString()})(${params})`
+  // M is an internal function in next-themes/dist/index.mjs.
+  // Params are serialized from the ThemeProvider props in src/app/layout.tsx:
+  //   attribute="class", defaultTheme="system", enableSystem=true
+  //   (storageKey, themes, value, enableColorScheme use their defaults)
+  // -------------------------------------------------------------------------
+  const nextThemesPath = resolve(
+    ROOT,
+    "node_modules/next-themes/dist/index.mjs"
+  );
+  const nextThemesSource = readFileSync(nextThemesPath, "utf-8");
+
+  const mFunctionSource = extractAntiFlicker(nextThemesSource);
+
+  // Sanity check: the extracted function should contain theme-detection patterns.
+  // If the regex matched the wrong block, this catches it early.
+  if (
+    !(
+      mFunctionSource.includes("localStorage") &&
+      mFunctionSource.includes("document")
+    )
+  ) {
+    console.error(
+      "Extracted function does not contain expected theme-detection patterns " +
+        "(localStorage, document). The regex may have captured the wrong function."
+    );
+    process.exit(1);
+  }
+
+  // Replicate the ThemeScript serialization:
+  // JSON.stringify([attribute, storageKey, defaultTheme, forcedTheme, themes, value, enableSystem, enableColorScheme]).slice(1,-1)
+  const params = JSON.stringify([
+    THEME_PROVIDER_PROPS.attribute,
+    "theme", // storageKey (default)
+    THEME_PROVIDER_PROPS.defaultTheme,
+    undefined, // forcedTheme
+    ["light", "dark"], // themes (default)
+    undefined, // value
+    THEME_PROVIDER_PROPS.enableSystem,
+    true, // enableColorScheme (default)
+  ]).slice(1, -1);
+
+  const themeScript = `(${mFunctionSource})(${params})`;
+  const themeHash = sha256Base64(themeScript);
+
+  // -------------------------------------------------------------------------
+  // 3. Update csp.ts in place
+  // -------------------------------------------------------------------------
+  const cspPath = resolve(ROOT, "src/lib/csp.ts");
+  const cspSource = readFileSync(cspPath, "utf-8");
+
+  const BASE64_RE = /^[A-Za-z0-9+/=]{44}$/;
+  if (!(BASE64_RE.test(langHash) && BASE64_RE.test(themeHash))) {
+    console.error("Computed hash contains unexpected characters.");
+    process.exit(1);
+  }
+
+  const result = replaceHashes(cspSource, langHash, themeHash);
+
+  if (result === null) {
+    console.error(
+      "Could not find LANG_SCRIPT_HASH / THEME_SCRIPT_HASH in src/lib/csp.ts. " +
+        "Has the format changed?"
+    );
+    process.exit(1);
+  }
+
+  if (result === cspSource) {
+    console.log("CSP hashes are up to date.");
+  } else {
+    writeFileSync(cspPath, result, "utf-8");
+    console.log("Updated CSP hashes in src/lib/csp.ts:");
+    console.log(`  LANG_SCRIPT:  sha256-${langHash}`);
+    console.log(`  next-themes:  sha256-${themeHash}`);
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,10 @@ import type { Metadata, Viewport } from "next";
 import { Geist } from "next/font/google";
 import type { ReactElement, ReactNode } from "react";
 import { ServiceWorkerRegistration } from "@/components/sw-registration";
-import { ThemeProvider } from "@/components/theme-provider";
+import {
+  THEME_PROVIDER_PROPS,
+  ThemeProvider,
+} from "@/components/theme-provider";
 import { LANG_SCRIPT } from "@/lib/lang-script";
 import "./globals.css";
 
@@ -69,9 +72,7 @@ export default function RootLayout({
             See src/lib/lang-script.ts for detection logic. */}
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: blocking inline script for a11y — same pattern as next-themes anti-flicker */}
         <script dangerouslySetInnerHTML={{ __html: LANG_SCRIPT }} />
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          {children}
-        </ThemeProvider>
+        <ThemeProvider {...THEME_PROVIDER_PROPS}>{children}</ThemeProvider>
         <ServiceWorkerRegistration />
         <Analytics />
         <SpeedInsights />

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -3,6 +3,16 @@
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import type { ComponentProps, ReactElement } from "react";
 
+/**
+ * ThemeProvider props used in the root layout.
+ * Shared with CSP hash verification tests and the hash computation script.
+ */
+export const THEME_PROVIDER_PROPS = {
+  attribute: "class",
+  defaultTheme: "system",
+  enableSystem: true,
+} as const;
+
 export function ThemeProvider({
   children,
   ...props

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -1,11 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import { render } from "@testing-library/react";
+// Imported directly from next-themes (not our wrapper @/components/theme-provider)
+// because the test must verify the raw script output of ThemeProvider itself.
+import { ThemeProvider } from "next-themes";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { THEME_PROVIDER_PROPS } from "@/components/theme-provider";
+import { LANG_SCRIPT } from "@/lib/lang-script";
 import {
   BASE_DIRECTIVES,
   buildCsp,
   DEV_EXTENSIONS,
   directivesToString,
+  INLINE_SCRIPT_HASHES,
+  LANG_SCRIPT_HASH,
   mergeDirectives,
+  THEME_SCRIPT_HASH,
 } from "./csp";
+
+const CSP_SHA256_FORMAT = /^'sha256-[A-Za-z0-9+/=]+'$/;
+const UPGRADE_INSECURE_WITH_TRAILING_SPACE = /upgrade-insecure-requests /;
+
+function sha256Csp(content: string): string {
+  const hash = createHash("sha256").update(content, "utf-8").digest("base64");
+  return `'sha256-${hash}'`;
+}
 
 describe("BASE_DIRECTIVES", () => {
   it("includes self in default-src", () => {
@@ -103,6 +122,20 @@ describe("directivesToString", () => {
     const result = directivesToString(BASE_DIRECTIVES);
     expect(result).not.toContain("frame-src");
   });
+
+  it("emits boolean directives without values", () => {
+    const result = directivesToString(BASE_DIRECTIVES);
+    expect(result).toContain("upgrade-insecure-requests");
+    expect(result).not.toMatch(UPGRADE_INSECURE_WITH_TRAILING_SPACE);
+  });
+
+  it("skips directives in the skip set", () => {
+    const result = directivesToString(
+      BASE_DIRECTIVES,
+      new Set(["upgrade-insecure-requests"])
+    );
+    expect(result).not.toContain("upgrade-insecure-requests");
+  });
 });
 
 describe("buildCsp", () => {
@@ -127,13 +160,82 @@ describe("buildCsp", () => {
     }
   });
 
-  it("includes unsafe-inline in script-src for ThemeProvider compatibility", () => {
+  it("includes unsafe-inline in script-src for CSP Level 1 fallback", () => {
     const csp = buildCsp({ isDev: false });
     expect(csp).toContain("'unsafe-inline'");
   });
 
-  it("does not include nonce (root layout ThemeProvider cannot receive one)", () => {
+  it("includes inline script hashes in script-src", () => {
     const csp = buildCsp({ isDev: false });
-    expect(csp).not.toContain("nonce");
+    for (const hash of INLINE_SCRIPT_HASHES) {
+      expect(csp).toContain(hash);
+    }
+  });
+
+  it("includes upgrade-insecure-requests in production", () => {
+    const csp = buildCsp({ isDev: false });
+    expect(csp).toContain("upgrade-insecure-requests");
+  });
+
+  it("omits upgrade-insecure-requests in dev", () => {
+    const csp = buildCsp({ isDev: true });
+    expect(csp).not.toContain("upgrade-insecure-requests");
+  });
+});
+
+describe("INLINE_SCRIPT_HASHES", () => {
+  beforeEach(() => {
+    // next-themes reads matchMedia during initialization.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn().mockReturnValue(true),
+      }))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("contains exactly 2 hashes (LANG_SCRIPT + next-themes)", () => {
+    expect(INLINE_SCRIPT_HASHES).toHaveLength(2);
+  });
+
+  it("all hashes use CSP sha256 format", () => {
+    for (const hash of INLINE_SCRIPT_HASHES) {
+      expect(hash).toMatch(CSP_SHA256_FORMAT);
+    }
+  });
+
+  it("LANG_SCRIPT hash matches actual content (update with: pnpm hash:csp)", () => {
+    expect(LANG_SCRIPT_HASH).toBe(sha256Csp(LANG_SCRIPT));
+  });
+
+  it("next-themes hash matches ThemeProvider script (update with: pnpm hash:csp)", () => {
+    // Render with the shared THEME_PROVIDER_PROPS (used by layout.tsx and this test).
+    const { container } = render(
+      createElement(ThemeProvider, THEME_PROVIDER_PROPS, createElement("div"))
+    );
+
+    const script = container.querySelector("script");
+    if (!script) {
+      throw new Error("Expected ThemeProvider to inject a <script> element");
+    }
+
+    const scriptContent = script.innerHTML;
+    expect(scriptContent.length).toBeGreaterThan(0);
+
+    expect(
+      THEME_SCRIPT_HASH,
+      "next-themes hash mismatch — run: pnpm hash:csp"
+    ).toBe(sha256Csp(scriptContent));
   });
 });

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -45,16 +45,34 @@ function cspDirectiveNames(
   return ALL_DIRECTIVE_NAMES.filter((key) => key in directives);
 }
 
+/**
+ * SHA-256 hashes of the two known inline scripts in the root layout.
+ *
+ * CSP Level 2+ browsers that see hash sources in script-src will ignore
+ * 'unsafe-inline' and only allow scripts whose content matches a listed hash.
+ * CSP Level 1 browsers ignore hashes and fall back to 'unsafe-inline'.
+ *
+ * LANG_SCRIPT_HASH = locale detection (src/lib/lang-script.ts)
+ * THEME_SCRIPT_HASH = next-themes ThemeProvider anti-flicker (next-themes@0.4.6)
+ *
+ * Recompute with: pnpm hash:csp
+ */
+const LANG_SCRIPT_HASH =
+  "'sha256-OXaEoHYR86dnPtcYJd0RDCyeOVHvj6cQ/jmfmAHCyOs='";
+const THEME_SCRIPT_HASH =
+  "'sha256-cd+HpnSsLaEz1lKWBNn+k+xOe1m2p5ZgfjoyNvHy9eU='";
+
+const INLINE_SCRIPT_HASHES = [LANG_SCRIPT_HASH, THEME_SCRIPT_HASH] as const;
+
 const BASE_DIRECTIVES: CspDirectives = {
   "default-src": ["'self'"],
-  // 'unsafe-inline' allows inline scripts (e.g., next-themes' ThemeProvider
-  // anti-flicker script and the lang-detection script in the root layout). A nonce-based policy
-  // would be more restrictive, but the root layout must stay static (no
-  // headers() call) for marketing pages, so ThemeProvider cannot receive a
-  // per-request nonce. React's default output escaping provides XSS protection.
+  // 'unsafe-inline' is kept for backward compatibility with CSP Level 1
+  // browsers. CSP Level 2+ browsers ignore it when hash sources are present,
+  // restricting inline scripts to the two hashed scripts above.
   "script-src": [
     "'self'",
     "'unsafe-inline'",
+    ...INLINE_SCRIPT_HASHES,
     "'wasm-unsafe-eval'",
     "https://va.vercel-scripts.com",
   ],
@@ -155,5 +173,8 @@ export {
   buildCsp,
   DEV_EXTENSIONS,
   directivesToString,
+  INLINE_SCRIPT_HASHES,
+  LANG_SCRIPT_HASH,
   mergeDirectives,
+  THEME_SCRIPT_HASH,
 };

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -36,7 +36,8 @@ vi.mock("@/auth/server", () => ({
 
 vi.mock("@/lib/csp", () => ({
   buildCsp: vi.fn(
-    () => "default-src 'self'; script-src 'self' 'unsafe-inline'"
+    () =>
+      "default-src 'self'; script-src 'self' 'unsafe-inline' 'sha256-test1' 'sha256-test2'"
   ),
 }));
 
@@ -274,7 +275,7 @@ describe("proxy", () => {
     expect(response.cookies.get("refresh-token")?.value).toBe("xyz789");
   });
 
-  it("does not include nonce in CSP (unsafe-inline covers all inline scripts)", async () => {
+  it("does not include nonce in CSP (hash-based policy, no per-request nonce)", async () => {
     const { proxy } = await import("./proxy");
 
     const response = await proxy(createRequest("/about", false));

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -71,12 +71,13 @@ function needsAuth(pathname: string): boolean {
 /**
  * Build CSP for the current route.
  *
- * No per-request nonce is generated. The CSP relies on 'unsafe-inline' for
- * inline scripts. A nonce-based approach would be more restrictive, but the
- * root layout's ThemeProvider (next-themes) injects an inline <script> that
- * cannot receive a nonce — the root layout must stay static for marketing
- * pages and cannot call headers(). Including a nonce in the CSP would cause
- * CSP Level 2+ browsers to ignore 'unsafe-inline', blocking that script.
+ * Inline scripts (lang-detection and next-themes anti-flicker) are allowed
+ * via SHA-256 hashes in script-src. CSP Level 2+ browsers ignore the
+ * co-present 'unsafe-inline' and only permit scripts matching a listed hash.
+ * 'unsafe-inline' is kept for CSP Level 1 fallback.
+ *
+ * No per-request nonce — the root layout must stay static for marketing
+ * pages and cannot call headers().
  */
 function buildCspForRoute(): string {
   return buildCsp({ isDev });


### PR DESCRIPTION
## Summary

- Add SHA-256 hashes of the two known inline scripts (locale detection + next-themes anti-flicker) to CSP `script-src`. CSP Level 2+ browsers ignore `'unsafe-inline'` when hashes are present, restricting inline scripts to only the two hashed scripts.
- Add `pnpm hash:csp` command to recompute hashes when next-themes or locales change.
- Add hash verification tests that render ThemeProvider and compare against hardcoded hashes — stale hashes fail CI with a clear message.
- Add `dependabot-csp-commit` CI job (separate from CI, scoped `contents: write`) to auto-update hashes on dependency PRs.

Closes #127

## Test plan

- [x] `pnpm hash:csp` runs idempotently (no diff when hashes are correct)
- [x] `pnpm test:run` — all 1224 tests pass, including hash verification
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint` — clean
- [x] `pnpm build` — production build succeeds
- [x] `pnpm docs:generate` — llms.txt regenerated from updated docs
- [ ] Manual: verify no CSP violations in browser console (dev server)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)