### PR TITLE
feat: refactor module registry into 4 groups with Repertoire enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Requires Node 24.x and pnpm >= 10.
 
 ### Route Groups
 
-- `src/app/(app)/` — authenticated routes (dashboard, repertoire, settings, account, feature modules). Protected by `proxy.ts`. Dynamic (server-rendered on demand). Notable non-module routes: `/repertoire` (trick CRUD — fully implemented, lives outside the module registry), `/account/[path]` (Neon Auth account management via `AccountView`).
+- `src/app/(app)/` — authenticated routes (dashboard, repertoire, settings, account, feature modules). Protected by `proxy.ts`. Dynamic (server-rendered on demand). `/repertoire` is the Repertoire module (Library group) — trick CRUD with tags, fully implemented and enabled. `/account/[path]` is Neon Auth account management via `AccountView`.
 - `src/app/(marketing)/[locale]/` — public pages (landing, FAQ, privacy). URL-based locale routing with `generateStaticParams` for all 7 locales. Statically generated at build time (21 pages). Bare paths (`/`, `/faq`, `/privacy`) are 302-redirected by proxy to locale-prefixed versions.
 - `src/app/auth/` — sign-in / sign-up pages. Dynamic (reads `NEXT_LOCALE` cookie for locale-aware rendering). Authenticated users are redirected to `/dashboard`.
 - `src/app/api/` — API route handlers (PowerSync upload, auth, unsubscribe, etc.).
@@ -77,9 +77,13 @@ Requires Node 24.x and pnpm >= 10.
 
 ### Module Registry
 
-- `src/lib/modules.ts` defines all feature modules (improve, train, plan, perform, enhance, collect, admin).
-- All modules are currently `enabled: false` — features are in development.
-- Each module has a slug, label, description, icon, and group (`main` or `admin`).
+- `src/lib/modules.ts` defines all feature modules, organized into 4 groups (`MODULE_GROUPS`):
+  - **Library**: Repertoire (`enabled: true`), Collection (slug: `collect`, `enabled: false`)
+  - **Lab**: Improve, Train, Plan, Perform (all `enabled: false`)
+  - **Insights**: Enhance (`enabled: false`)
+  - **Admin**: Admin (`enabled: false`)
+- Each module has a slug, label, description, icon, enabled state, and group.
+- Use `getModulesByGroup(group)` to retrieve modules for a specific group.
 
 ---
 
@@ -220,7 +224,7 @@ Type safety is a first-class concern. All code must be rigorously typed.
 - **Empty states**: Icon + title + description + primary CTA. Use `ModuleComingSoon` pattern
 - **Loading states**: Skeleton for cold start only — offline-first means data is usually instant
 - **Error states**: Error boundary with retry button
-- **Mobile nav**: Bottom tab bar (<768px) — Dashboard, Improve, Plan, Perform, More
+- **Mobile nav**: Bottom tab bar (<768px) — Dashboard, Repertoire, Plan, Perform, More
 - **Desktop nav**: Sidebar (unchanged existing pattern)
 - **Accent color**: Violet (oklch hue 280) — matches the theatrical nature of magic
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ src/
     (app)/                # Authenticated app (dashboard, modules)
     auth/                 # Sign-in / sign-up (dynamic, locale-aware)
     api/                  # API routes (auth, sync, email, cron)
-  features/               # Feature modules (improve, train, plan, ...)
+  features/               # Feature modules grouped by purpose (library, lab, insights)
     <module>/components/  # Module-specific components
     <module>/hooks/       # Module-specific hooks
   components/             # Shared React components

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,14 +30,15 @@ src/app/
   (app)/                # Authenticated application
     layout.tsx          # Sidebar + header chrome
     dashboard/page.tsx  # Home dashboard
-    improve/page.tsx    # Practice session logging
-    train/page.tsx      # Goal setting and drills
-    plan/page.tsx       # Setlist builder
-    perform/page.tsx    # Performance tracking
-    enhance/page.tsx    # Insights and suggestions
-    collect/page.tsx    # Inventory management
+    repertoire/page.tsx # Trick library (Library module)
+    collect/page.tsx    # Inventory management (Library module)
+    improve/page.tsx    # Practice session logging (Lab module)
+    train/page.tsx      # Goal setting and drills (Lab module)
+    plan/page.tsx       # Setlist builder (Lab module)
+    perform/page.tsx    # Performance tracking (Lab module)
+    enhance/page.tsx    # Insights and suggestions (Insights module)
     settings/page.tsx   # User preferences
-    admin/page.tsx      # Admin panel
+    admin/page.tsx      # Admin panel (Admin module)
   layout.tsx            # Root layout (theme, fonts, analytics)
   api/                  # API routes
 ```
@@ -46,9 +47,14 @@ See [route-structure.md](./route-structure.md) for the complete route tree.
 
 ## Feature Modules
 
-Each feature area is organized as a self-contained module defined in `src/lib/modules.ts`. Modules declare their slug, label, description, icon, and enabled state. The module registry drives both the sidebar navigation and the marketing feature grid.
+Each feature area is organized as a self-contained module defined in `src/lib/modules.ts`. Modules declare their slug, label, description, icon, enabled state, and group. The module registry drives both the sidebar navigation and the marketing feature grid. Use `getModulesByGroup(group)` to retrieve modules for a specific group.
 
-Current modules: **Improve**, **Train**, **Plan**, **Perform**, **Enhance**, **Collect**, **Admin**.
+Modules are organized into 4 groups:
+
+- **Library**: Repertoire (enabled), Collection
+- **Lab**: Improve, Train, Plan, Perform
+- **Insights**: Enhance
+- **Admin**: Admin
 
 See [diagrams/module-deps.md](./diagrams/module-deps.md) for feature module dependencies.
 

--- a/docs/diagrams/module-deps.md
+++ b/docs/diagrams/module-deps.md
@@ -12,17 +12,20 @@ graph TB
         I18n["i18n<br/>(next-intl)"]
     end
 
-    subgraph Modules["Feature Modules"]
+    subgraph Library["Library"]
+        Repertoire["Repertoire<br/>Tricks"]
+        Collect["Collection<br/>Inventory"]
+    end
+
+    subgraph Lab["The Lab"]
         Improve["Improve<br/>Practice Sessions"]
         Train["Train<br/>Goals & Drills"]
         Plan["Plan<br/>Setlists"]
         Perform["Perform<br/>Performances"]
-        Enhance["Enhance<br/>Insights"]
-        Collect["Collect<br/>Inventory"]
     end
 
-    subgraph Shared["Shared Domain"]
-        Tricks["Tricks<br/>(repertoire)"]
+    subgraph Insights["Insights"]
+        Enhance["Enhance<br/>Insights"]
     end
 
     %% Core dependencies
@@ -31,6 +34,10 @@ graph TB
     Notify --> Auth
 
     %% Module to core
+    Repertoire --> Sync
+    Repertoire --> Auth
+    Collect --> Sync
+    Collect --> Auth
     Improve --> Sync
     Improve --> Auth
     Train --> Sync
@@ -42,63 +49,65 @@ graph TB
     Perform --> Auth
     Enhance --> Sync
     Enhance --> Auth
-    Collect --> Sync
-    Collect --> Auth
 
-    %% Module to shared domain
-    Improve --> Tricks
-    Train --> Tricks
-    Plan --> Tricks
-    Perform --> Tricks
-    Collect --> Tricks
+    %% Module to shared domain (Repertoire)
+    Improve --> Repertoire
+    Train --> Repertoire
+    Plan --> Repertoire
+    Perform --> Repertoire
+    Collect --> Repertoire
 
     %% Cross-module dependencies
     Improve -.->|"practice data"| Enhance
     Train -.->|"goal progress"| Enhance
     Perform -.->|"performance data"| Enhance
     Plan -.->|"setlists for shows"| Perform
-    Collect -.->|"props used in"| Tricks
+    Collect -.->|"props used in"| Repertoire
 
     %% i18n is used by everything
-    I18n -.->|"all modules"| Modules
+    I18n -.->|"all modules"| Library
+    I18n -.->|"all modules"| Lab
+    I18n -.->|"all modules"| Insights
 
     style Core fill:#f3e5f5,stroke:#9c27b0
-    style Modules fill:#e3f2fd,stroke:#2196f3
-    style Shared fill:#fff3e0,stroke:#ff9800
+    style Library fill:#e8f5e9,stroke:#4caf50
+    style Lab fill:#e3f2fd,stroke:#2196f3
+    style Insights fill:#fff3e0,stroke:#ff9800
 ```
 
 ## Module Descriptions
 
