### PR TITLE
feat: redirect authenticated users from / to dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Requires Node 24.x and pnpm >= 10.
 ### Route Groups
 
 - `src/app/(app)/` — authenticated routes (dashboard, repertoire, settings, account, feature modules). Protected by `proxy.ts`. Dynamic (server-rendered on demand). `/repertoire` is the Repertoire module (Library group) — trick CRUD with tags, fully implemented and enabled. `/account/[path]` is Neon Auth account management via `AccountView`.
-- `src/app/(marketing)/[locale]/` — public pages (landing, FAQ, privacy). URL-based locale routing with `generateStaticParams` for all 7 locales. Statically generated at build time (21 pages). Bare paths (`/`, `/faq`, `/privacy`) are 302-redirected by proxy to locale-prefixed versions.
+- `src/app/(marketing)/[locale]/` — public pages (landing, FAQ, privacy). URL-based locale routing with `generateStaticParams` for all 7 locales. Statically generated at build time (21 pages). Bare paths (`/faq`, `/privacy`) are 302-redirected by proxy to locale-prefixed versions. The root path `/` redirects authenticated users to `/dashboard` and unauthenticated users to the locale-prefixed landing page.
 - `src/app/auth/` — sign-in / sign-up pages. Dynamic (reads `NEXT_LOCALE` cookie for locale-aware rendering). Authenticated users are redirected to `/dashboard`.
 - `src/app/api/` — API route handlers (PowerSync upload, auth, unsubscribe, etc.).
 

--- a/docs/diagrams/route-map.md
+++ b/docs/diagrams/route-map.md
@@ -62,7 +62,8 @@ graph TD
 - `/[locale]` — Landing page (hero, features, CTAs) — 7 locale variants
 - `/[locale]/privacy` — Privacy policy — 7 locale variants
 - `/[locale]/faq` — Frequently asked questions — 7 locale variants
-- Bare paths (`/`, `/faq`, `/privacy`) are 302-redirected by proxy to locale-prefixed versions
+- Bare paths (`/faq`, `/privacy`) are 302-redirected by proxy to locale-prefixed versions
+- The root path `/` redirects authenticated users to `/dashboard`, unauthenticated users to the locale-prefixed landing page
 
 ### `(app)/` — Authenticated App
 - `/dashboard` — Main dashboard

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -20,10 +20,10 @@ The app uses a dual strategy for locale detection:
 
 ### Marketing Pages -- URL-based Locale Routing
 
-Public marketing pages use a `[locale]` URL segment for locale. Bare paths (`/`, `/faq`, `/privacy`) are 302-redirected by the proxy to locale-prefixed versions based on the user's `NEXT_LOCALE` cookie or `Accept-Language` header.
+Public marketing pages use a `[locale]` URL segment for locale. Bare paths (`/faq`, `/privacy`) are 302-redirected by the proxy to locale-prefixed versions based on the user's `NEXT_LOCALE` cookie or `Accept-Language` header. The root path `/` redirects authenticated users to `/dashboard` and unauthenticated users to the locale-prefixed landing page.
 
 ```
-/           --> 302 redirect to /en (or detected locale)
+/           --> 302 redirect to /dashboard (authenticated) or /en (unauthenticated)
 /en         --> English homepage (static)
 /fr         --> French homepage (static)
 /es/faq     --> Spanish FAQ page (static)

--- a/docs/route-structure.md
+++ b/docs/route-structure.md
@@ -22,7 +22,7 @@ src/app/
 
 ### Marketing Routes -- `(marketing)/[locale]/`
 
-Marketing pages use URL-based locale routing for SEO. Each page is statically generated for all 7 locales (21 total pages). Bare paths (`/`, `/faq`, `/privacy`) are redirected by the proxy to locale-prefixed versions (e.g., `/en`, `/en/faq`).
+Marketing pages use URL-based locale routing for SEO. Each page is statically generated for all 7 locales (21 total pages). Bare paths (`/faq`, `/privacy`) are redirected by the proxy to locale-prefixed versions (e.g., `/en/faq`). The root path `/` redirects authenticated users to `/dashboard` and unauthenticated users to the locale-prefixed landing page (e.g., `/en`).
 
 | Path | Page | Description |
 |---|---|---|
@@ -66,13 +66,16 @@ The proxy (`src/proxy.ts`) handles locale redirects and auth-based routing:
 ```
 Any user
   |
