### PR TITLE
fix(ci): skip Dependabot drift checks via PR author, not triggerer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm i18n:check
 
       - name: Check migration drift
-        if: github.actor != 'dependabot[bot]'
+        if: github.event_name == 'push' || github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           pnpm db:generate
           git diff --exit-code src/db/migrations/
@@ -72,7 +72,7 @@ jobs:
           DATABASE_URL: postgresql://unused:unused@localhost:5432/unused
 
       - name: Check generated docs staleness
-        if: github.actor != 'dependabot[bot]'
+        if: github.event_name == 'push' || github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           pnpm docs:generate
           git diff --exit-code public/llms.txt public/llms-full.txt docs/diagrams/

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ next-env.d.ts
 .claude/audit-*
 .claude/review-*.json
 .claude/settings.local.json
+/CLAUDE.local.md
 
 TODO.txt
 .env*.local


### PR DESCRIPTION
## Summary

- `github.actor` is the user who **triggered** the workflow run, not the PR author. When a maintainer re-ran CI, pushed to a Dependabot branch, or closed/reopened a Dependabot PR, `github.actor` flipped to the maintainer — and the migration-drift and generated-docs-staleness checks ran against Dependabot-authored diffs the bot cannot regenerate, failing predictably.
- New condition: `github.event_name == 'push' || github.event.pull_request.user.login != 'dependabot[bot]'`. Same truth table as the prior buggy form (runs on push-to-main; runs for human PRs; skips for Dependabot PRs), but now stable across re-runs because `pull_request.user.login` is the PR author fixed server-side.
- Also gitignore `/CLAUDE.local.md` at repo root — prevents tackle's per-task briefing from accidentally landing in the tracked `CLAUDE.md` on future runs.

## Test plan

- [x] This PR itself: the two guarded steps (`Check migration drift`, `Check generated docs staleness`) should **run** (not skip), since `pull_request.user.login` is `julienroussel`, not `dependabot[bot]`.
- [ ] After merge, on the next Dependabot PR (or by re-running an open one): the two steps should show as **SKIPPED** even if a human pushes a commit to the branch or re-runs CI.
- [ ] `push` to `main` (post-merge): the two steps still run (regression guard — `github.event_name == 'push'` short-circuits to true).

## Out of scope

- The companion `auto-merge-dependabot.yml` workflow already uses the stable two-field pattern (`pull_request_target` + write perms demand it). Untouched.
- Issue #209 (docs generator non-determinism) is the independent root cause of some post-merge `push`-to-`main` failures. Tracked separately.

Closes #210