### PR TITLE
fix: mark (app) layout as force-dynamic to suppress build warnings

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { ShieldAlert } from "lucide-react";
 import { redirect } from "next/navigation";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";


### PR DESCRIPTION
## Summary

- Add `export const dynamic = "force-dynamic"` to `src/app/(app)/layout.tsx`
- The layout calls `auth.getSession()` which uses `cookies()` internally, making it inherently dynamic — but without the explicit export, Next.js 16 attempts static rendering during build, triggers cookie access, and logs a `[auth.getSession] Cookie validation error` warning for every child route
- This is consistent with the documented architecture (app routes are "Dynamic, server-rendered on demand")

## Test plan

- [x] `pnpm build` — no more `Cookie validation error` warnings, all `(app)` routes show as `ƒ (Dynamic)`
- [x] `pnpm typecheck` — passes
- [x] `pnpm test:run` — 1232/1232 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)