-  +--> visits / or /faq or /privacy
-  |      --> 302 redirect to /[locale] (detected from cookie or Accept-Language)
+  +--> visits /faq or /privacy
+  |      --> 302 redirect to /[locale]/... (detected from cookie or Accept-Language)
   |
   +--> visits /en, /fr/faq, etc.
          --> Serve static page (no server computation)
 
 Unauthenticated user
+  |
+  +--> visits /
+  |      --> 302 redirect to /[locale] (marketing landing page)
   |
   +--> visits /dashboard, /improve, etc.
   |      --> Redirect to /auth/sign-in
@@ -81,6 +84,9 @@ Unauthenticated user
          --> Show static FAQ page
 
 Authenticated user
+  |
+  +--> visits /
+  |      --> 302 redirect to /dashboard
   |
   +--> visits /auth/sign-in, /auth/sign-up
   |      --> Redirect to /dashboard

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1077,7 +1077,8 @@ graph TD
 - `/[locale]` — Landing page (hero, features, CTAs) — 7 locale variants
 - `/[locale]/privacy` — Privacy policy — 7 locale variants
 - `/[locale]/faq` — Frequently asked questions — 7 locale variants
-- Bare paths (`/`, `/faq`, `/privacy`) are 302-redirected by proxy to locale-prefixed versions
+- Bare paths (`/faq`, `/privacy`) are 302-redirected by proxy to locale-prefixed versions
+- The root path `/` redirects authenticated users to `/dashboard`, unauthenticated users to the locale-prefixed landing page
 
 ### `(app)/` — Authenticated App
 - `/dashboard` — Main dashboard
@@ -1456,10 +1457,10 @@ The app uses a dual strategy for locale detection:
 
 ### Marketing Pages -- URL-based Locale Routing
 
-Public marketing pages use a `[locale]` URL segment for locale. Bare paths (`/`, `/faq`, `/privacy`) are 302-redirected by the proxy to locale-prefixed versions based on the user's `NEXT_LOCALE` cookie or `Accept-Language` header.
+Public marketing pages use a `[locale]` URL segment for locale. Bare paths (`/faq`, `/privacy`) are 302-redirected by the proxy to locale-prefixed versions based on the user's `NEXT_LOCALE` cookie or `Accept-Language` header. The root path `/` redirects authenticated users to `/dashboard` and unauthenticated users to the locale-prefixed landing page.
 
 ```
-/           --> 302 redirect to /en (or detected locale)
+/           --> 302 redirect to /dashboard (authenticated) or /en (unauthenticated)
 /en         --> English homepage (static)
 /fr         --> French homepage (static)
 /es/faq     --> Spanish FAQ page (static)
@@ -2059,7 +2060,7 @@ src/app/
 
 ### Marketing Routes -- `(marketing)/[locale]/`
 
-Marketing pages use URL-based locale routing for SEO. Each page is statically generated for all 7 locales (21 total pages). Bare paths (`/`, `/faq`, `/privacy`) are redirected by the proxy to locale-prefixed versions (e.g., `/en`, `/en/faq`).
+Marketing pages use URL-based locale routing for SEO. Each page is statically generated for all 7 locales (21 total pages). Bare paths (`/faq`, `/privacy`) are redirected by the proxy to locale-prefixed versions (e.g., `/en/faq`). The root path `/` redirects authenticated users to `/dashboard` and unauthenticated users to the locale-prefixed landing page (e.g., `/en`).
 
 | Path | Page | Description |
 |---|---|---|
@@ -2103,13 +2104,16 @@ The proxy (`src/proxy.ts`) handles locale redirects and auth-based routing:
 ```
 Any user
   |