-| Module | Purpose | Key Entities |
-|---|---|---|
-| **Improve** | Log practice sessions, track skill progress | practice_sessions, practice_session_tricks |
-| **Train** | Set goals, create drills, build streaks | goals |
-| **Plan** | Build setlists for shows | setlists, setlist_tricks |
-| **Perform** | Log performances, review feedback | performances |
-| **Enhance** | Analytics, insights, improvement suggestions | Reads from all modules |
-| **Collect** | Manage inventory of props and materials | items, item_tricks |
+| Module | Group | Purpose | Key Entities |
+|---|---|---|---|
+| **Repertoire** | Library | Manage trick library with tags and metadata | tricks, trick_tags |
+| **Collection** | Library | Manage inventory of props and materials | items, item_tricks |
+| **Improve** | Lab | Log practice sessions, track skill progress | practice_sessions, practice_session_tricks |
+| **Train** | Lab | Set goals, create drills, build streaks | goals |
+| **Plan** | Lab | Build setlists for shows | setlists, setlist_tricks |
+| **Perform** | Lab | Log performances, review feedback | performances |
+| **Enhance** | Insights | Analytics, insights, improvement suggestions | Reads from all modules |
 
-## Shared Domain: Tricks
+## Central Entity: Tricks (Repertoire)
 
-The `tricks` table is the central entity shared across modules:
+The `tricks` table (managed by the Repertoire module) is the central entity shared across modules:
 
+- **Collection**: Items (props) are linked to tricks that use them
 - **Improve**: Practice sessions reference tricks being practiced
 - **Train**: Goals can target specific tricks
 - **Plan**: Setlists are ordered collections of tricks
 - **Perform**: (Indirect) Performances use setlists which contain tricks
-- **Collect**: Items (props) are linked to tricks that use them
 
 ## Data Flow
 
 ```
-Collect (items) --> Tricks <-- Improve (practice)
-                      ^
-                      |
-              Plan (setlists) --> Perform (shows)
-                      ^
-                      |
-                Train (goals)
-                      |
-                      v
-                Enhance (insights) <-- All modules
+Library:  Collection (items) --> Repertoire (tricks) <-- Improve (practice)  :Lab
+                                       ^
+                                       |
+                               Plan (setlists) --> Perform (shows)          :Lab
+                                       ^
+                                       |
+                                 Train (goals)                              :Lab
+                                       |
+                                       v
+                                Enhance (insights) <-- All modules          :Insights
 ```

--- a/docs/route-structure.md
+++ b/docs/route-structure.md
@@ -35,15 +35,15 @@ Marketing pages use URL-based locale routing for SEO. Each page is statically ge
 | Path | Page | Module | Description |
 |---|---|---|---|
 | `/dashboard` | Dashboard | -- | Home with module grid and quick stats |
-| `/repertoire` | Repertoire | -- | Trick CRUD with tags, filtering, and search |
-| `/improve` | Improve | Improve | Practice session logging and history |
-| `/train` | Train | Train | Goal setting, drills, streaks |
-| `/plan` | Plan | Plan | Setlist builder |
-| `/perform` | Perform | Perform | Performance logging and review |
-| `/enhance` | Enhance | Enhance | Insights, suggestions, analytics |
-| `/collect` | Collect | Collect | Inventory of props, books, gimmicks |
+| `/repertoire` | Repertoire | Repertoire (Library) | Trick CRUD with tags, filtering, and search |
+| `/collect` | Collection | Collection (Library) | Inventory of props, books, gimmicks |
+| `/improve` | Improve | Improve (Lab) | Practice session logging and history |
+| `/train` | Train | Train (Lab) | Goal setting, drills, streaks |
+| `/plan` | Plan | Plan (Lab) | Setlist builder |
+| `/perform` | Perform | Perform (Lab) | Performance logging and review |
+| `/enhance` | Enhance | Enhance (Insights) | Insights, suggestions, analytics |
 | `/settings` | Settings | -- | User preferences, account |
-| `/admin` | Admin | Admin | Application administration |
+| `/admin` | Admin | Admin (Admin) | Application administration |
 | `/account/[path]` | Account | -- | Neon Auth account management (sign-in, sign-up, etc.) |
 
 ### Auth Routes

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -35,7 +35,7 @@ Design principles and component conventions for The Magic Lab.
 
 ### Mobile Navigation
 
-- **Bottom tab bar** for primary module navigation (Improve, Train, Plan, Perform, Collect)
+- **Bottom tab bar** for primary module navigation (Dashboard, Repertoire, Plan, Perform, More)
 - Fixed to bottom of viewport
 - 44px minimum touch targets
 - Active state indicated by violet accent
@@ -58,7 +58,7 @@ Design principles and component conventions for The Magic Lab.
 |          (p-4)                           |
 |                                          |
 +------------------------------------------+
-| [Improve] [Train] [Plan] [Perform] [...] |  <- Bottom tabs (mobile only)
+| [Dashboard] [Repertoire] [Plan] [Perform] [More] |  <- Bottom tabs (mobile only)
 +------------------------------------------+
 ```
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -40,14 +40,15 @@ src/app/
   (app)/                # Authenticated application
     layout.tsx          # Sidebar + header chrome
     dashboard/page.tsx  # Home dashboard
-    improve/page.tsx    # Practice session logging
-    train/page.tsx      # Goal setting and drills
-    plan/page.tsx       # Setlist builder
-    perform/page.tsx    # Performance tracking
-    enhance/page.tsx    # Insights and suggestions
-    collect/page.tsx    # Inventory management
+    repertoire/page.tsx # Trick library (Library module)
+    collect/page.tsx    # Inventory management (Library module)
+    improve/page.tsx    # Practice session logging (Lab module)
+    train/page.tsx      # Goal setting and drills (Lab module)
+    plan/page.tsx       # Setlist builder (Lab module)
+    perform/page.tsx    # Performance tracking (Lab module)
+    enhance/page.tsx    # Insights and suggestions (Insights module)
     settings/page.tsx   # User preferences
-    admin/page.tsx      # Admin panel
+    admin/page.tsx      # Admin panel (Admin module)
   layout.tsx            # Root layout (theme, fonts, analytics)
   api/                  # API routes
 ```
