### PR TITLE
fix: convert sidebar to client component for instant locale switching

### DIFF
--- a/src/components/app-sidebar.test.tsx
+++ b/src/components/app-sidebar.test.tsx
@@ -69,9 +69,8 @@ vi.mock("@/components/ui/sidebar", () => ({
 }));
 
 describe("AppSidebar", () => {
-  it("renders the home/logo link pointing to /dashboard", async () => {
-    const element = await AppSidebar();
-    render(element);
+  it("renders the home/logo link pointing to /dashboard", () => {
+    render(<AppSidebar />);
 
     const links = screen.getAllByRole("link");
     const homeLink = links.find(
@@ -80,25 +79,22 @@ describe("AppSidebar", () => {
     expect(homeLink).toBeInTheDocument();
   });
 
-  it('renders "The Magic Lab" sr-only text', async () => {
-    const element = await AppSidebar();
-    render(element);
+  it('renders "The Magic Lab" sr-only text', () => {
+    render(<AppSidebar />);
 
     const srText = screen.getByText("The Magic Lab");
     expect(srText).toBeInTheDocument();
     expect(srText.className).toContain("sr-only");
   });
 
-  it("renders the Dashboard nav item", async () => {
-    const element = await AppSidebar();
-    render(element);
+  it("renders the Dashboard nav item", () => {
+    render(<AppSidebar />);
 
     expect(screen.getByText("nav.dashboard")).toBeInTheDocument();
   });
 
-  it("renders nav items for all module groups", async () => {
-    const element = await AppSidebar();
-    render(element);
+  it("renders nav items for all module groups", () => {
+    render(<AppSidebar />);
 
     const navItems = screen.getAllByTestId("sidebar-nav-item");
     for (const group of MODULE_GROUPS) {
@@ -111,9 +107,8 @@ describe("AppSidebar", () => {
     }
   });
 
-  it("renders a nav item for every module", async () => {
-    const element = await AppSidebar();
-    render(element);
+  it("renders a nav item for every module", () => {
+    render(<AppSidebar />);
 
     for (const mod of APP_MODULES) {
       // Some slugs (e.g. "admin") also appear as group labels, so use getAllByText
@@ -123,9 +118,8 @@ describe("AppSidebar", () => {
     }
   });
 
-  it("renders group labels for all module groups", async () => {
-    const element = await AppSidebar();
-    render(element);
+  it("renders group labels for all module groups", () => {
+    render(<AppSidebar />);
 
     expect(screen.getByText("nav.library")).toBeInTheDocument();
     expect(screen.getByText("nav.theLab")).toBeInTheDocument();
@@ -133,9 +127,8 @@ describe("AppSidebar", () => {
     expect(screen.getAllByText("nav.admin").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders the Settings nav item", async () => {
-    const element = await AppSidebar();
-    render(element);
+  it("renders the Settings nav item", () => {
+    render(<AppSidebar />);
 
     expect(screen.getByText("nav.settings")).toBeInTheDocument();
     const navItems = screen.getAllByTestId("sidebar-nav-item");

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import { UserButton } from "@neondatabase/auth/react";
 import { LayoutDashboard, UserCog } from "lucide-react";
-import { getTranslations } from "next-intl/server";
+import { useTranslations } from "next-intl";
 import { Fragment, type ReactElement } from "react";
 import { Logo } from "@/components/logo";
 import { SidebarNavItem } from "@/components/sidebar-nav";
@@ -22,8 +24,8 @@ import {
   MODULE_GROUPS,
 } from "@/lib/modules";
 
-export async function AppSidebar(): Promise<ReactElement> {
-  const t = await getTranslations("nav");
+export function AppSidebar(): ReactElement {
+  const t = useTranslations("nav");
 
   return (
     <Sidebar>


### PR DESCRIPTION
## Summary

- Convert `AppSidebar` from an async server component to a client component using `useTranslations("nav")` instead of `getTranslations("nav")`
- When changing language in Settings, the sidebar menu now updates instantly without requiring a page reload
- Update all 7 test cases to use synchronous `render(<AppSidebar />)` pattern

## Context

The sidebar used server-side `getTranslations()`, so its labels stayed in the old language when the user changed locale in Settings. Client-side `switchLocale()` only re-renders components using the `useTranslations()` hook. All sidebar children (`SidebarNavItem`, `UserButton`, `ThemeToggle`) were already client components, and all locale messages are bundled client-side for offline support — no performance impact.

## Test plan

- [x] `pnpm test:run -- src/components/app-sidebar` — all 7 tests pass
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint` — no lint issues
- [ ] Manual: change language in Settings → sidebar labels update instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)