-  +--> visits / or /faq or /privacy
-  |      --> 302 redirect to /[locale] (detected from cookie or Accept-Language)
+  +--> visits /faq or /privacy
+  |      --> 302 redirect to /[locale]/... (detected from cookie or Accept-Language)
   |
   +--> visits /en, /fr/faq, etc.
          --> Serve static page (no server computation)
 
 Unauthenticated user
+  |
+  +--> visits /
+  |      --> 302 redirect to /[locale] (marketing landing page)
   |
   +--> visits /dashboard, /improve, etc.
   |      --> Redirect to /auth/sign-in
@@ -2118,6 +2122,9 @@ Unauthenticated user
          --> Show static FAQ page
 
 Authenticated user
+  |
+  +--> visits /
+  |      --> 302 redirect to /dashboard
   |
   +--> visits /auth/sign-in, /auth/sign-up
   |      --> Redirect to /dashboard

--- a/scripts/generate-route-map.ts
+++ b/scripts/generate-route-map.ts
@@ -108,7 +108,8 @@ ${mermaid}
 - \`/[locale]\` — Landing page (hero, features, CTAs) — 7 locale variants
 - \`/[locale]/privacy\` — Privacy policy — 7 locale variants
 - \`/[locale]/faq\` — Frequently asked questions — 7 locale variants
-- Bare paths (\`/\`, \`/faq\`, \`/privacy\`) are 302-redirected by proxy to locale-prefixed versions
+- Bare paths (\`/faq\`, \`/privacy\`) are 302-redirected by proxy to locale-prefixed versions
+- The root path \`/\` redirects authenticated users to \`/dashboard\`, unauthenticated users to the locale-prefixed landing page
 
 ### \`(app)/\` — Authenticated App
 - \`/dashboard\` — Main dashboard

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -165,6 +165,17 @@ describe("proxy", () => {
     expect(mockMiddleware).not.toHaveBeenCalled();
   });
 
+  it("redirects authenticated users from / to /dashboard", async () => {
+    const { proxy } = await import("./proxy");
+
+    const response = await proxy(createRequest("/", true));
+    expect(response.status).toBe(302);
+    expect(new URL(response.headers.get("location") ?? "").pathname).toBe(
+      "/dashboard"
+    );
+    expect(response.headers.get("Content-Security-Policy")).toBeTruthy();
+  });
+
   it("redirects bare marketing paths to locale-prefixed versions", async () => {
     const { proxy } = await import("./proxy");
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -103,6 +103,18 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   const { pathname } = request.nextUrl;
   const csp = buildCspForRoute();
 
+  // Redirect authenticated users from root to dashboard.
+  // Cookie-existence check only — no session validation to keep proxy fast.
+  // If the cookie is stale, the dashboard's auth guard redirects to sign-in.
+  if (pathname === "/" && request.cookies.has(SESSION_COOKIE_NAME)) {
+    const response = NextResponse.redirect(
+      new URL("/dashboard", request.url),
+      302
+    );
+    response.headers.set("Content-Security-Policy", csp);
+    return response;
+  }
+
   // Redirect bare marketing paths to locale-prefixed versions.
   // Uses 302 (not 301) because the target depends on the user's locale
   // preference which can change (cookie + Accept-Language).


### PR DESCRIPTION
## Summary

- Authenticated users visiting `/` now get a 302 redirect to `/dashboard` instead of seeing the marketing landing page
- Uses cookie-existence check only (no session validation) to keep the proxy fast — if the cookie is stale, the dashboard's auth guard handles the redirect to sign-in
- Unauthenticated users continue to be redirected to the locale-prefixed marketing page (e.g., `/en`) as before

## Test plan

- [ ] Visit `/` while logged in → redirected to `/dashboard`
- [ ] Visit `/` while logged out → redirected to `/en` (marketing page)
- [ ] Visit `/en` while logged in → marketing page renders (no redirect)
- [ ] Visit `/faq` or `/privacy` → locale redirect unchanged for all users
- [ ] Unit tests pass (`pnpm test:run` — new test for authenticated `/` → `/dashboard`)
- [ ] Typecheck passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.ai/code)