@@ -56,9 +57,14 @@ See [route-structure.md](./route-structure.md) for the complete route tree.
 
 ## Feature Modules
 
-Each feature area is organized as a self-contained module defined in `src/lib/modules.ts`. Modules declare their slug, label, description, icon, and enabled state. The module registry drives both the sidebar navigation and the marketing feature grid.
+Each feature area is organized as a self-contained module defined in `src/lib/modules.ts`. Modules declare their slug, label, description, icon, enabled state, and group. The module registry drives both the sidebar navigation and the marketing feature grid. Use `getModulesByGroup(group)` to retrieve modules for a specific group.
 
-Current modules: **Improve**, **Train**, **Plan**, **Perform**, **Enhance**, **Collect**, **Admin**.
+Modules are organized into 4 groups:
+
+- **Library**: Repertoire (enabled), Collection
+- **Lab**: Improve, Train, Plan, Perform
+- **Insights**: Enhance
+- **Admin**: Admin
 
 See [diagrams/module-deps.md](./diagrams/module-deps.md) for feature module dependencies.
 
@@ -798,17 +804,20 @@ graph TB
         I18n["i18n<br/>(next-intl)"]
     end
 
-    subgraph Modules["Feature Modules"]
+    subgraph Library["Library"]
+        Repertoire["Repertoire<br/>Tricks"]
+        Collect["Collection<br/>Inventory"]
+    end
+
+    subgraph Lab["The Lab"]
         Improve["Improve<br/>Practice Sessions"]
         Train["Train<br/>Goals & Drills"]
         Plan["Plan<br/>Setlists"]
         Perform["Perform<br/>Performances"]
-        Enhance["Enhance<br/>Insights"]
-        Collect["Collect<br/>Inventory"]
     end
 
-    subgraph Shared["Shared Domain"]
-        Tricks["Tricks<br/>(repertoire)"]
+    subgraph Insights["Insights"]
+        Enhance["Enhance<br/>Insights"]
     end
 
     %% Core dependencies
@@ -817,6 +826,10 @@ graph TB
     Notify --> Auth
 
     %% Module to core
+    Repertoire --> Sync
+    Repertoire --> Auth
+    Collect --> Sync
+    Collect --> Auth
     Improve --> Sync
     Improve --> Auth
     Train --> Sync
@@ -828,65 +841,67 @@ graph TB
     Perform --> Auth
     Enhance --> Sync
     Enhance --> Auth
-    Collect --> Sync
-    Collect --> Auth
 
-    %% Module to shared domain
-    Improve --> Tricks
-    Train --> Tricks
-    Plan --> Tricks
-    Perform --> Tricks
-    Collect --> Tricks
+    %% Module to shared domain (Repertoire)
+    Improve --> Repertoire
+    Train --> Repertoire
+    Plan --> Repertoire
+    Perform --> Repertoire
+    Collect --> Repertoire
 
     %% Cross-module dependencies
     Improve -.->|"practice data"| Enhance
     Train -.->|"goal progress"| Enhance
     Perform -.->|"performance data"| Enhance
     Plan -.->|"setlists for shows"| Perform
-    Collect -.->|"props used in"| Tricks
+    Collect -.->|"props used in"| Repertoire
 
     %% i18n is used by everything
-    I18n -.->|"all modules"| Modules
+    I18n -.->|"all modules"| Library
+    I18n -.->|"all modules"| Lab
+    I18n -.->|"all modules"| Insights
 
     style Core fill:#f3e5f5,stroke:#9c27b0
-    style Modules fill:#e3f2fd,stroke:#2196f3
-    style Shared fill:#fff3e0,stroke:#ff9800
+    style Library fill:#e8f5e9,stroke:#4caf50
+    style Lab fill:#e3f2fd,stroke:#2196f3
+    style Insights fill:#fff3e0,stroke:#ff9800
 ```
 
 ## Module Descriptions
 
-| Module | Purpose | Key Entities |
-|---|---|---|
-| **Improve** | Log practice sessions, track skill progress | practice_sessions, practice_session_tricks |
-| **Train** | Set goals, create drills, build streaks | goals |
-| **Plan** | Build setlists for shows | setlists, setlist_tricks |
-| **Perform** | Log performances, review feedback | performances |
-| **Enhance** | Analytics, insights, improvement suggestions | Reads from all modules |
-| **Collect** | Manage inventory of props and materials | items, item_tricks |
+| Module | Group | Purpose | Key Entities |
+|---|---|---|---|
+| **Repertoire** | Library | Manage trick library with tags and metadata | tricks, trick_tags |
+| **Collection** | Library | Manage inventory of props and materials | items, item_tricks |
+| **Improve** | Lab | Log practice sessions, track skill progress | practice_sessions, practice_session_tricks |
+| **Train** | Lab | Set goals, create drills, build streaks | goals |
+| **Plan** | Lab | Build setlists for shows | setlists, setlist_tricks |
+| **Perform** | Lab | Log performances, review feedback | performances |
+| **Enhance** | Insights | Analytics, insights, improvement suggestions | Reads from all modules |
 
-## Shared Domain: Tricks
+## Central Entity: Tricks (Repertoire)
 
-The `tricks` table is the central entity shared across modules:
+The `tricks` table (managed by the Repertoire module) is the central entity shared across modules:
 
+- **Collection**: Items (props) are linked to tricks that use them
 - **Improve**: Practice sessions reference tricks being practiced
 - **Train**: Goals can target specific tricks
 - **Plan**: Setlists are ordered collections of tricks
 - **Perform**: (Indirect) Performances use setlists which contain tricks
-- **Collect**: Items (props) are linked to tricks that use them
 
 ## Data Flow
 
 ```
