### PR TITLE
fix(scripts): make docs generation deterministic

### DIFF
--- a/docs/diagrams/route-map.md
+++ b/docs/diagrams/route-map.md
@@ -1,6 +1,6 @@
 # Route Map
 
-<!-- Last verified: 2026-04-09 -->
+<!-- Last verified: 2026-04-13 -->
 
 ## Route Structure
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1015,7 +1015,7 @@ Source: docs/diagrams/route-map.md
 
 # Route Map
 
-<!-- Last verified: 2026-04-09 -->
+<!-- Last verified: 2026-04-13 -->
 
 ## Route Structure
 

--- a/scripts/generate-docs.test.ts
+++ b/scripts/generate-docs.test.ts
@@ -97,23 +97,25 @@ describe("generateAll", () => {
     const results = generateAll("/project");
 
     expect(results).toHaveLength(2);
-    expect(results[0]?.name).toBe("llms.txt");
-    expect(results[1]?.name).toBe("Route map");
+    expect(results[0]?.name).toBe("Route map");
+    expect(results[1]?.name).toBe("llms.txt");
     expect(results.every((r) => r.success)).toBe(true);
   });
 
   it("includes failures in results without stopping", () => {
     mockedExistsSync.mockReturnValue(true);
-    mockedExecSync.mockReturnValueOnce("").mockImplementationOnce(() => {
-      throw new Error("route map failed");
-    });
+    mockedExecSync
+      .mockImplementationOnce(() => {
+        throw new Error("route map failed");
+      })
+      .mockReturnValueOnce("");
 
     const results = generateAll("/project");
 
     expect(results).toHaveLength(2);
-    expect(results[0]?.success).toBe(true);
-    expect(results[1]?.success).toBe(false);
-    expect(results[1]?.message).toBe("route map failed");
+    expect(results[0]?.success).toBe(false);
+    expect(results[0]?.message).toBe("route map failed");
+    expect(results[1]?.success).toBe(true);
   });
 
   it("logs output for each generator", () => {

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -34,8 +34,8 @@ function runGenerator(
 
 function generateAll(projectRoot: string): GeneratorResult[] {
   const generators = [
-    { name: "llms.txt", script: "scripts/generate-llms-txt.ts" },
     { name: "Route map", script: "scripts/generate-route-map.ts" },
+    { name: "llms.txt", script: "scripts/generate-llms-txt.ts" },
   ];
 
   const results: GeneratorResult[] = [];

--- a/scripts/generate-route-map.ts
+++ b/scripts/generate-route-map.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { readdirSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 
@@ -88,13 +89,21 @@ function generateMermaid(appDir: string): string {
   return lines.join("\n");
 }
 
+function getLastCommitDate(projectRoot: string): string {
+  const iso = execSync("git log -1 --format=%cI HEAD", {
+    cwd: projectRoot,
+    encoding: "utf-8",
+  }).trim();
+  return iso.slice(0, 10);
+}
+
 function generateRouteMap(projectRoot: string): string {
   const appDir = join(projectRoot, "src", "app");
   const mermaid = generateMermaid(appDir);
 
   return `# Route Map
 
-<!-- Last verified: ${new Date().toISOString().split("T")[0]} -->
+<!-- Last verified: ${getLastCommitDate(projectRoot)} -->
 
 ## Route Structure
 


### PR DESCRIPTION
## Summary

The `Check generated docs staleness` CI step has been flaking on every PR that happens to be re-generated on a different calendar day than its last committed generation — because `scripts/generate-route-map.ts` stamped `<!-- Last verified: ... -->` with **today's date** (`new Date().toISOString()`). Any re-run on a later day produces drift, regardless of whether route sources changed.

Two fixes, both scoped to making `pnpm docs:generate` idempotent:

1. **Deterministic date source** — `scripts/generate-route-map.ts` now uses `git log -1 --format=%cI HEAD` and slices to `YYYY-MM-DD`. Stable for a given commit SHA, TZ-independent (the commit's own TZ offset is baked in), safe on GitHub's default `fetch-depth: 1` checkout (HEAD is always in the clone).
2. **Generator ordering** — `scripts/generate-docs.ts` now runs `route-map` **before** `llms.txt`. `llms-full.txt` embeds `route-map.md` content, so the previous order (`llms.txt` first) caused `llms-full.txt` to always reflect the PRIOR `route-map.md` generation. Running `route-map` first converges both outputs in a single `pnpm docs:generate` pass.

Regenerated `docs/diagrams/route-map.md` and `public/llms-full.txt` accordingly. Test `scripts/generate-docs.test.ts` updated to match the new invocation order.

## Test plan

- [x] `pnpm docs:generate` locally — both outputs stable.
- [x] Second `pnpm docs:generate` invocation — zero additional diff (idempotent in one pass).
- [x] `pnpm vitest run scripts/generate-*.test.ts` — all 12 tests pass.
- [x] `pnpm exec tsc --noEmit` — clean.
- [ ] CI `Check generated docs staleness` step — should pass now.
- [ ] After merge, re-run CI on PR #211 (the companion fix for #210) — should unblock its merge.

## Why this surfaces now

Companion PR #211 fixes the Dependabot skip guard in `ci.yml` so that the drift-check steps actually **run** on human-authored PRs (they were incorrectly skipping before, hiding this rot). That fix's first CI run exposed this #209 symptom. #211 notes this dependency in its own body.

## Out of scope

- Changing the checkout depth or adding path-scoped git log semantics — HEAD's commit date is good enough for "Last verified" in the single-workflow repo.

Closes #209