-Collect (items) --> Tricks <-- Improve (practice)
-                      ^
-                      |
-              Plan (setlists) --> Perform (shows)
-                      ^
-                      |
-                Train (goals)
-                      |
-                      v
-                Enhance (insights) <-- All modules
+Library:  Collection (items) --> Repertoire (tricks) <-- Improve (practice)  :Lab
+                                       ^
+                                       |
+                               Plan (setlists) --> Perform (shows)          :Lab
+                                       ^
+                                       |
+                                 Train (goals)                              :Lab
+                                       |
+                                       v
+                                Enhance (insights) <-- All modules          :Insights
 ```
 
 ---
@@ -2057,15 +2072,15 @@ Marketing pages use URL-based locale routing for SEO. Each page is statically ge
 | Path | Page | Module | Description |
 |---|---|---|---|
 | `/dashboard` | Dashboard | -- | Home with module grid and quick stats |
-| `/repertoire` | Repertoire | -- | Trick CRUD with tags, filtering, and search |
-| `/improve` | Improve | Improve | Practice session logging and history |
-| `/train` | Train | Train | Goal setting, drills, streaks |
-| `/plan` | Plan | Plan | Setlist builder |
-| `/perform` | Perform | Perform | Performance logging and review |
-| `/enhance` | Enhance | Enhance | Insights, suggestions, analytics |
-| `/collect` | Collect | Collect | Inventory of props, books, gimmicks |
+| `/repertoire` | Repertoire | Repertoire (Library) | Trick CRUD with tags, filtering, and search |
+| `/collect` | Collection | Collection (Library) | Inventory of props, books, gimmicks |
+| `/improve` | Improve | Improve (Lab) | Practice session logging and history |
+| `/train` | Train | Train (Lab) | Goal setting, drills, streaks |
+| `/plan` | Plan | Plan (Lab) | Setlist builder |
+| `/perform` | Perform | Perform (Lab) | Performance logging and review |
+| `/enhance` | Enhance | Enhance (Insights) | Insights, suggestions, analytics |
 | `/settings` | Settings | -- | User preferences, account |
-| `/admin` | Admin | Admin | Application administration |
+| `/admin` | Admin | Admin (Admin) | Application administration |
 | `/account/[path]` | Account | -- | Neon Auth account management (sign-in, sign-up, etc.) |
 
 ### Auth Routes
@@ -2512,7 +2527,7 @@ Design principles and component conventions for The Magic Lab.
 
 ### Mobile Navigation
 
-- **Bottom tab bar** for primary module navigation (Improve, Train, Plan, Perform, Collect)
+- **Bottom tab bar** for primary module navigation (Dashboard, Repertoire, Plan, Perform, More)
 - Fixed to bottom of viewport
 - 44px minimum touch targets
 - Active state indicated by violet accent
@@ -2535,7 +2550,7 @@ Design principles and component conventions for The Magic Lab.
 |          (p-4)                           |
 |                                          |
 +------------------------------------------+
-| [Improve] [Train] [Plan] [Perform] [...] |  <- Bottom tabs (mobile only)
+| [Dashboard] [Repertoire] [Plan] [Perform] [More] |  <- Bottom tabs (mobile only)
 +------------------------------------------+
 ```
 

--- a/src/app/(marketing)/[locale]/page.test.tsx
+++ b/src/app/(marketing)/[locale]/page.test.tsx
@@ -40,14 +40,36 @@ describe("Home (marketing landing page)", () => {
     expect(ctas.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders feature section with all 6 modules", async () => {
+  it("renders feature section with all 7 non-admin modules", async () => {
     render(await Home(defaultParams));
     const featureSection = document.getElementById("features");
     expect(featureSection).toBeInTheDocument();
     // Each module renders as a link with an h3 heading
     const headings =
       featureSection?.parentElement?.querySelectorAll("h3") ?? [];
-    expect(headings).toHaveLength(6);
+    expect(headings).toHaveLength(7);
+  });
+
+  it("does not show coming soon badge or aria-label on enabled modules", async () => {
+    render(await Home(defaultParams));
+    const featureGrid = document.getElementById("features")?.parentElement;
+    expect(featureGrid).toBeInTheDocument();
+
+    // Repertoire is the only enabled module — its link should exist
+    const repertoireLink = featureGrid?.querySelector('a[href="/repertoire"]');
+    expect(repertoireLink).toBeInTheDocument();
+
+    // Enabled modules must NOT have a "comingSoon" badge
+    expect(repertoireLink?.textContent).not.toContain("marketing.comingSoon");
+
+    // Enabled modules must NOT have an aria-label override
+    expect(repertoireLink).not.toHaveAttribute("aria-label");
+
+    // Disabled modules (e.g. improve) SHOULD have the badge and aria-label
+    const disabledLink = featureGrid?.querySelector('a[href="/improve"]');
+    expect(disabledLink).toBeInTheDocument();
+    expect(disabledLink?.textContent).toContain("marketing.comingSoon");
+    expect(disabledLink).toHaveAttribute("aria-label");
   });
 
   it("renders the GitHub link with correct attributes", async () => {

--- a/src/app/(marketing)/[locale]/page.tsx
+++ b/src/app/(marketing)/[locale]/page.tsx
@@ -13,7 +13,7 @@ import {
   type LocaleParams,
   locales,
 } from "@/i18n/config";
-import { getMainModules } from "@/lib/modules";
+import { getModulesByGroup, MODULE_GROUPS } from "@/lib/modules";
 
 export async function generateMetadata({
   params,
@@ -37,7 +37,9 @@ export default async function Home({
 
   const t = await getTranslations({ locale, namespace: "marketing" });
   const tModules = await getTranslations({ locale });
-  const modules = getMainModules();
+  const modules = MODULE_GROUPS.filter((g) => g !== "admin").flatMap((g) =>
+    getModulesByGroup(g)
+  );
 
   return (
     <>
@@ -166,7 +168,12 @@ export default async function Home({
               const Icon = mod.icon;
               return (
                 <Link
-                  className="group flex flex-col gap-3 rounded-xl p-4 transition-colors hover:bg-background"
+                  aria-label={
+                    mod.enabled
+                      ? undefined
+                      : `${tModules(`${mod.slug}.title`)} (${t("comingSoon")})`
+                  }
+                  className="group flex flex-col gap-3 rounded-xl p-4 transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                   href={`/${mod.slug}`}
                   key={mod.slug}
                 >
@@ -178,7 +185,9 @@ export default async function Home({
                       <h3 className="font-semibold">
                         {tModules(`${mod.slug}.title`)}
                       </h3>
-                      <Badge variant="secondary">{t("comingSoon")}</Badge>
+                      {!mod.enabled && (
+                        <Badge variant="secondary">{t("comingSoon")}</Badge>
+                      )}
                     </div>
                   </div>
                   <p className="text-muted-foreground text-sm leading-relaxed">

--- a/src/components/app-sidebar.test.tsx
+++ b/src/components/app-sidebar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { getAdminModules, getMainModules } from "@/lib/modules";
+import { APP_MODULES, getModulesByGroup, MODULE_GROUPS } from "@/lib/modules";
 import { AppSidebar } from "./app-sidebar";
 
 vi.mock("next/link", () => ({
@@ -96,40 +96,41 @@ describe("AppSidebar", () => {
     expect(screen.getByText("nav.dashboard")).toBeInTheDocument();
   });
 
-  it("renders all main module nav items", async () => {
+  it("renders nav items for all module groups", async () => {
     const element = await AppSidebar();
     render(element);
-
-    const mainModules = getMainModules();
-    for (const mod of mainModules) {
-      expect(screen.getByText(`nav.${mod.slug}`)).toBeInTheDocument();
-    }
 
     const navItems = screen.getAllByTestId("sidebar-nav-item");
-    const mainHrefs = mainModules.map((m) => `/${m.slug}`);
-    const renderedMainItems = navItems.filter((item) =>
-      mainHrefs.includes(item.getAttribute("data-href") ?? "")
-    );
-    expect(renderedMainItems).toHaveLength(mainModules.length);
+    for (const group of MODULE_GROUPS) {
+      const modules = getModulesByGroup(group);
+      const groupHrefs = modules.map((m) => `/${m.slug}`);
+      const rendered = navItems.filter((item) =>
+        groupHrefs.includes(item.getAttribute("data-href") ?? "")
+      );
+      expect(rendered).toHaveLength(modules.length);
+    }
   });
 
-  it("renders all admin module nav items", async () => {
+  it("renders a nav item for every module", async () => {
     const element = await AppSidebar();
     render(element);
 
-    const adminModules = getAdminModules();
-    for (const mod of adminModules) {
+    for (const mod of APP_MODULES) {
+      // Some slugs (e.g. "admin") also appear as group labels, so use getAllByText
       expect(
         screen.getAllByText(`nav.${mod.slug}`).length
       ).toBeGreaterThanOrEqual(1);
     }
+  });
 
-    const navItems = screen.getAllByTestId("sidebar-nav-item");
-    const adminHrefs = adminModules.map((m) => `/${m.slug}`);
-    const renderedAdminItems = navItems.filter((item) =>
-      adminHrefs.includes(item.getAttribute("data-href") ?? "")
-    );
-    expect(renderedAdminItems).toHaveLength(adminModules.length);
+  it("renders group labels for all module groups", async () => {
+    const element = await AppSidebar();
+    render(element);
+
+    expect(screen.getByText("nav.library")).toBeInTheDocument();
+    expect(screen.getByText("nav.theLab")).toBeInTheDocument();
+    expect(screen.getByText("nav.insights")).toBeInTheDocument();
+    expect(screen.getAllByText("nav.admin").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders the Settings nav item", async () => {

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,7 +1,7 @@
 import { UserButton } from "@neondatabase/auth/react";
-import { LayoutDashboard, UserCog, WandSparkles } from "lucide-react";
+import { LayoutDashboard, UserCog } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import type { ReactElement } from "react";
+import { Fragment, type ReactElement } from "react";
 import { Logo } from "@/components/logo";
 import { SidebarNavItem } from "@/components/sidebar-nav";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -16,12 +16,14 @@ import {
   SidebarMenu,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
-import { getAdminModules, getMainModules } from "@/lib/modules";
+import {
+  getModulesByGroup,
+  MODULE_GROUP_NAV_KEYS,
+  MODULE_GROUPS,
+} from "@/lib/modules";
 
 export async function AppSidebar(): Promise<ReactElement> {
   const t = await getTranslations("nav");
-  const mainModules = getMainModules();
-  const adminModules = getAdminModules();
 
   return (
     <Sidebar>
@@ -40,52 +42,37 @@ export async function AppSidebar(): Promise<ReactElement> {
               <SidebarNavItem href="/dashboard" label={t("dashboard")}>
                 <LayoutDashboard />
               </SidebarNavItem>
-              <SidebarNavItem href="/repertoire" label={t("repertoire")}>
-                <WandSparkles />
-              </SidebarNavItem>
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
-        <SidebarSeparator />
-        <SidebarGroup>
-          <SidebarGroupLabel>{t("modules")}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {mainModules.map((mod) => {
-                const Icon = mod.icon;
-                return (
-                  <SidebarNavItem
-                    href={`/${mod.slug}`}
-                    key={mod.slug}
-                    label={t(mod.slug)}
-                  >
-                    <Icon />
-                  </SidebarNavItem>
-                );
-              })}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarSeparator />
-        <SidebarGroup>
-          <SidebarGroupLabel>{t("admin")}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {adminModules.map((mod) => {
-                const Icon = mod.icon;
-                return (
-                  <SidebarNavItem
-                    href={`/${mod.slug}`}
-                    key={mod.slug}
-                    label={t(mod.slug)}
-                  >
-                    <Icon />
-                  </SidebarNavItem>
-                );
-              })}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        {MODULE_GROUPS.map((group) => {
+          const modules = getModulesByGroup(group);
+          const navKey = MODULE_GROUP_NAV_KEYS[group];
+          return (
+            <Fragment key={group}>
+              <SidebarSeparator />
+              <SidebarGroup>
+                <SidebarGroupLabel>{t(navKey)}</SidebarGroupLabel>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {modules.map((mod) => {
+                      const Icon = mod.icon;
+                      return (
+                        <SidebarNavItem
+                          href={`/${mod.slug}`}
+                          key={mod.slug}
+                          label={t(mod.slug)}
+                        >
+                          <Icon />
+                        </SidebarNavItem>
+                      );
+                    })}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
+            </Fragment>
+          );
+        })}
       </SidebarContent>
       <SidebarFooter>
         <SidebarMenu>

--- a/src/components/dashboard-grid.test.tsx
+++ b/src/components/dashboard-grid.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
-import { Dumbbell, Star } from "lucide-react";
+import { Dumbbell, Package, Sparkles, Star } from "lucide-react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { DashboardGrid } from "./dashboard-grid";
@@ -16,35 +16,75 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-// One enabled + one disabled to exercise both badge-visible and badge-hidden paths
-const MOCK_MODULES = [
+const MOCK_LIBRARY = [
+  {
+    slug: "collect" as const,
+    icon: Package,
+    enabled: false,
+    group: "library" as const,
+  },
+];
+
+const MOCK_LAB = [
   {
     slug: "improve" as const,
     icon: Dumbbell,
-    enabled: true,
-    group: "main" as const,
+    enabled: false,
+    group: "lab" as const,
   },
   {
     slug: "perform" as const,
     icon: Star,
     enabled: false,
-    group: "main" as const,
+    group: "lab" as const,
   },
 ];
 
-vi.mock("@/lib/modules", () => ({
-  getMainModules: () => MOCK_MODULES,
-}));
+const MOCK_INSIGHTS = [
+  {
+    slug: "enhance" as const,
+    icon: Sparkles,
+    enabled: false,
+    group: "insights" as const,
+  },
+];
+
+vi.mock("@/lib/modules", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/modules")>();
+  return {
+    MODULE_GROUPS: actual.MODULE_GROUPS,
+    MODULE_GROUP_NAV_KEYS: actual.MODULE_GROUP_NAV_KEYS,
+    getModulesByGroup: (group: string) => {
+      if (group === "library") {
+        return MOCK_LIBRARY;
+      }
+      if (group === "lab") {
+        return MOCK_LAB;
+      }
+      if (group === "insights") {
+        return MOCK_INSIGHTS;
+      }
+      return [];
+    },
+  };
+});
 
 const IMPROVE_RE = /improve/i;
-const PERFORM_RE = /perform/i;
 
 describe("DashboardGrid", () => {
-  it("renders a card for each main module", async () => {
+  it("renders grouped sections with headings", async () => {
+    const element = await DashboardGrid();
+    render(element);
+    expect(screen.getByText("nav.library")).toBeInTheDocument();
+    expect(screen.getByText("nav.theLab")).toBeInTheDocument();
+    expect(screen.getByText("nav.insights")).toBeInTheDocument();
+  });
+
+  it("renders a card for each non-admin, non-repertoire module", async () => {
     const element = await DashboardGrid();
     render(element);
     const links = screen.getAllByRole("link");
-    expect(links).toHaveLength(2);
+    expect(links).toHaveLength(4);
   });
 
   it("links each card to the correct /{slug} href", async () => {
@@ -54,40 +94,39 @@ describe("DashboardGrid", () => {
       "href",
       "/improve"
     );
-    expect(screen.getByRole("link", { name: PERFORM_RE })).toHaveAttribute(
-      "href",
-      "/perform"
-    );
   });
 
-  it("shows a coming-soon badge only for disabled modules", async () => {
+  it("shows a coming-soon badge on disabled modules", async () => {
     const element = await DashboardGrid();
     render(element);
-    const performLink = screen.getByRole("link", { name: PERFORM_RE });
-    expect(
-      within(performLink).getByText("common.comingSoon")
-    ).toBeInTheDocument();
     const improveLink = screen.getByRole("link", { name: IMPROVE_RE });
     expect(
-      within(improveLink).queryByText("common.comingSoon")
-    ).not.toBeInTheDocument();
+      within(improveLink).getByText("common.comingSoon")
+    ).toBeInTheDocument();
   });
 
   it("sets aria-label on disabled module links", async () => {
     const element = await DashboardGrid();
     render(element);
-    expect(screen.getByRole("link", { name: PERFORM_RE })).toHaveAttribute(
-      "aria-label",
-      "perform.title (common.comingSoon)"
-    );
     const improveLink = screen.getByRole("link", { name: IMPROVE_RE });
-    expect(improveLink).not.toHaveAttribute("aria-label");
+    expect(improveLink).toHaveAttribute(
+      "aria-label",
+      "improve.title (common.comingSoon)"
+    );
   });
 
   it("renders module descriptions", async () => {
     const element = await DashboardGrid();
     render(element);
+    expect(screen.getByText("collect.description")).toBeInTheDocument();
     expect(screen.getByText("improve.description")).toBeInTheDocument();
     expect(screen.getByText("perform.description")).toBeInTheDocument();
+    expect(screen.getByText("enhance.description")).toBeInTheDocument();
+  });
+
+  it("does not render the admin group", async () => {
+    const element = await DashboardGrid();
+    render(element);
+    expect(screen.queryByText("nav.admin")).not.toBeInTheDocument();
   });
 });

--- a/src/components/dashboard-grid.tsx
+++ b/src/components/dashboard-grid.tsx
@@ -8,55 +8,81 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { getMainModules } from "@/lib/modules";
+import {
+  getModulesByGroup,
+  MODULE_GROUP_NAV_KEYS,
+  MODULE_GROUPS,
+} from "@/lib/modules";
+
+const DISPLAY_GROUPS = MODULE_GROUPS.filter((g) => g !== "admin");
 
 export async function DashboardGrid(): Promise<ReactElement> {
   const t = await getTranslations();
-  const mainModules = getMainModules();
   return (
-    <nav aria-label="Modules">
-      <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {mainModules.map((mod) => {
-          const Icon = mod.icon;
-          const title = t(`${mod.slug}.title`);
-          return (
-            <li key={mod.slug}>
-              <Link
-                aria-label={
-                  mod.enabled
-                    ? undefined
-                    : `${title} (${t("common.comingSoon")})`
-                }
-                className="rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                href={`/${mod.slug}`}
-              >
-                <Card className="h-full transition-colors focus-within:bg-muted/50 hover:bg-muted/50">
-                  <CardHeader>
-                    <div className="flex items-center gap-3">
-                      <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted">
-                        <Icon className="size-5 text-muted-foreground" />
-                      </div>
-                      <div className="flex flex-1 flex-col gap-1">
-                        <div className="flex items-center gap-2">
-                          <CardTitle>{title}</CardTitle>
-                          {!mod.enabled && (
-                            <Badge variant="secondary">
-                              {t("common.comingSoon")}
-                            </Badge>
-                          )}
-                        </div>
-                        <CardDescription>
-                          {t(`${mod.slug}.description`)}
-                        </CardDescription>
-                      </div>
-                    </div>
-                  </CardHeader>
-                </Card>
-              </Link>
-            </li>
-          );
-        })}
-      </ul>
-    </nav>
+    <div className="flex flex-col gap-8">
+      {DISPLAY_GROUPS.map((group) => {
+        const modules = getModulesByGroup(group).filter(
+          (m) => m.slug !== "repertoire"
+        );
+        if (modules.length === 0) {
+          return null;
+        }
+        const navKey = MODULE_GROUP_NAV_KEYS[group];
+        return (
+          <section aria-labelledby={`group-${group}`} key={group}>
+            <h2
+              className="mb-4 font-semibold text-muted-foreground text-sm uppercase tracking-wide"
+              id={`group-${group}`}
+            >
+              {t(`nav.${navKey}`)}
+            </h2>
+            <nav aria-labelledby={`group-${group}`}>
+              <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {modules.map((mod) => {
+                  const Icon = mod.icon;
+                  const title = t(`${mod.slug}.title`);
+                  return (
+                    <li key={mod.slug}>
+                      <Link
+                        aria-label={
+                          mod.enabled
+                            ? undefined
+                            : `${title} (${t("common.comingSoon")})`
+                        }
+                        className="rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        href={`/${mod.slug}`}
+                      >
+                        <Card className="h-full transition-colors focus-within:bg-muted/50 hover:bg-muted/50">
+                          <CardHeader>
+                            <div className="flex items-center gap-3">
+                              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+                                <Icon className="size-5 text-muted-foreground" />
+                              </div>
+                              <div className="flex flex-1 flex-col gap-1">
+                                <div className="flex items-center gap-2">
+                                  <CardTitle>{title}</CardTitle>
+                                  {!mod.enabled && (
+                                    <Badge variant="secondary">
+                                      {t("common.comingSoon")}
+                                    </Badge>
+                                  )}
+                                </div>
+                                <CardDescription>
+                                  {t(`${mod.slug}.description`)}
+                                </CardDescription>
+                              </div>
+                            </div>
+                          </CardHeader>
+                        </Card>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </nav>
+          </section>
+        );
+      })}
+    </div>
   );
 }

--- a/src/components/header-title.test.tsx
+++ b/src/components/header-title.test.tsx
@@ -26,6 +26,12 @@ describe("HeaderTitle", () => {
     expect(screen.getByText("nav.improve")).toBeInTheDocument();
   });
 
+  it("renders module label for /repertoire", () => {
+    vi.mocked(usePathname).mockReturnValue("/repertoire");
+    render(<HeaderTitle />);
+    expect(screen.getByText("nav.repertoire")).toBeInTheDocument();
+  });
+
   it("renders nothing for unknown route", () => {
     vi.mocked(usePathname).mockReturnValue("/unknown");
     const { container } = render(<HeaderTitle />);

--- a/src/components/header-title.tsx
+++ b/src/components/header-title.tsx
@@ -9,7 +9,6 @@ type NavKey = Parameters<ReturnType<typeof useTranslations<"nav">>>[0];
 
 const NAV_KEYS = [
   "dashboard",
-  "repertoire",
   "settings",
   ...APP_MODULES.map((m) => m.slug),
 ] satisfies readonly NavKey[];

--- a/src/features/repertoire/components/trick-filters.tsx
+++ b/src/features/repertoire/components/trick-filters.tsx
@@ -51,7 +51,7 @@ export function TrickFilters({
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
       {/* Search input */}
-      <div className="relative w-full sm:max-w-xs">
+      <div className="relative w-full sm:flex-1">
         <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           aria-label={t("searchPlaceholder")}

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -32,10 +32,12 @@
     "plan": "Planen",
     "perform": "Auftreten",
     "enhance": "Optimieren",
-    "collect": "Sammeln",
+    "collect": "Sammlung",
     "settings": "Einstellungen",
     "admin": "Admin",
-    "modules": "Module"
+    "library": "Bibliothek",
+    "theLab": "Das Labor",
+    "insights": "Einblicke"
   },
   "repertoire": {
     "title": "Repertoire",
@@ -230,7 +232,7 @@
     "description": "Entdecke Einblicke und Vorschläge, um deine Magie zu verbessern."
   },
   "collect": {
-    "title": "Sammeln",
+    "title": "Sammlung",
     "description": "Verwalte dein Inventar an Requisiten, Büchern, Gimmicks und mehr."
   },
   "admin": {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -32,10 +32,12 @@
     "plan": "Plan",
     "perform": "Perform",
     "enhance": "Enhance",
-    "collect": "Collect",
+    "collect": "Collection",
     "settings": "Settings",
     "admin": "Admin",
-    "modules": "Modules"
+    "library": "Library",
+    "theLab": "The Lab",
+    "insights": "Insights"
   },
   "repertoire": {
     "title": "Repertoire",
@@ -230,7 +232,7 @@
     "description": "Discover insights and suggestions to elevate your magic."
   },
   "collect": {
-    "title": "Collect",
+    "title": "Collection",
     "description": "Manage your inventory of props, books, gimmicks, and more."
   },
   "admin": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -32,10 +32,12 @@
     "plan": "Planificar",
     "perform": "Actuar",
     "enhance": "Optimizar",
-    "collect": "Coleccionar",
+    "collect": "Colección",
     "settings": "Ajustes",
     "admin": "Admin",
-    "modules": "Módulos"
+    "library": "Biblioteca",
+    "theLab": "El Laboratorio",
+    "insights": "Análisis"
   },
   "repertoire": {
     "title": "Repertorio",
@@ -230,7 +232,7 @@
     "description": "Descubre análisis y sugerencias para elevar tu magia."
   },
   "collect": {
-    "title": "Coleccionar",
+    "title": "Colección",
     "description": "Gestiona tu inventario de accesorios, libros, gimmicks y más."
   },
   "admin": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -35,7 +35,9 @@
     "collect": "Collection",
     "settings": "Paramètres",
     "admin": "Admin",
-    "modules": "Modules"
+    "library": "Bibliothèque",
+    "theLab": "Le Labo",
+    "insights": "Analyses"
   },
   "repertoire": {
     "title": "Répertoire",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -32,10 +32,12 @@
     "plan": "Pianifica",
     "perform": "Esibisciti",
     "enhance": "Potenzia",
-    "collect": "Colleziona",
+    "collect": "Collezione",
     "settings": "Impostazioni",
     "admin": "Admin",
-    "modules": "Moduli"
+    "library": "Libreria",
+    "theLab": "Il Laboratorio",
+    "insights": "Analisi"
   },
   "repertoire": {
     "title": "Repertorio",
@@ -230,7 +232,7 @@
     "description": "Scopri analisi e suggerimenti per migliorare la tua magia."
   },
   "collect": {
-    "title": "Colleziona",
+    "title": "Collezione",
     "description": "Gestisci il tuo inventario di attrezzi, libri, gimmick e altro."
   },
   "admin": {

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -32,10 +32,12 @@
     "plan": "Plannen",
     "perform": "Optreden",
     "enhance": "Optimaliseren",
-    "collect": "Verzamelen",
+    "collect": "Collectie",
     "settings": "Instellingen",
     "admin": "Admin",
-    "modules": "Modules"
+    "library": "Bibliotheek",
+    "theLab": "Het Lab",
+    "insights": "Inzichten"
   },
   "repertoire": {
     "title": "Repertoire",
@@ -230,7 +232,7 @@
     "description": "Ontdek inzichten en suggesties om je magie te verbeteren."
   },
   "collect": {
-    "title": "Verzamelen",
+    "title": "Collectie",
     "description": "Beheer je inventaris van rekwisieten, boeken, gimmicks en meer."
   },
   "admin": {

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -32,10 +32,12 @@
     "plan": "Planear",
     "perform": "Apresentar",
     "enhance": "Aperfeiçoar",
-    "collect": "Colecionar",
+    "collect": "Coleção",
     "settings": "Definições",
     "admin": "Admin",
-    "modules": "Módulos"
+    "library": "Biblioteca",
+    "theLab": "O Laboratório",
+    "insights": "Análises"
   },
   "repertoire": {
     "title": "Repertório",
@@ -230,7 +232,7 @@
     "description": "Descubra análises e sugestões para elevar a sua magia."
   },
   "collect": {
-    "title": "Colecionar",
+    "title": "Coleção",
     "description": "Faça a gestão do seu inventário de adereços, livros, gimmicks e outros itens."
   },
   "admin": {

--- a/src/lib/modules.test.ts
+++ b/src/lib/modules.test.ts
@@ -2,36 +2,41 @@ import { describe, expect, it } from "vitest";
 import type { ModuleSlug } from "./modules";
 import {
   APP_MODULES,
-  getAdminModules,
-  getMainModules,
   getModule,
+  getModulesByGroup,
+  MODULE_GROUP_NAV_KEYS,
+  MODULE_GROUPS,
 } from "./modules";
 
 describe("modules registry", () => {
   it("contains all expected slugs", () => {
     const slugs = APP_MODULES.map((m) => m.slug);
+    expect(slugs).toContain("repertoire");
+    expect(slugs).toContain("collect");
     expect(slugs).toContain("improve");
     expect(slugs).toContain("train");
     expect(slugs).toContain("plan");
     expect(slugs).toContain("perform");
     expect(slugs).toContain("enhance");
-    expect(slugs).toContain("collect");
     expect(slugs).toContain("admin");
-    expect(slugs).toHaveLength(7);
+    expect(slugs).toHaveLength(8);
   });
 
-  it("main + admin modules equal total", () => {
-    expect(getMainModules().length + getAdminModules().length).toBe(
-      APP_MODULES.length
+  it("groups combined equal total module count", () => {
+    const totalFromGroups = MODULE_GROUPS.reduce(
+      (sum, g) => sum + getModulesByGroup(g).length,
+      0
     );
+    expect(totalFromGroups).toBe(APP_MODULES.length);
   });
 
   it("every module has required fields", () => {
+    const validGroups = new Set(["library", "lab", "insights", "admin"]);
     for (const mod of APP_MODULES) {
       expect(mod.slug).toBeTruthy();
       expect(mod.icon).toBeDefined();
       expect(typeof mod.enabled).toBe("boolean");
-      expect(["main", "admin"]).toContain(mod.group);
+      expect(validGroups.has(mod.group)).toBe(true);
     }
   });
 
@@ -40,17 +45,8 @@ describe("modules registry", () => {
     expect(new Set(slugs).size).toBe(slugs.length);
   });
 
-  it("module groups are valid values", () => {
-    const validGroups = new Set(["main", "admin"]);
-    for (const mod of APP_MODULES) {
-      expect(validGroups.has(mod.group)).toBe(true);
-    }
-  });
-
-  it("all modules are currently disabled", () => {
-    for (const mod of APP_MODULES) {
-      expect(mod.enabled).toBe(false);
-    }
+  it("repertoire is enabled", () => {
+    expect(getModule("repertoire").enabled).toBe(true);
   });
 });
 
@@ -67,22 +63,30 @@ describe("getModule", () => {
   });
 });
 
-describe("getMainModules", () => {
-  it("returns only main modules", () => {
-    const mods = getMainModules();
-    expect(mods.length).toBeGreaterThan(0);
-    for (const mod of mods) {
-      expect(mod.group).toBe("main");
+describe("MODULE_GROUP_NAV_KEYS", () => {
+  it("has a key for every entry in MODULE_GROUPS", () => {
+    for (const group of MODULE_GROUPS) {
+      expect(MODULE_GROUP_NAV_KEYS).toHaveProperty(group);
+    }
+  });
+
+  it("every value is a non-empty string", () => {
+    for (const value of Object.values(MODULE_GROUP_NAV_KEYS)) {
+      expect(typeof value).toBe("string");
+      expect(value.length).toBeGreaterThan(0);
     }
   });
 });
 
-describe("getAdminModules", () => {
-  it("returns only admin modules", () => {
-    const mods = getAdminModules();
-    expect(mods.length).toBeGreaterThan(0);
-    for (const mod of mods) {
-      expect(mod.group).toBe("admin");
+describe("getModulesByGroup", () => {
+  it("returns only modules of the requested group", () => {
+    for (const group of MODULE_GROUPS) {
+      const mods = getModulesByGroup(group);
+      const expected = APP_MODULES.filter((m) => m.group === group);
+      expect(mods).toHaveLength(expected.length);
+      for (const mod of mods) {
+        expect(mod.group).toBe(group);
+      }
     }
   });
 });

--- a/src/lib/modules.ts
+++ b/src/lib/modules.ts
@@ -7,9 +7,12 @@ import {
   Settings,
   Sparkles,
   Star,
+  WandSparkles,
 } from "lucide-react";
 
-type ModuleGroup = "admin" | "main";
+const MODULE_GROUPS = ["library", "lab", "insights", "admin"] as const;
+
+type ModuleGroup = (typeof MODULE_GROUPS)[number];
 
 interface AppModuleBase {
   enabled: boolean;
@@ -18,42 +21,55 @@ interface AppModuleBase {
   slug: string;
 }
 
+const MODULE_GROUP_NAV_KEYS = {
+  admin: "admin",
+  insights: "insights",
+  lab: "theLab",
+  library: "library",
+} as const satisfies Record<ModuleGroup, string>;
+
 const APP_MODULES = [
   {
-    slug: "improve",
-    icon: Dumbbell,
-    enabled: false,
-    group: "main",
-  },
-  {
-    slug: "train",
-    icon: ListChecks,
-    enabled: false,
-    group: "main",
-  },
-  {
-    slug: "plan",
-    icon: BookOpen,
-    enabled: false,
-    group: "main",
-  },
-  {
-    slug: "perform",
-    icon: Star,
-    enabled: false,
-    group: "main",
-  },
-  {
-    slug: "enhance",
-    icon: Sparkles,
-    enabled: false,
-    group: "main",
+    slug: "repertoire",
+    icon: WandSparkles,
+    enabled: true,
+    group: "library",
   },
   {
     slug: "collect",
     icon: Package,
     enabled: false,
-    group: "main",
+    group: "library",
+  },
+  {
+    slug: "improve",
+    icon: Dumbbell,
+    enabled: false,
+    group: "lab",
+  },
+  {
+    slug: "train",
+    icon: ListChecks,
+    enabled: false,
+    group: "lab",
+  },
+  {
+    slug: "plan",
+    icon: BookOpen,
+    enabled: false,
+    group: "lab",
+  },
+  {
+    slug: "perform",
+    icon: Star,
+    enabled: false,
+    group: "lab",
+  },
+  {
+    slug: "enhance",
+    icon: Sparkles,
+    enabled: false,
+    group: "insights",
   },
   {
     slug: "admin",
@@ -79,23 +95,19 @@ function getModule<S extends ModuleSlug>(
   return mod;
 }
 
-function getMainModules(): readonly Extract<
-  AppModuleEntry,
-  { group: "main" }
->[] {
+function getModulesByGroup<G extends ModuleGroup>(
+  group: G
+): readonly Extract<AppModuleEntry, { group: G }>[] {
   return APP_MODULES.filter(
-    (m): m is Extract<AppModuleEntry, { group: "main" }> => m.group === "main"
-  );
-}
-
-function getAdminModules(): readonly Extract<
-  AppModuleEntry,
-  { group: "admin" }
->[] {
-  return APP_MODULES.filter(
-    (m): m is Extract<AppModuleEntry, { group: "admin" }> => m.group === "admin"
+    (m): m is Extract<AppModuleEntry, { group: G }> => m.group === group
   );
 }
 
 export type { AppModuleEntry, ModuleGroup, ModuleSlug };
-export { APP_MODULES, getAdminModules, getMainModules, getModule };
+export {
+  APP_MODULES,
+  getModule,
+  getModulesByGroup,
+  MODULE_GROUP_NAV_KEYS,
+  MODULE_GROUPS,
+};


### PR DESCRIPTION
## Summary

- Reorganize the module registry from 2 groups (`main`/`admin`) into 4 semantic groups (`library`/`lab`/`insights`/`admin`) with `MODULE_GROUPS`, `MODULE_GROUP_NAV_KEYS`, and a generic `getModulesByGroup()` replacing `getMainModules()`/`getAdminModules()`
- Add **Repertoire** as the first enabled module in the Library group — trick CRUD with tags, fully implemented
- Update sidebar, dashboard grid, and marketing page to render modules by group with section headings and proper ARIA landmarks
- Exclude Repertoire from the dashboard grid (it has a dedicated `RepertoireCard` with live trick count above)
- Make the repertoire search bar fill available width alongside filter selects (`sm:flex-1`)
- Add/update i18n keys for group nav labels across all 7 locales
- Update all tests and documentation

## Test plan

- [ ] `pnpm test:run` — all 1232 tests pass
- [ ] `pnpm lint` — 0 issues
- [ ] `pnpm typecheck` — 0 errors
- [ ] Verify sidebar shows 4 group sections (Library, The Lab, Insights, Admin)
- [ ] Verify dashboard shows grouped module cards without Repertoire (RepertoireCard is above)
- [ ] Verify marketing page shows all 7 non-admin modules with coming-soon badges on disabled ones
- [ ] Verify repertoire search bar fills available width on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)