### PR TITLE
feat: add Collect inventory module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ next-env.d.ts
 .claude/review-*.json
 .claude/settings.local.json
 /CLAUDE.local.md
+.claude/worktrees
 
 TODO.txt
 .env*.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Requires Node 24.x and pnpm >= 10.
 
 ### Route Groups
 
-- `src/app/(app)/` — authenticated routes (dashboard, repertoire, settings, account, feature modules). Protected by `proxy.ts`. Dynamic (server-rendered on demand). `/repertoire` is the Repertoire module (Library group) — trick CRUD with tags, fully implemented and enabled. `/account/[path]` is Neon Auth account management via `AccountView`.
+- `src/app/(app)/` — authenticated routes (dashboard, repertoire, collect, settings, account, feature modules). Protected by `proxy.ts`. Dynamic (server-rendered on demand). `/repertoire` is the Repertoire module (Library group) — trick CRUD with tags, fully implemented and enabled. `/collect` is the Collection module (Library group) — item CRUD with tags, trick linking, and filtering, fully implemented and enabled. `/account/[path]` is Neon Auth account management via `AccountView`.
 - `src/app/(marketing)/[locale]/` — public pages (landing, FAQ, privacy). URL-based locale routing with `generateStaticParams` for all 7 locales. Statically generated at build time (21 pages). Bare paths (`/faq`, `/privacy`) are 302-redirected by proxy to locale-prefixed versions. The root path `/` redirects authenticated users to `/dashboard` and unauthenticated users to the locale-prefixed landing page.
 - `src/app/auth/` — sign-in / sign-up pages. Dynamic (reads `NEXT_LOCALE` cookie for locale-aware rendering). Authenticated users are redirected to `/dashboard`.
 - `src/app/api/` — API route handlers (PowerSync upload, auth, unsubscribe, etc.).
@@ -78,7 +78,7 @@ Requires Node 24.x and pnpm >= 10.
 ### Module Registry
 
 - `src/lib/modules.ts` defines all feature modules, organized into 4 groups (`MODULE_GROUPS`):
-  - **Library**: Repertoire (`enabled: true`), Collection (slug: `collect`, `enabled: false`)
+  - **Library**: Repertoire (`enabled: true`), Collection (slug: `collect`, `enabled: true`)
   - **Lab**: Improve, Train, Plan, Perform (all `enabled: false`)
   - **Insights**: Enhance (`enabled: false`)
   - **Admin**: Admin (`enabled: false`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,7 @@ src/app/
     layout.tsx          # Sidebar + header chrome
     dashboard/page.tsx  # Home dashboard
     repertoire/page.tsx # Trick library (Library module)
-    collect/page.tsx    # Inventory management (Library module)
+    collect/page.tsx    # Inventory management (Library module) — enabled
     improve/page.tsx    # Practice session logging (Lab module)
     train/page.tsx      # Goal setting and drills (Lab module)
     plan/page.tsx       # Setlist builder (Lab module)
@@ -51,7 +51,7 @@ Each feature area is organized as a self-contained module defined in `src/lib/mo
 
 Modules are organized into 4 groups:
 
-- **Library**: Repertoire (enabled), Collection
+- **Library**: Repertoire (enabled), Collection (enabled)
 - **Lab**: Improve, Train, Plan, Perform
 - **Insights**: Enhance
 - **Admin**: Admin

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -200,17 +200,36 @@ Props, books, gimmicks, and other collectible items.
 | id | UUID (PK) | Branded as `ItemId` |
 | user_id | UUID (FK -> users) | NOT NULL, cascade delete |
 | name | text | NOT NULL |
-| type | text | NOT NULL: `"prop"`, `"book"`, `"gimmick"`, `"dvd"`, `"download"`, `"other"` |
+| type | text | NOT NULL: `"prop"`, `"book"`, `"gimmick"`, `"dvd"`, `"download"`, `"other"`, `"deck"`, `"clothing"`, `"consumable"`, `"accessory"` |
 | description | text | |
-| brand | text | Manufacturer/creator |
+| brand | text | Manufacturer/publisher |
 | condition | text | `"new"`, `"good"`, `"worn"`, `"needs_repair"` |
 | location | text | Storage location |
 | notes | text | |
 | purchase_date | date | |
 | purchase_price | numeric(10,2) | |
+| quantity | integer | NOT NULL, default 1, CHECK >= 0 |
+| creator | text | Author (books), inventor (gimmicks), designer |
+| url | text | Product URL (HTTPS) |
 | created_at | timestamptz | NOT NULL, default now() |
 | updated_at | timestamptz | NOT NULL, default now() |
 | deleted_at | timestamptz | Soft-delete |
+
+### item_tags
+
+Join table linking tags to items (many-to-many). Reuses the shared `tags` table.
+
+| Column | Type | Notes |
+|---|---|---|
+| id | UUID (PK) | |
+| user_id | UUID (FK -> users) | NOT NULL, cascade delete |
+| item_id | UUID (FK -> items) | NOT NULL, no action |
+| tag_id | UUID (FK -> tags) | NOT NULL, no action |
+| created_at | timestamptz | NOT NULL, default now() |
+| updated_at | timestamptz | NOT NULL, default now() |
+| deleted_at | timestamptz | Soft-delete |
+
+Unique constraint on `(item_id, tag_id)` where `deleted_at IS NULL`.
 
 ### item_tricks
 

--- a/docs/diagrams/module-deps.md
+++ b/docs/diagrams/module-deps.md
@@ -80,7 +80,7 @@ graph TB
 | Module | Group | Purpose | Key Entities |
 |---|---|---|---|
 | **Repertoire** | Library | Manage trick library with tags and metadata | tricks, trick_tags |
-| **Collection** | Library | Manage inventory of props and materials | items, item_tricks |
+| **Collection** | Library | Manage inventory of props and materials | items, item_tags, item_tricks |
 | **Improve** | Lab | Log practice sessions, track skill progress | practice_sessions, practice_session_tricks |
 | **Train** | Lab | Set goals, create drills, build streaks | goals |
 | **Plan** | Lab | Build setlists for shows | setlists, setlist_tricks |

--- a/docs/diagrams/route-map.md
+++ b/docs/diagrams/route-map.md
@@ -1,6 +1,6 @@
 # Route Map
 
-<!-- Last verified: 2026-04-13 -->
+<!-- Last verified: 2026-04-16 -->
 
 ## Route Structure
 

--- a/docs/diagrams/schema-er.md
+++ b/docs/diagrams/schema-er.md
@@ -132,7 +132,7 @@ erDiagram
         uuid id PK "default random"
         uuid user_id FK
         text name
-        text type "prop, book, gimmick, dvd, download, other"
+        text type "prop, book, gimmick, dvd, download, other, deck, clothing, consumable, accessory"
         text description
         text brand
         text condition "new, good, worn, needs_repair"
@@ -140,6 +140,19 @@ erDiagram
         text notes
         date purchase_date
         numeric purchase_price
+        integer quantity "default 1, >= 0"
+        text creator
+        text url
+        timestamptz created_at
+        timestamptz updated_at
+        timestamptz deleted_at
+    }
+
+    item_tags {
+        uuid id PK "default random"
+        uuid user_id FK
+        uuid item_id FK
+        uuid tag_id FK
         timestamptz created_at
         timestamptz updated_at
         timestamptz deleted_at
@@ -147,6 +160,7 @@ erDiagram
 
     item_tricks {
         uuid id PK "default random"
+        uuid user_id FK
         uuid item_id FK
         uuid trick_id FK
         timestamptz created_at
@@ -209,6 +223,9 @@ erDiagram
     tricks ||--o{ practice_session_tricks : "practiced in"
 
     performances ||--o| setlists : "performed"
+
+    items ||--o{ item_tags : "tagged with"
+    tags ||--o{ item_tags : "applied to"
 
     items ||--o{ item_tricks : "used for"
     tricks ||--o{ item_tricks : "requires"

--- a/docs/route-structure.md
+++ b/docs/route-structure.md
@@ -36,7 +36,7 @@ Marketing pages use URL-based locale routing for SEO. Each page is statically ge
 |---|---|---|---|
 | `/dashboard` | Dashboard | -- | Home with module grid and quick stats |
 | `/repertoire` | Repertoire | Repertoire (Library) | Trick CRUD with tags, filtering, and search |
-| `/collect` | Collection | Collection (Library) | Inventory of props, books, gimmicks |
+| `/collect` | Collection | Collection (Library) | Item CRUD with tags, trick linking, filtering, and search |
 | `/improve` | Improve | Improve (Lab) | Practice session logging and history |
 | `/train` | Train | Train (Lab) | Goal setting, drills, streaks |
 | `/plan` | Plan | Plan (Lab) | Setlist builder |

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -41,7 +41,7 @@ src/app/
     layout.tsx          # Sidebar + header chrome
     dashboard/page.tsx  # Home dashboard
     repertoire/page.tsx # Trick library (Library module)
-    collect/page.tsx    # Inventory management (Library module)
+    collect/page.tsx    # Inventory management (Library module) — enabled
     improve/page.tsx    # Practice session logging (Lab module)
     train/page.tsx      # Goal setting and drills (Lab module)
     plan/page.tsx       # Setlist builder (Lab module)
@@ -61,7 +61,7 @@ Each feature area is organized as a self-contained module defined in `src/lib/mo
 
 Modules are organized into 4 groups:
 
-- **Library**: Repertoire (enabled), Collection
+- **Library**: Repertoire (enabled), Collection (enabled)
 - **Lab**: Improve, Train, Plan, Perform
 - **Insights**: Enhance
 - **Admin**: Admin
@@ -600,17 +600,36 @@ Props, books, gimmicks, and other collectible items.
 | id | UUID (PK) | Branded as `ItemId` |
 | user_id | UUID (FK -> users) | NOT NULL, cascade delete |
 | name | text | NOT NULL |
-| type | text | NOT NULL: `"prop"`, `"book"`, `"gimmick"`, `"dvd"`, `"download"`, `"other"` |
+| type | text | NOT NULL: `"prop"`, `"book"`, `"gimmick"`, `"dvd"`, `"download"`, `"other"`, `"deck"`, `"clothing"`, `"consumable"`, `"accessory"` |
 | description | text | |
-| brand | text | Manufacturer/creator |
+| brand | text | Manufacturer/publisher |
 | condition | text | `"new"`, `"good"`, `"worn"`, `"needs_repair"` |
 | location | text | Storage location |
 | notes | text | |
 | purchase_date | date | |
 | purchase_price | numeric(10,2) | |
+| quantity | integer | NOT NULL, default 1, CHECK >= 0 |
+| creator | text | Author (books), inventor (gimmicks), designer |
+| url | text | Product URL (HTTPS) |
 | created_at | timestamptz | NOT NULL, default now() |
 | updated_at | timestamptz | NOT NULL, default now() |
 | deleted_at | timestamptz | Soft-delete |
+
+### item_tags
+
+Join table linking tags to items (many-to-many). Reuses the shared `tags` table.
+
+| Column | Type | Notes |
+|---|---|---|
+| id | UUID (PK) | |
+| user_id | UUID (FK -> users) | NOT NULL, cascade delete |
+| item_id | UUID (FK -> items) | NOT NULL, no action |
+| tag_id | UUID (FK -> tags) | NOT NULL, no action |
+| created_at | timestamptz | NOT NULL, default now() |
+| updated_at | timestamptz | NOT NULL, default now() |
+| deleted_at | timestamptz | Soft-delete |
+
+Unique constraint on `(item_id, tag_id)` where `deleted_at IS NULL`.
 
 ### item_tricks
 
@@ -872,7 +891,7 @@ graph TB
 | Module | Group | Purpose | Key Entities |
 |---|---|---|---|
 | **Repertoire** | Library | Manage trick library with tags and metadata | tricks, trick_tags |
-| **Collection** | Library | Manage inventory of props and materials | items, item_tricks |
+| **Collection** | Library | Manage inventory of props and materials | items, item_tags, item_tricks |
 | **Improve** | Lab | Log practice sessions, track skill progress | practice_sessions, practice_session_tricks |
 | **Train** | Lab | Set goals, create drills, build streaks | goals |
 | **Plan** | Lab | Build setlists for shows | setlists, setlist_tricks |
@@ -1015,7 +1034,7 @@ Source: docs/diagrams/route-map.md
 
 # Route Map
 
-<!-- Last verified: 2026-04-13 -->
+<!-- Last verified: 2026-04-16 -->
 
 ## Route Structure
 
@@ -1236,7 +1255,7 @@ erDiagram
         uuid id PK "default random"
         uuid user_id FK
         text name
-        text type "prop, book, gimmick, dvd, download, other"
+        text type "prop, book, gimmick, dvd, download, other, deck, clothing, consumable, accessory"
         text description
         text brand
         text condition "new, good, worn, needs_repair"
@@ -1244,6 +1263,19 @@ erDiagram
         text notes
         date purchase_date
         numeric purchase_price
+        integer quantity "default 1, >= 0"
+        text creator
+        text url
+        timestamptz created_at
+        timestamptz updated_at
+        timestamptz deleted_at
+    }
+
+    item_tags {
+        uuid id PK "default random"
+        uuid user_id FK
+        uuid item_id FK
+        uuid tag_id FK
         timestamptz created_at
         timestamptz updated_at
         timestamptz deleted_at
@@ -1251,6 +1283,7 @@ erDiagram
 
     item_tricks {
         uuid id PK "default random"
+        uuid user_id FK
         uuid item_id FK
         uuid trick_id FK
         timestamptz created_at
@@ -1313,6 +1346,9 @@ erDiagram
     tricks ||--o{ practice_session_tricks : "practiced in"
 
     performances ||--o| setlists : "performed"
+
+    items ||--o{ item_tags : "tagged with"
+    tags ||--o{ item_tags : "applied to"
 
     items ||--o{ item_tricks : "used for"
     tricks ||--o{ item_tricks : "requires"
@@ -2074,7 +2110,7 @@ Marketing pages use URL-based locale routing for SEO. Each page is statically ge
 |---|---|---|---|
 | `/dashboard` | Dashboard | -- | Home with module grid and quick stats |
 | `/repertoire` | Repertoire | Repertoire (Library) | Trick CRUD with tags, filtering, and search |
-| `/collect` | Collection | Collection (Library) | Inventory of props, books, gimmicks |
+| `/collect` | Collection | Collection (Library) | Item CRUD with tags, trick linking, filtering, and search |
 | `/improve` | Improve | Improve (Lab) | Practice session logging and history |
 | `/train` | Train | Train (Lab) | Goal setting, drills, streaks |
 | `/plan` | Plan | Plan (Lab) | Setlist builder |

--- a/src/app/(app)/collect/error.tsx
+++ b/src/app/(app)/collect/error.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { track } from "@vercel/analytics";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { type ReactElement, useEffect, useRef } from "react";
+
+import { Button } from "@/components/ui/button";
+
+export default function CollectError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}): ReactElement {
+  const t = useTranslations("errors");
+  const tCommon = useTranslations("common");
+  const mainRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    console.error(error);
+    // Surface the Next.js production digest so we can correlate the boundary
+    // hit to a specific server-side log line (digest is opaque to the user
+    // but unique per error in the runtime). `track` is used directly because
+    // the typed `trackEvent` wrapper only accepts pre-declared event names.
+    // `error.message` is intentionally omitted — it may contain PII.
+    try {
+      track("page_error", {
+        page: "collect",
+        digest: error.digest ?? "",
+        name: error.name,
+      });
+    } catch (trackError) {
+      console.warn("page_error analytics failed", trackError);
+    }
+    mainRef.current?.focus();
+  }, [error]);
+
+  return (
+    <div
+      className="flex min-h-[50vh] flex-col items-center justify-center gap-4"
+      ref={mainRef}
+      tabIndex={-1}
+    >
+      <div role="alert">
+        <h1 className="font-semibold text-xl">{t("somethingWrong")}</h1>
+        <p className="text-muted-foreground">{t("unexpectedError")}</p>
+      </div>
+      <div className="flex gap-2">
+        <Button className="min-h-11" onClick={reset} type="button">
+          {t("tryAgain")}
+        </Button>
+        <Button asChild className="min-h-11" variant="outline">
+          <Link href="/dashboard">{tCommon("goToDashboard")}</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/collect/loading.tsx
+++ b/src/app/(app)/collect/loading.tsx
@@ -1,0 +1,40 @@
+import type { ReactElement } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function CollectLoading(): ReactElement {
+  return (
+    <div aria-label="Loading..." className="flex flex-col gap-6" role="status">
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-40" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <Skeleton className="h-10 w-28" />
+      </div>
+
+      {/* Filters skeleton */}
+      <div className="flex flex-wrap gap-3">
+        <Skeleton className="h-10 w-full sm:w-64" />
+        <Skeleton className="h-10 w-32" />
+        <Skeleton className="h-10 w-32" />
+        <Skeleton className="h-10 w-32" />
+      </div>
+
+      {/* Card grid skeleton */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {["s1", "s2", "s3", "s4", "s5", "s6"].map((id) => (
+          <div className="flex flex-col gap-3 rounded-lg border p-4" key={id}>
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+            <div className="flex gap-2 pt-1">
+              <Skeleton className="h-5 w-16" />
+              <Skeleton className="h-5 w-12" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/collect/page.tsx
+++ b/src/app/(app)/collect/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
-import { ModuleComingSoon } from "@/components/module-coming-soon";
+import { CollectView } from "@/features/collect/components/collect-view";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("collect");
@@ -12,5 +12,5 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default function CollectPage(): ReactElement {
-  return <ModuleComingSoon slug="collect" />;
+  return <CollectView />;
 }

--- a/src/app/(app)/dashboard/page.test.tsx
+++ b/src/app/(app)/dashboard/page.test.tsx
@@ -6,6 +6,12 @@ vi.mock("@/components/dashboard-grid", () => ({
   DashboardGrid: () => <div data-testid="dashboard-grid" />,
 }));
 
+vi.mock("@/components/collection-card", () => ({
+  CollectionCard: ({ itemCount }: { itemCount: number }) => (
+    <div data-count={itemCount} data-testid="collection-card" />
+  ),
+}));
+
 vi.mock("@/components/repertoire-card", () => ({
   RepertoireCard: ({ trickCount }: { trickCount: number }) => (
     <div data-count={trickCount} data-testid="repertoire-card" />
@@ -32,6 +38,9 @@ const mockWhere = vi.fn(() => Promise.resolve([{ count: 3 }]));
 const mockFrom = vi.fn(() => ({ where: mockWhere }));
 const mockSelect = vi.fn(() => ({ from: mockFrom }));
 
+// The dashboard page calls select().from(tricks).where() then select().from(items).where()
+// Both return the same mock chain — the mockWhere default returns [{ count: 3 }] for both.
+
 vi.mock("@/db", () => ({
   getDb: vi.fn(() => ({
     select: mockSelect,
@@ -52,6 +61,13 @@ vi.mock("drizzle-orm", () => ({
   isNull: (col: unknown) => mockIsNull(col),
 }));
 
+vi.mock("@/db/schema/items", () => ({
+  items: {
+    userId: "items.userId",
+    deletedAt: "items.deletedAt",
+  },
+}));
+
 vi.mock("@/db/schema/tricks", () => ({
   tricks: {
     userId: "tricks.userId",
@@ -70,6 +86,17 @@ describe("DashboardPage", () => {
     mockWhere.mockImplementation(() => Promise.resolve([{ count: 3 }]));
     mockFrom.mockImplementation(() => ({ where: mockWhere }));
     mockSelect.mockImplementation(() => ({ from: mockFrom }));
+  });
+
+  it("renders the CollectionCard with the correct itemCount", async () => {
+    mockWhere
+      .mockResolvedValueOnce([{ count: 3 }]) // tricks query (first)
+      .mockResolvedValueOnce([{ count: 7 }]); // items query (second)
+    render(await DashboardPage());
+
+    const card = screen.getByTestId("collection-card");
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveAttribute("data-count", "7");
   });
 
   it("renders the Dashboard heading", async () => {
@@ -101,6 +128,9 @@ describe("DashboardPage", () => {
   });
 
   it("renders the RepertoireCard with the correct trickCount", async () => {
+    mockWhere
+      .mockResolvedValueOnce([{ count: 3 }]) // tricks query (first)
+      .mockResolvedValueOnce([{ count: 7 }]); // items query (second)
     render(await DashboardPage());
 
     const card = screen.getByTestId("repertoire-card");
@@ -115,6 +145,8 @@ describe("DashboardPage", () => {
     expect(mockFrom).toHaveBeenCalled();
     expect(mockEq).toHaveBeenCalledWith("tricks.userId", "user-1");
     expect(mockIsNull).toHaveBeenCalledWith("tricks.deletedAt");
+    expect(mockEq).toHaveBeenCalledWith("items.userId", "user-1");
+    expect(mockIsNull).toHaveBeenCalledWith("items.deletedAt");
     expect(mockAnd).toHaveBeenCalled();
     expect(mockWhere).toHaveBeenCalled();
   });

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -3,9 +3,11 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
 import { auth } from "@/auth/server";
+import { CollectionCard } from "@/components/collection-card";
 import { DashboardGrid } from "@/components/dashboard-grid";
 import { RepertoireCard } from "@/components/repertoire-card";
 import { getDb } from "@/db";
+import { items } from "@/db/schema/items";
 import { tricks } from "@/db/schema/tricks";
 
 export const metadata: Metadata = {
@@ -18,14 +20,22 @@ export default async function DashboardPage(): Promise<ReactElement> {
   const { data: session } = await auth.getSession();
   const userId = session?.user?.id;
   let trickCount = 0;
+  let itemCount = 0;
 
   if (userId) {
     const db = getDb();
-    const [result] = await db
-      .select({ count: count() })
-      .from(tricks)
-      .where(and(eq(tricks.userId, userId), isNull(tricks.deletedAt)));
-    trickCount = result?.count ?? 0;
+    const [trickRows, itemRows] = await Promise.all([
+      db
+        .select({ count: count() })
+        .from(tricks)
+        .where(and(eq(tricks.userId, userId), isNull(tricks.deletedAt))),
+      db
+        .select({ count: count() })
+        .from(items)
+        .where(and(eq(items.userId, userId), isNull(items.deletedAt))),
+    ]);
+    trickCount = trickRows[0]?.count ?? 0;
+    itemCount = itemRows[0]?.count ?? 0;
   }
 
   return (
@@ -41,6 +51,7 @@ export default async function DashboardPage(): Promise<ReactElement> {
         </p>
       </div>
       <RepertoireCard trickCount={trickCount} />
+      <CollectionCard itemCount={itemCount} />
       <DashboardGrid />
     </div>
   );

--- a/src/app/api/cron/cleanup/route.test.ts
+++ b/src/app/api/cron/cleanup/route.test.ts
@@ -3,6 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
+/**
+ * Counts derived from the cleanup route's internal table arrays.
+ * Update these when adding or removing tables from TABLES_IN_ORDER / USER_OWNED_TABLES.
+ */
+const PRE_PASS_TABLE_COUNT = 12;
+const MAIN_TABLE_COUNT = 12;
+const TOTAL_QUERY_COUNT = PRE_PASS_TABLE_COUNT + MAIN_TABLE_COUNT + 1;
+
 // timingSafeEqual is mocked with plain string equality for unit test determinism.
 // The auth boundary (timing-attack resistance) is covered by the real implementation;
 // these tests only verify the route's request/response logic.
@@ -125,7 +133,7 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
-      // 11 pre-pass UPDATEs + 11 main DELETEs + 1 user DELETE = 23 queries
+      // pre-pass UPDATEs + main DELETEs + 1 user DELETE
       mockQuery.mockResolvedValue({ rowCount: 2 });
 
       const response = await GET(createRequest("Bearer test-cron-secret"));
@@ -133,16 +141,15 @@ describe("GET /api/cron/cleanup", () => {
       expect(response.status).toBe(200);
       const body = await response.json();
       expect(body.success).toBe(true);
-      // 11 main tables + 1 user delete = 12 results, each with rowCount 2
-      expect(body.totalDeleted).toBe(24);
+      // main tables + user delete = result entries, each with rowCount 2
+      expect(body.totalDeleted).toBe((MAIN_TABLE_COUNT + 1) * 2);
 
       expect(body.errorsCount).toBe(0);
       // No internal table names should be exposed
       expect(body.deleted).toBeUndefined();
       expect(body.errors).toBeUndefined();
 
-      // 11 pre-pass UPDATEs + 11 main DELETEs + 1 user DELETE
-      expect(mockQuery).toHaveBeenCalledTimes(23);
+      expect(mockQuery).toHaveBeenCalledTimes(TOTAL_QUERY_COUNT);
     });
 
     it("handles tables with zero deleted rows", async () => {
@@ -229,7 +236,7 @@ describe("GET /api/cron/cleanup", () => {
 
       const calls = mockQuery.mock.calls.map((call) => call[0] as string);
       const updateCalls = calls.filter((q) => q.startsWith("UPDATE"));
-      expect(updateCalls).toHaveLength(11);
+      expect(updateCalls).toHaveLength(PRE_PASS_TABLE_COUNT);
       for (const sql of updateCalls) {
         expect(sql).toContain("SET deleted_at = NOW()");
         expect(sql).toContain("INTERVAL '1 day' * $1");
@@ -329,8 +336,8 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
-      // 11 pre-pass UPDATEs succeed, first main DELETE fails, rest succeed
-      for (let i = 0; i < 11; i++) {
+      // pre-pass UPDATEs succeed, first main DELETE fails, rest succeed
+      for (let i = 0; i < PRE_PASS_TABLE_COUNT; i++) {
         mockQuery.mockResolvedValueOnce({ rowCount: 0 }); // pre-pass
       }
       mockQuery
@@ -339,15 +346,17 @@ describe("GET /api/cron/cleanup", () => {
 
       const response = await GET(createRequest("Bearer test-cron-secret"));
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(500);
       const body = await response.json();
-      expect(body.success).toBe(true);
-      // First main table failed, 10 main + 1 user succeeded with 1 row each
-      expect(body.totalDeleted).toBe(11);
+      expect(body.success).toBe(false);
+      // First main table failed, remaining main + user succeeded with 1 row each
+      expect(body.totalDeleted).toBe(MAIN_TABLE_COUNT);
       expect(body.errorsCount).toBe(1);
-      // No internal table names should be exposed
+      // No internal table-name details should be exposed in the response body
+      // (per security review — details remain in server logs only)
       expect(body.deleted).toBeUndefined();
       expect(body.errors).toBeUndefined();
+      expect(body.results).toBeUndefined();
     });
 
     it("handles non-Error thrown by a table DELETE", async () => {
@@ -356,8 +365,8 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
-      // 11 pre-pass UPDATEs succeed, then first main DELETE throws a string
-      for (let i = 0; i < 11; i++) {
+      // pre-pass UPDATEs succeed, then first main DELETE throws a string
+      for (let i = 0; i < PRE_PASS_TABLE_COUNT; i++) {
         mockQuery.mockResolvedValueOnce({ rowCount: 0 });
       }
       mockQuery
@@ -366,9 +375,9 @@ describe("GET /api/cron/cleanup", () => {
 
       const response = await GET(createRequest("Bearer test-cron-secret"));
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(500);
       const body = await response.json();
-      expect(body.success).toBe(true);
+      expect(body.success).toBe(false);
       expect(body.errorsCount).toBe(1);
       expect(body.errors).toBeUndefined();
     });
@@ -394,8 +403,8 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
-      // 11 pre-pass UPDATEs succeed, then first main DELETE fails
-      for (let i = 0; i < 11; i++) {
+      // pre-pass UPDATEs succeed, then first main DELETE fails
+      for (let i = 0; i < PRE_PASS_TABLE_COUNT; i++) {
         mockQuery.mockResolvedValueOnce({ rowCount: 0 });
       }
       mockQuery
@@ -425,6 +434,7 @@ describe("GET /api/cron/cleanup", () => {
       expect(userDeleteQuery).toContain("NOT EXISTS");
       for (const table of [
         "goals",
+        "item_tags",
         "item_tricks",
         "items",
         "performances",
@@ -446,14 +456,14 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
-      // All pre-pass (11) + main DELETEs (11) succeed, user DELETE fails
-      for (let i = 0; i < 22; i++) {
+      // All pre-pass + main DELETEs succeed, user DELETE fails
+      for (let i = 0; i < PRE_PASS_TABLE_COUNT + MAIN_TABLE_COUNT; i++) {
         mockQuery.mockResolvedValueOnce({ rowCount: 0 });
       }
       mockQuery.mockRejectedValueOnce(new Error("FK violation"));
 
       const response = await GET(createRequest("Bearer test-cron-secret"));
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(500);
       const body = await response.json();
       expect(body.errorsCount).toBe(1);
     });
@@ -469,7 +479,7 @@ describe("GET /api/cron/cleanup", () => {
 
       const response = await GET(createRequest("Bearer test-cron-secret"));
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(500);
       const body = await response.json();
       expect(body.success).toBe(false);
       expect(body.totalDeleted).toBe(0);
@@ -482,9 +492,9 @@ describe("GET /api/cron/cleanup", () => {
       vi.resetModules();
       const { GET } = await import("./route");
 
-      // 11 pre-pass UPDATEs succeed, first main DELETE succeeds,
+      // pre-pass UPDATEs succeed, first main DELETE succeeds,
       // second fails, rest succeed
-      for (let i = 0; i < 11; i++) {
+      for (let i = 0; i < PRE_PASS_TABLE_COUNT; i++) {
         mockQuery.mockResolvedValueOnce({ rowCount: 0 });
       }
       mockQuery
@@ -494,9 +504,8 @@ describe("GET /api/cron/cleanup", () => {
 
       const response = await GET(createRequest("Bearer test-cron-secret"));
 
-      expect(response.status).toBe(200);
-      // 11 pre-pass + 11 main DELETEs + 1 user DELETE = 23 total queries
-      expect(mockQuery).toHaveBeenCalledTimes(23);
+      expect(response.status).toBe(500);
+      expect(mockQuery).toHaveBeenCalledTimes(TOTAL_QUERY_COUNT);
     });
   });
 });

--- a/src/app/api/cron/cleanup/route.ts
+++ b/src/app/api/cron/cleanup/route.ts
@@ -41,6 +41,7 @@ function verifySecret(header: string | null, secret: string): boolean {
  *  they lack deleted_at columns and are cleaned up via CASCADE when the
  *  owning user row is hard-deleted. */
 const TABLES_IN_ORDER = [
+  "item_tags",
   "item_tricks",
   "setlist_tricks",
   "practice_session_tricks",
@@ -62,6 +63,7 @@ const TABLES_IN_ORDER = [
  *  cron run after their own retention period expires. */
 const USER_OWNED_TABLES = [
   "goals",
+  "item_tags",
   "item_tricks",
   "items",
   "performances",
@@ -218,13 +220,33 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       });
 
       const errorsCount = Object.keys(errors).length;
-      const resultCount = Object.keys(results).length;
-      const allFailed = resultCount > 0 && errorsCount === resultCount;
+
+      // Any table failure should signal failure (HTTP 500) so Vercel Cron
+      // surfaces the issue and retries on the next schedule. The body still
+      // includes per-table results so operators can diagnose which tables
+      // failed without needing the logs.
+      if (errorsCount > 0) {
+        console.warn("Soft-delete cleanup completed with errors:", {
+          errorsCount,
+          failedTables: Object.keys(errors),
+        });
+        return NextResponse.json(
+          {
+            success: false,
+            totalDeleted,
+            errorsCount,
+            // errors and results intentionally omitted — see security review.
+            // Per-table failure details remain in server logs (console.warn above).
+          },
+          { status: 500 }
+        );
+      }
 
       return NextResponse.json({
-        success: !allFailed,
+        success: true,
         totalDeleted,
         errorsCount,
+        results,
       });
     } finally {
       client.release();

--- a/src/components/collection-card.tsx
+++ b/src/components/collection-card.tsx
@@ -1,0 +1,51 @@
+import { ChevronRight, Package } from "lucide-react";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import type { ReactElement } from "react";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface CollectionCardProps {
+  itemCount: number;
+}
+
+export async function CollectionCard({
+  itemCount,
+}: CollectionCardProps): Promise<ReactElement> {
+  const t = await getTranslations("dashboard");
+
+  return (
+    <Link
+      aria-label={t("collectionLink")}
+      className="rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      href="/collect"
+    >
+      <Card className="border-l-4 border-l-primary transition-colors hover:bg-muted/50">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary">
+              <Package
+                aria-hidden="true"
+                className="size-5 text-primary-foreground"
+              />
+            </div>
+            <div className="flex flex-1 flex-col gap-1">
+              <CardTitle>{t("collectionTitle")}</CardTitle>
+              <CardDescription>
+                {t("collectionDescription", { count: itemCount })}
+              </CardDescription>
+            </div>
+            <ChevronRight
+              aria-hidden="true"
+              className="size-5 shrink-0 text-muted-foreground"
+            />
+          </div>
+        </CardHeader>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/dashboard-grid.test.tsx
+++ b/src/components/dashboard-grid.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
-import { Dumbbell, Package, Sparkles, Star } from "lucide-react";
+import { Dumbbell, Sparkles, Star } from "lucide-react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { DashboardGrid } from "./dashboard-grid";
@@ -16,14 +16,9 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-const MOCK_LIBRARY = [
-  {
-    slug: "collect" as const,
-    icon: Package,
-    enabled: false,
-    group: "library" as const,
-  },
-];
+// After filtering out repertoire + collect, library group is empty in the grid.
+// This matches the real behavior — both have their own dedicated dashboard cards.
+const MOCK_LIBRARY: never[] = [];
 
 const MOCK_LAB = [
   {
@@ -75,16 +70,17 @@ describe("DashboardGrid", () => {
   it("renders grouped sections with headings", async () => {
     const element = await DashboardGrid();
     render(element);
-    expect(screen.getByText("nav.library")).toBeInTheDocument();
+    // Library group is empty (repertoire + collect filtered out — they have dedicated cards)
+    expect(screen.queryByText("nav.library")).not.toBeInTheDocument();
     expect(screen.getByText("nav.theLab")).toBeInTheDocument();
     expect(screen.getByText("nav.insights")).toBeInTheDocument();
   });
 
-  it("renders a card for each non-admin, non-repertoire module", async () => {
+  it("renders a card for each non-admin, non-repertoire, non-collect module", async () => {
     const element = await DashboardGrid();
     render(element);
     const links = screen.getAllByRole("link");
-    expect(links).toHaveLength(4);
+    expect(links).toHaveLength(3);
   });
 
   it("links each card to the correct /{slug} href", async () => {
@@ -118,7 +114,6 @@ describe("DashboardGrid", () => {
   it("renders module descriptions", async () => {
     const element = await DashboardGrid();
     render(element);
-    expect(screen.getByText("collect.description")).toBeInTheDocument();
     expect(screen.getByText("improve.description")).toBeInTheDocument();
     expect(screen.getByText("perform.description")).toBeInTheDocument();
     expect(screen.getByText("enhance.description")).toBeInTheDocument();

--- a/src/components/dashboard-grid.tsx
+++ b/src/components/dashboard-grid.tsx
@@ -22,7 +22,7 @@ export async function DashboardGrid(): Promise<ReactElement> {
     <div className="flex flex-col gap-8">
       {DISPLAY_GROUPS.map((group) => {
         const modules = getModulesByGroup(group).filter(
-          (m) => m.slug !== "repertoire"
+          (m) => m.slug !== "repertoire" && m.slug !== "collect"
         );
         if (modules.length === 0) {
           return null;

--- a/src/db/migrations/0017_collect_inventory_columns_and_item_tags.sql
+++ b/src/db/migrations/0017_collect_inventory_columns_and_item_tags.sql
@@ -1,0 +1,150 @@
+-- Migration 0017: Collect inventory enhancements
+--
+-- 1. Add quantity, creator, url columns to items table
+-- 2. Add items.type check constraint (10 item types)
+-- 3. Add items.quantity non-negative check constraint
+-- 4. Create item_tags junction table (mirrors trick_tags)
+-- 5. Indexes, RLS, GRANTs, and updated_at trigger for item_tags
+
+-- ============================================================
+-- Part 1: New columns on items
+-- ============================================================
+
+ALTER TABLE "items" ADD COLUMN "quantity" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "items" ADD COLUMN "creator" text;--> statement-breakpoint
+ALTER TABLE "items" ADD COLUMN "url" text;--> statement-breakpoint
+
+-- ============================================================
+-- Part 2: Check constraints
+-- ============================================================
+
+ALTER TABLE "items" ADD CONSTRAINT "items_quantity_non_negative"
+  CHECK ("quantity" >= 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "items" VALIDATE CONSTRAINT "items_quantity_non_negative";--> statement-breakpoint
+
+-- Pre-deploy check for items.type CHECK constraint:
+--   SELECT DISTINCT type FROM items WHERE type NOT IN
+--     ('prop', 'book', 'gimmick', 'dvd', 'download', 'deck',
+--      'clothing', 'consumable', 'accessory', 'other');
+-- Items table is currently empty in production, so VALIDATE is safe today.
+-- The DO $$ block below enforces the precondition at migration time so a
+-- future preview branch or seeded dev DB with a stale `type` value fails the
+-- migration with a clear error rather than silently leaving the constraint
+-- in NOT VALID state.
+-- Future enum changes (adding/removing types) MUST run this query first.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM items WHERE type NOT IN
+      ('prop', 'book', 'gimmick', 'dvd', 'download', 'deck',
+       'clothing', 'consumable', 'accessory', 'other')
+  ) THEN
+    RAISE EXCEPTION 'items.type contains values outside the allowed enum; fix existing rows before applying items_type_valid';
+  END IF;
+END $$;--> statement-breakpoint
+ALTER TABLE "items" ADD CONSTRAINT "items_type_valid"
+  CHECK ("type" IN ('prop', 'book', 'gimmick', 'dvd', 'download', 'deck', 'clothing', 'consumable', 'accessory', 'other')) NOT VALID;--> statement-breakpoint
+ALTER TABLE "items" VALIDATE CONSTRAINT "items_type_valid";--> statement-breakpoint
+
+-- ============================================================
+-- Part 3: item_tags junction table
+-- ============================================================
+
+CREATE TABLE "item_tags" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "item_id" uuid NOT NULL,
+  "tag_id" uuid NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "deleted_at" timestamp with time zone
+);--> statement-breakpoint
+
+ALTER TABLE "item_tags" ADD CONSTRAINT "item_tags_user_id_users_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+  ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "item_tags" ADD CONSTRAINT "item_tags_item_id_items_id_fk"
+  FOREIGN KEY ("item_id") REFERENCES "public"."items"("id")
+  ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "item_tags" ADD CONSTRAINT "item_tags_tag_id_tags_id_fk"
+  FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id")
+  ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+
+-- ============================================================
+-- Part 4: Indexes for item_tags
+-- ============================================================
+
+CREATE INDEX "item_tags_user_id_idx" ON "item_tags" USING btree ("user_id") WHERE deleted_at IS NULL;--> statement-breakpoint
+CREATE INDEX "item_tags_item_id_idx" ON "item_tags" USING btree ("item_id") WHERE deleted_at IS NULL;--> statement-breakpoint
+CREATE INDEX "item_tags_tag_id_idx" ON "item_tags" USING btree ("tag_id") WHERE deleted_at IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "item_tags_item_tag_idx" ON "item_tags" USING btree ("item_id", "tag_id") WHERE deleted_at IS NULL;--> statement-breakpoint
+
+-- Partial index on deleted_at for cron cleanup job (matches pattern from migration 0010)
+CREATE INDEX IF NOT EXISTS "idx_item_tags_deleted_at" ON "item_tags" ("deleted_at") WHERE "deleted_at" IS NOT NULL;--> statement-breakpoint
+
+-- ============================================================
+-- Part 5: RLS, GRANTs, updated_at trigger
+-- ============================================================
+
+ALTER TABLE "item_tags" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON "item_tags" TO authenticated;--> statement-breakpoint
+
+-- ============================================================
+-- RLS policy (mirrors trick_tags from migration 0015)
+-- ============================================================
+-- USING checks only user_id so soft-deleted junction rows remain visible
+-- to PowerSync sync (tombstone propagation). Cross-table ownership is
+-- enforced on writes via WITH CHECK.
+--
+-- Threat model:
+--   USING checks only the user_id column for tombstone propagation:
+--   PowerSync needs to deliver soft-deleted (tombstoned) junction rows to
+--   offline clients so they can mirror the deletion locally. Cross-table
+--   ownership (items.user_id == auth.user_id and tags.user_id == auth.user_id)
+--   is enforced by WITH CHECK on writes — so a malicious client cannot link
+--   another user's item to their own tag (or vice versa).
+--
+--   FK CASCADE on user delete guarantees junction cleanup if a user is
+--   hard-deleted, so orphaned junction rows are not possible by ownership
+--   drift.
+--
+--   Defense-in-depth: even if user_id were to drift from the parent row's
+--   ownership (e.g., a buggy admin migration), only the user_id-matching
+--   user would be able to read or affect the row via this policy.
+--
+-- WITH CHECK does NOT filter by parent deleted_at: a junction may need to
+-- be inserted/restored even when the parent item or tag is being
+-- soft-deleted in the same transaction (tombstone propagation, soft-delete
+-- resurrection on re-insert via PowerSync upsert). Filtering by
+-- deleted_at IS NULL here would block legitimate junction restores that
+-- happen to race with parent UPDATE order. This matches trick_tags in 0015.
+DROP POLICY IF EXISTS "item_tags_rls_policy" ON "item_tags";--> statement-breakpoint
+CREATE POLICY "item_tags_rls_policy" ON "item_tags" FOR ALL TO authenticated
+  USING (user_id = auth.user_id()::uuid)
+  WITH CHECK (
+    user_id = auth.user_id()::uuid
+    AND EXISTS (SELECT 1 FROM "items" WHERE "items".id = "item_tags".item_id AND "items".user_id = auth.user_id()::uuid)
+    AND EXISTS (SELECT 1 FROM "tags" WHERE "tags".id = "item_tags".tag_id AND "tags".user_id = auth.user_id()::uuid)
+  );--> statement-breakpoint
+
+CREATE OR REPLACE TRIGGER "set_updated_at_item_tags"
+  BEFORE UPDATE ON "item_tags"
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();--> statement-breakpoint
+
+-- ============================================================
+-- Part 6: URL HTTPS constraint on items
+-- ============================================================
+
+ALTER TABLE "items" ADD CONSTRAINT "items_url_https_only"
+  CHECK ("url" IS NULL OR "url" LIKE 'https://%') NOT VALID;--> statement-breakpoint
+ALTER TABLE "items" VALIDATE CONSTRAINT "items_url_https_only";--> statement-breakpoint
+
+-- ============================================================
+-- Part 7: Condition check constraint on items
+-- ============================================================
+
+ALTER TABLE "items" ADD CONSTRAINT "items_condition_check"
+  CHECK ("condition" IS NULL OR "condition" IN ('new', 'good', 'worn', 'needs_repair')) NOT VALID;--> statement-breakpoint
+ALTER TABLE "items" VALIDATE CONSTRAINT "items_condition_check";

--- a/src/db/migrations/meta/0017_snapshot.json
+++ b/src/db/migrations/meta/0017_snapshot.json
@@ -1,0 +1,2188 @@
+{
+  "id": "ebae2e0b-82f7-47da-a537-d948bc5cf0ca",
+  "prevId": "b573667c-09e1-4bf6-948d-c8ede3469647",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_value": {
+          "name": "target_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "goals_user_id_idx": {
+          "name": "goals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "goals_trick_id_idx": {
+          "name": "goals_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goals_trick_id_tricks_id_fk": {
+          "name": "goals_trick_id_tricks_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_tags": {
+      "name": "item_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "item_tags_user_id_idx": {
+          "name": "item_tags_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tags_item_id_idx": {
+          "name": "item_tags_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tags_tag_id_idx": {
+          "name": "item_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tags_item_tag_idx": {
+          "name": "item_tags_item_tag_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_tags_user_id_users_id_fk": {
+          "name": "item_tags_user_id_users_id_fk",
+          "tableFrom": "item_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_tags_item_id_items_id_fk": {
+          "name": "item_tags_item_id_items_id_fk",
+          "tableFrom": "item_tags",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "item_tags_tag_id_tags_id_fk": {
+          "name": "item_tags_tag_id_tags_id_fk",
+          "tableFrom": "item_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_tricks": {
+      "name": "item_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "item_tricks_user_id_idx": {
+          "name": "item_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tricks_item_id_idx": {
+          "name": "item_tricks_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tricks_trick_id_idx": {
+          "name": "item_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_tricks_item_trick_idx": {
+          "name": "item_tricks_item_trick_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_tricks_user_id_users_id_fk": {
+          "name": "item_tricks_user_id_users_id_fk",
+          "tableFrom": "item_tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_tricks_item_id_items_id_fk": {
+          "name": "item_tricks_item_id_items_id_fk",
+          "tableFrom": "item_tricks",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "item_tricks_trick_id_tricks_id_fk": {
+          "name": "item_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "item_tricks",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "items_user_id_idx": {
+          "name": "items_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "items_user_id_users_id_fk": {
+          "name": "items_user_id_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.performances": {
+      "name": "performances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setlist_id": {
+          "name": "setlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_size": {
+          "name": "audience_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_type": {
+          "name": "audience_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "performances_user_id_idx": {
+          "name": "performances_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "performances_setlist_id_idx": {
+          "name": "performances_setlist_id_idx",
+          "columns": [
+            {
+              "expression": "setlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "performances_user_id_date_idx": {
+          "name": "performances_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "performances_user_id_users_id_fk": {
+          "name": "performances_user_id_users_id_fk",
+          "tableFrom": "performances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "performances_setlist_id_setlists_id_fk": {
+          "name": "performances_setlist_id_setlists_id_fk",
+          "tableFrom": "performances",
+          "tableTo": "setlists",
+          "columnsFrom": [
+            "setlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_session_tricks": {
+      "name": "practice_session_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_session_tricks_user_id_idx": {
+          "name": "practice_session_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_tricks_practice_session_id_idx": {
+          "name": "practice_session_tricks_practice_session_id_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_tricks_trick_id_idx": {
+          "name": "practice_session_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_session_tricks_session_trick_idx": {
+          "name": "practice_session_tricks_session_trick_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_session_tricks_user_id_users_id_fk": {
+          "name": "practice_session_tricks_user_id_users_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "practice_session_tricks_practice_session_id_practice_sessions_id_fk": {
+          "name": "practice_session_tricks_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "tableTo": "practice_sessions",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "practice_session_tricks_trick_id_tricks_id_fk": {
+          "name": "practice_session_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_sessions": {
+      "name": "practice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_sessions_user_id_idx": {
+          "name": "practice_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_sessions_user_id_date_idx": {
+          "name": "practice_sessions_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_sessions_user_id_users_id_fk": {
+          "name": "practice_sessions_user_id_users_id_fk",
+          "tableFrom": "practice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setlist_tricks": {
+      "name": "setlist_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setlist_id": {
+          "name": "setlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_notes": {
+          "name": "transition_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "setlist_tricks_user_id_idx": {
+          "name": "setlist_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setlist_tricks_setlist_id_idx": {
+          "name": "setlist_tricks_setlist_id_idx",
+          "columns": [
+            {
+              "expression": "setlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setlist_tricks_trick_id_idx": {
+          "name": "setlist_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setlist_tricks_setlist_position_idx": {
+          "name": "setlist_tricks_setlist_position_idx",
+          "columns": [
+            {
+              "expression": "setlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setlist_tricks_user_id_users_id_fk": {
+          "name": "setlist_tricks_user_id_users_id_fk",
+          "tableFrom": "setlist_tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "setlist_tricks_setlist_id_setlists_id_fk": {
+          "name": "setlist_tricks_setlist_id_setlists_id_fk",
+          "tableFrom": "setlist_tricks",
+          "tableTo": "setlists",
+          "columnsFrom": [
+            "setlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "setlist_tricks_trick_id_tricks_id_fk": {
+          "name": "setlist_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "setlist_tricks",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setlists": {
+      "name": "setlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_duration_minutes": {
+          "name": "estimated_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "setlists_user_id_idx": {
+          "name": "setlists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setlists_user_id_users_id_fk": {
+          "name": "setlists_user_id_users_id_fk",
+          "tableFrom": "setlists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tags_user_id_idx": {
+          "name": "tags_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_user_name_idx": {
+          "name": "tags_user_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(name)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trick_tags": {
+      "name": "trick_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trick_tags_user_id_idx": {
+          "name": "trick_tags_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trick_tags_trick_id_idx": {
+          "name": "trick_tags_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trick_tags_tag_id_idx": {
+          "name": "trick_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trick_tags_trick_tag_idx": {
+          "name": "trick_tags_trick_tag_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trick_tags_user_id_users_id_fk": {
+          "name": "trick_tags_user_id_users_id_fk",
+          "tableFrom": "trick_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trick_tags_trick_id_tricks_id_fk": {
+          "name": "trick_tags_trick_id_tricks_id_fk",
+          "tableFrom": "trick_tags",
+          "tableTo": "tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trick_tags_tag_id_tags_id_fk": {
+          "name": "trick_tags_tag_id_tags_id_fk",
+          "tableFrom": "trick_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tricks": {
+      "name": "tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_type": {
+          "name": "effect_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performance_type": {
+          "name": "performance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle_sensitivity": {
+          "name": "angle_sensitivity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "props": {
+          "name": "props",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "music": {
+          "name": "music",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_camera_friendly": {
+          "name": "is_camera_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_silent": {
+          "name": "is_silent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tricks_user_id_idx": {
+          "name": "tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tricks_user_id_users_id_fk": {
+          "name": "tricks_user_id_users_id_fk",
+          "tableFrom": "tricks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "push_enabled": {
+          "name": "push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "practice_reminder_time": {
+          "name": "practice_reminder_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_reminder_days": {
+          "name": "practice_reminder_days",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_summary_enabled": {
+          "name": "weekly_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1775111777730,
       "tag": "0016_tricks_duration_check_constraint",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1775200000000,
+      "tag": "0017_collect_inventory_columns_and_item_tags",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,6 +1,6 @@
 // biome-ignore lint/performance/noBarrelFile: schema barrel file is intentional for Drizzle config
 export { goals } from "./goals";
-export { items, itemTricks } from "./items";
+export { items, itemTags, itemTricks } from "./items";
 export { performances } from "./performances";
 export {
   practiceSessions,

--- a/src/db/schema/items.ts
+++ b/src/db/schema/items.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import {
   date,
   index,
+  integer,
   numeric,
   pgTable,
   text,
@@ -9,6 +10,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
+import { tags } from "./tags";
 import { tricks } from "./tricks";
 import { users } from "./users";
 
@@ -21,7 +23,18 @@ export const items = pgTable(
       .references(() => users.id, { onDelete: "cascade" }),
     name: text().notNull(),
     type: text({
-      enum: ["prop", "book", "gimmick", "dvd", "download", "other"],
+      enum: [
+        "prop",
+        "book",
+        "gimmick",
+        "dvd",
+        "download",
+        "deck",
+        "clothing",
+        "consumable",
+        "accessory",
+        "other",
+      ],
     }).notNull(),
     description: text(),
     brand: text(),
@@ -30,6 +43,9 @@ export const items = pgTable(
     notes: text(),
     purchaseDate: date("purchase_date"),
     purchasePrice: numeric("purchase_price", { precision: 10, scale: 2 }),
+    quantity: integer().notNull().default(1),
+    creator: text(),
+    url: text(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
@@ -41,6 +57,50 @@ export const items = pgTable(
   },
   (table) => [
     index("items_user_id_idx").on(table.userId).where(sql`deleted_at IS NULL`),
+  ]
+);
+
+export const itemTags = pgTable(
+  "item_tags",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    // NO ACTION prevents the hard-delete cleanup job (#55) from physically
+    // removing a parent while junction rows still reference it. Unlike
+    // RESTRICT, NO ACTION defers the check to statement end, which allows
+    // user account deletion to cascade correctly through both user_id and
+    // entity FK paths. The cleanup job must soft-delete junctions first
+    // (creating sync tombstones), then hard-delete in the correct order.
+    itemId: uuid("item_id")
+      .notNull()
+      .references(() => items.id, { onDelete: "no action" }),
+    tagId: uuid("tag_id")
+      .notNull()
+      .references(() => tags.id, { onDelete: "no action" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => sql`NOW()`),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("item_tags_user_id_idx")
+      .on(table.userId)
+      .where(sql`deleted_at IS NULL`),
+    index("item_tags_item_id_idx")
+      .on(table.itemId)
+      .where(sql`deleted_at IS NULL`),
+    index("item_tags_tag_id_idx")
+      .on(table.tagId)
+      .where(sql`deleted_at IS NULL`),
+    uniqueIndex("item_tags_item_tag_idx")
+      .on(table.itemId, table.tagId)
+      .where(sql`deleted_at IS NULL`),
   ]
 );
 

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,6 +1,6 @@
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 import type { goals } from "./schema/goals";
-import type { items, itemTricks } from "./schema/items";
+import type { items, itemTags, itemTricks } from "./schema/items";
 import type { performances } from "./schema/performances";
 import type {
   practiceSessions,
@@ -31,8 +31,24 @@ type SetlistId = string & { readonly __brand: "SetlistId" };
 type PracticeSessionId = string & { readonly __brand: "PracticeSessionId" };
 type PerformanceId = string & { readonly __brand: "PerformanceId" };
 type ItemId = string & { readonly __brand: "ItemId" };
+type ItemTagId = string & { readonly __brand: "ItemTagId" };
 type GoalId = string & { readonly __brand: "GoalId" };
 type TagId = string & { readonly __brand: "TagId" };
+
+// Single-location brand constructors. Centralising the cast here means call
+// sites express intent without scattering `as ItemId` casts across the
+// codebase, and any future runtime validation has exactly one chokepoint.
+//
+// IMPORTANT: these are type-only casts — they do NOT validate the input is a
+// real UUID at runtime. Cross-brand misuse (e.g. `asUserId(item.id)`) is
+// prevented at compile time by branded types, but malformed strings from
+// trust boundaries (auth session, sync row, URL params) are NOT rejected
+// here. If you need runtime validation at a boundary, parse the input with
+// Zod / a UUID guard BEFORE calling the brand constructor.
+const asItemId = (value: string): ItemId => value as ItemId;
+const asTagId = (value: string): TagId => value as TagId;
+const asTrickId = (value: string): TrickId => value as TrickId;
+const asUserId = (value: string): UserId => value as UserId;
 
 // Select types (read from DB)
 type User = InferSelectModel<typeof users>;
@@ -43,6 +59,7 @@ type PracticeSession = InferSelectModel<typeof practiceSessions>;
 type PracticeSessionTrick = InferSelectModel<typeof practiceSessionTricks>;
 type Performance = InferSelectModel<typeof performances>;
 type Item = InferSelectModel<typeof items>;
+type ItemTag = InferSelectModel<typeof itemTags>;
 type ItemTrick = InferSelectModel<typeof itemTricks>;
 type Goal = InferSelectModel<typeof goals>;
 type Tag = InferSelectModel<typeof tags>;
@@ -65,6 +82,8 @@ export type {
   GoalId,
   Item,
   ItemId,
+  ItemTag,
+  ItemTagId,
   ItemTrick,
   NewGoal,
   NewItem,
@@ -92,3 +111,4 @@ export type {
   UserId,
   UserPreference,
 };
+export { asItemId, asTagId, asTrickId, asUserId };

--- a/src/features/collect/components/collect-helpers.test.ts
+++ b/src/features/collect/components/collect-helpers.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import type { ItemId, TagId, TrickId } from "@/db/types";
+import {
+  buildItemTagMap,
+  buildItemTrickMap,
+  type ItemTagRow,
+  type ItemTrickRow,
+} from "./collect-helpers";
+
+describe("buildItemTagMap", () => {
+  it("returns empty map for empty array", () => {
+    const result = buildItemTagMap([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("maps single item with one tag", () => {
+    const rows: ItemTagRow[] = [
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        tag_id: "00000000-0000-4000-8000-00000000bb01",
+        tag_name: "Fire",
+        color: "#ff0000",
+      },
+    ];
+    const result = buildItemTagMap(rows);
+
+    expect(result.size).toBe(1);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa01" as ItemId)
+    ).toEqual([
+      {
+        id: "00000000-0000-4000-8000-00000000bb01" as TagId,
+        name: "Fire",
+        color: "#ff0000",
+      },
+    ]);
+  });
+
+  it("handles null color", () => {
+    const rows: ItemTagRow[] = [
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        tag_id: "00000000-0000-4000-8000-00000000bb01",
+        tag_name: "Uncolored",
+        color: null,
+      },
+    ];
+    const result = buildItemTagMap(rows);
+
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa01" as ItemId)
+    ).toEqual([
+      {
+        id: "00000000-0000-4000-8000-00000000bb01" as TagId,
+        name: "Uncolored",
+        color: null,
+      },
+    ]);
+  });
+
+  it("groups multiple tags under the same item", () => {
+    const rows: ItemTagRow[] = [
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        tag_id: "00000000-0000-4000-8000-00000000bb01",
+        tag_name: "Fire",
+        color: "#ff0000",
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        tag_id: "00000000-0000-4000-8000-00000000bb02",
+        tag_name: "Stage",
+        color: null,
+      },
+    ];
+    const result = buildItemTagMap(rows);
+
+    expect(result.size).toBe(1);
+    const tags = result.get("00000000-0000-4000-8000-00000000aa01" as ItemId);
+    expect(tags).toHaveLength(2);
+    expect(tags).toEqual([
+      {
+        id: "00000000-0000-4000-8000-00000000bb01" as TagId,
+        name: "Fire",
+        color: "#ff0000",
+      },
+      {
+        id: "00000000-0000-4000-8000-00000000bb02" as TagId,
+        name: "Stage",
+        color: null,
+      },
+    ]);
+  });
+
+  it("separates tags from different items", () => {
+    const rows: ItemTagRow[] = [
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        tag_id: "00000000-0000-4000-8000-00000000bb01",
+        tag_name: "Fire",
+        color: "#ff0000",
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa02",
+        tag_id: "00000000-0000-4000-8000-00000000bb02",
+        tag_name: "Stage",
+        color: "#0000ff",
+      },
+    ];
+    const result = buildItemTagMap(rows);
+
+    expect(result.size).toBe(2);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa01" as ItemId)
+    ).toHaveLength(1);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa02" as ItemId)
+    ).toHaveLength(1);
+  });
+
+  it("handles mixed items with multiple tags each", () => {
+    const rows: ItemTagRow[] = [
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        tag_id: "00000000-0000-4000-8000-00000000bb01",
+        tag_name: "Fire",
+        color: "#ff0000",
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa02",
+        tag_id: "00000000-0000-4000-8000-00000000bb02",
+        tag_name: "Stage",
+        color: "#0000ff",
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        tag_id: "00000000-0000-4000-8000-00000000bb03",
+        tag_name: "Close-up",
+        color: null,
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa02",
+        tag_id: "00000000-0000-4000-8000-00000000bb04",
+        tag_name: "Parlor",
+        color: "#00ff00",
+      },
+    ];
+    const result = buildItemTagMap(rows);
+
+    expect(result.size).toBe(2);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa01" as ItemId)
+    ).toHaveLength(2);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa02" as ItemId)
+    ).toHaveLength(2);
+  });
+});
+
+describe("buildItemTrickMap", () => {
+  it("returns empty map for empty array", () => {
+    const result = buildItemTrickMap([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("maps single item with one trick", () => {
+    const rows: ItemTrickRow[] = [
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        trick_id: "00000000-0000-4000-8000-00000000cc01",
+        trick_name: "Ambitious Card",
+      },
+    ];
+    const result = buildItemTrickMap(rows);
+
+    expect(result.size).toBe(1);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa01" as ItemId)
+    ).toEqual([
+      {
+        id: "00000000-0000-4000-8000-00000000cc01" as TrickId,
+        name: "Ambitious Card",
+      },
+    ]);
+  });
+
+  it("groups multiple tricks under the same item", () => {
+    const rows: ItemTrickRow[] = [
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        trick_id: "00000000-0000-4000-8000-00000000cc01",
+        trick_name: "Ambitious Card",
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        trick_id: "00000000-0000-4000-8000-00000000cc02",
+        trick_name: "Triumph",
+      },
+    ];
+    const result = buildItemTrickMap(rows);
+
+    expect(result.size).toBe(1);
+    const tricks = result.get("00000000-0000-4000-8000-00000000aa01" as ItemId);
+    expect(tricks).toHaveLength(2);
+    expect(tricks).toEqual([
+      {
+        id: "00000000-0000-4000-8000-00000000cc01" as TrickId,
+        name: "Ambitious Card",
+      },
+      {
+        id: "00000000-0000-4000-8000-00000000cc02" as TrickId,
+        name: "Triumph",
+      },
+    ]);
+  });
+
+  it("separates tricks from different items", () => {
+    const rows: ItemTrickRow[] = [
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        trick_id: "00000000-0000-4000-8000-00000000cc01",
+        trick_name: "Ambitious Card",
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa02",
+        trick_id: "00000000-0000-4000-8000-00000000cc02",
+        trick_name: "Triumph",
+      },
+    ];
+    const result = buildItemTrickMap(rows);
+
+    expect(result.size).toBe(2);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa01" as ItemId)
+    ).toHaveLength(1);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa02" as ItemId)
+    ).toHaveLength(1);
+  });
+
+  it("handles mixed items with multiple tricks each", () => {
+    const rows: ItemTrickRow[] = [
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        trick_id: "00000000-0000-4000-8000-00000000cc01",
+        trick_name: "Ambitious Card",
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa02",
+        trick_id: "00000000-0000-4000-8000-00000000cc02",
+        trick_name: "Triumph",
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa01",
+        trick_id: "00000000-0000-4000-8000-00000000cc03",
+        trick_name: "Oil and Water",
+      },
+      {
+        item_id: "00000000-0000-4000-8000-00000000aa02",
+        trick_id: "00000000-0000-4000-8000-00000000cc04",
+        trick_name: "Reset",
+      },
+    ];
+    const result = buildItemTrickMap(rows);
+
+    expect(result.size).toBe(2);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa01" as ItemId)
+    ).toHaveLength(2);
+    expect(
+      result.get("00000000-0000-4000-8000-00000000aa02" as ItemId)
+    ).toHaveLength(2);
+  });
+});

--- a/src/features/collect/components/collect-helpers.ts
+++ b/src/features/collect/components/collect-helpers.ts
@@ -1,0 +1,106 @@
+import { asItemId, asTagId, asTrickId, type ItemId } from "@/db/types";
+import type { ParsedTag } from "@/features/repertoire/types";
+import type { LinkedTrick } from "../types";
+
+/**
+ * UUID v1-v5 regex. Validates at the trust boundary where untyped strings
+ * from PowerSync's local SQLite enter the typed domain — the brand
+ * constructors (asItemId, asTagId, asTrickId) are deliberately type-only
+ * casts, so runtime validation lives here.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_RE.test(value);
+}
+
+/** Row shape returned by the item_tags + tags join query. */
+export interface ItemTagRow {
+  color: string | null;
+  item_id: string;
+  tag_id: string;
+  tag_name: string;
+}
+
+/** Row shape returned by the item_tricks + tricks join query. */
+export interface ItemTrickRow {
+  item_id: string;
+  trick_id: string;
+  trick_name: string;
+}
+
+/**
+ * Builds a Map from item ID to its parsed tags, given the raw join rows.
+ * Runs on every render but the data set is small (local SQLite) and the
+ * React Compiler handles memoization automatically.
+ *
+ * Rows whose `item_id` or `tag_id` are not valid UUIDs are skipped (the
+ * trust boundary where untyped sync rows enter the typed domain).
+ */
+export function buildItemTagMap(rows: ItemTagRow[]): Map<ItemId, ParsedTag[]> {
+  const map = new Map<ItemId, ParsedTag[]>();
+
+  for (const row of rows) {
+    if (!(isUuid(row.item_id) && isUuid(row.tag_id))) {
+      console.warn("[buildItemTagMap] Invalid UUID in row, skipping", {
+        item_id: isUuid(row.item_id) ? row.item_id : "invalid",
+        tag_id: isUuid(row.tag_id) ? row.tag_id : "invalid",
+      });
+      continue;
+    }
+
+    const itemId = asItemId(row.item_id);
+    const tag: ParsedTag = {
+      id: asTagId(row.tag_id),
+      name: row.tag_name,
+      color: row.color,
+    };
+
+    const existing = map.get(itemId);
+    if (existing) {
+      existing.push(tag);
+    } else {
+      map.set(itemId, [tag]);
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Builds a Map from item ID to its linked tricks, given the raw join rows.
+ *
+ * Rows whose `item_id` or `trick_id` are not valid UUIDs are skipped (the
+ * trust boundary where untyped sync rows enter the typed domain).
+ */
+export function buildItemTrickMap(
+  rows: ItemTrickRow[]
+): Map<ItemId, LinkedTrick[]> {
+  const map = new Map<ItemId, LinkedTrick[]>();
+
+  for (const row of rows) {
+    if (!(isUuid(row.item_id) && isUuid(row.trick_id))) {
+      console.warn("[buildItemTrickMap] Invalid UUID in row, skipping", {
+        item_id: isUuid(row.item_id) ? row.item_id : "invalid",
+        trick_id: isUuid(row.trick_id) ? row.trick_id : "invalid",
+      });
+      continue;
+    }
+
+    const itemId = asItemId(row.item_id);
+    const trick: LinkedTrick = {
+      id: asTrickId(row.trick_id),
+      name: row.trick_name,
+    };
+
+    const existing = map.get(itemId);
+    if (existing) {
+      existing.push(trick);
+    } else {
+      map.set(itemId, [trick]);
+    }
+  }
+
+  return map;
+}

--- a/src/features/collect/components/collect-view.test.tsx
+++ b/src/features/collect/components/collect-view.test.tsx
@@ -1,0 +1,768 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ItemId, TagId, TrickId } from "@/db/types";
+import type { ParsedItem } from "../types";
+import { CollectView } from "./collect-view";
+import type { ItemDeleteDialogProps } from "./item-delete-dialog";
+import type { ItemFiltersProps } from "./item-filters";
+import type { ItemFormSheetProps } from "./item-form-sheet";
+
+// Mock PowerSync useQuery — used directly by CollectView for the join queries.
+vi.mock("@powersync/react", () => ({
+  useQuery: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+  })),
+  usePowerSync: vi.fn(() => ({ execute: vi.fn() })),
+}));
+
+// Mock auth client used by mutation hooks (not relevant here but imported transitively).
+vi.mock("@/auth/client", () => ({
+  authClient: {
+    useSession: vi.fn(() => ({ data: { user: { id: "test-user-id" } } })),
+  },
+}));
+
+// Mock analytics
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
+// Mock sonner toast
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Mock feature-level hooks
+vi.mock("../hooks/use-items", () => ({
+  useItems: vi.fn(() => ({ items: [], error: null, isLoading: false })),
+}));
+
+vi.mock("../hooks/use-item", () => ({
+  useItem: vi.fn(() => ({ item: null, error: null, isLoading: false })),
+}));
+
+vi.mock("../hooks/use-item-brands", () => ({
+  useItemBrands: vi.fn(() => ({ brands: [], error: null })),
+}));
+
+vi.mock("../hooks/use-item-locations", () => ({
+  useItemLocations: vi.fn(() => ({ locations: [], error: null })),
+}));
+
+const mockCreateItem = vi.fn().mockResolvedValue("new-item-id");
+const mockUpdateItem = vi.fn().mockResolvedValue(undefined);
+const mockDeleteItem = vi.fn().mockResolvedValue(undefined);
+
+// Use importOriginal so the mock re-exports the REAL typed error classes.
+// Nominal equality matters: the production code uses `instanceof` checks, so
+// if the test declared its own classes the `instanceof` branches would never
+// fire and the translated-toast paths would be uncovered.
+vi.mock("../hooks/use-item-mutations", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../hooks/use-item-mutations")>();
+  return {
+    ...actual,
+    useItemMutations: vi.fn(() => ({
+      createItem: mockCreateItem,
+      updateItem: mockUpdateItem,
+      deleteItem: mockDeleteItem,
+    })),
+  };
+});
+
+vi.mock("@/features/repertoire/hooks/use-tags", () => ({
+  useTags: vi.fn(() => ({ tags: [], isLoading: false })),
+}));
+
+vi.mock("@/features/repertoire/hooks/use-tag-mutations", () => ({
+  useTagMutations: vi.fn(() => ({
+    createTag: vi.fn().mockResolvedValue("new-tag-id"),
+  })),
+}));
+
+// Mock child components so we can capture and drive their props
+let capturedFormSheetProps: Partial<ItemFormSheetProps> = {};
+
+vi.mock("./item-form-sheet", () => ({
+  ItemFormSheet: (props: ItemFormSheetProps) => {
+    capturedFormSheetProps = props;
+    return <div data-open={String(props.open)} data-testid="item-form-sheet" />;
+  },
+}));
+
+let capturedDeleteDialogProps: Partial<ItemDeleteDialogProps> = {};
+
+vi.mock("./item-delete-dialog", () => ({
+  ItemDeleteDialog: (props: ItemDeleteDialogProps) => {
+    capturedDeleteDialogProps = props;
+    return (
+      <div data-open={String(props.open)} data-testid="item-delete-dialog">
+        {props.open && (
+          <button
+            data-testid="confirm-delete"
+            onClick={props.onConfirm}
+            type="button"
+          >
+            Confirm
+          </button>
+        )}
+      </div>
+    );
+  },
+}));
+
+let capturedFiltersProps: Partial<ItemFiltersProps> = {};
+
+vi.mock("./item-filters", () => ({
+  ItemFilters: (props: ItemFiltersProps) => {
+    capturedFiltersProps = props;
+    return (
+      <div>
+        <input
+          aria-label="collect.searchPlaceholder"
+          onChange={(e) => props.onSearchChange(e.target.value)}
+          type="search"
+          value={props.search}
+        />
+      </div>
+    );
+  },
+}));
+
+vi.mock("./item-list", () => ({
+  ItemList: ({
+    items,
+    onEdit,
+    onDelete,
+  }: {
+    items: { id: ItemId; name: string }[];
+    onEdit: (id: ItemId) => void;
+    onDelete: (id: ItemId) => void;
+  }) => (
+    <div data-testid="item-list">
+      {items.map((item) => (
+        <div key={item.id}>
+          <span>{item.name}</span>
+          <button
+            data-testid={`edit-${item.id}`}
+            onClick={() => onEdit(item.id)}
+            type="button"
+          >
+            Edit
+          </button>
+          <button
+            data-testid={`delete-${item.id}`}
+            onClick={() => onDelete(item.id)}
+            type="button"
+          >
+            Delete
+          </button>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("./item-empty-state", () => ({
+  ItemEmptyState: ({ onAddItem }: { onAddItem: () => void }) => (
+    <button data-testid="item-empty-state" onClick={onAddItem} type="button">
+      Add your first item
+    </button>
+  ),
+}));
+
+const ADD_ITEM_PATTERN = /collect.addItem/i;
+
+function makeItem(
+  id: string,
+  name: string,
+  overrides: Partial<ParsedItem> = {}
+): ParsedItem {
+  return {
+    id: id as ItemId,
+    name,
+    type: "prop",
+    description: null,
+    brand: null,
+    condition: null,
+    location: null,
+    notes: null,
+    purchaseDate: null,
+    purchasePrice: null,
+    quantity: 1,
+    creator: null,
+    url: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeFormValues(
+  overrides: Record<string, unknown> = {}
+): Parameters<NonNullable<ItemFormSheetProps["onSubmit"]>>[0] {
+  return {
+    name: "Test",
+    type: "prop",
+    description: "",
+    brand: "",
+    creator: "",
+    condition: null,
+    location: "",
+    quantity: 1,
+    purchaseDate: "",
+    purchasePrice: "",
+    url: "",
+    notes: "",
+    ...overrides,
+  } as Parameters<NonNullable<ItemFormSheetProps["onSubmit"]>>[0];
+}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+
+  const { useQuery } = await import("@powersync/react");
+  const { useItems } = await import("../hooks/use-items");
+  const { useItem } = await import("../hooks/use-item");
+
+  vi.mocked(useQuery).mockReturnValue({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    error: undefined,
+  });
+  vi.mocked(useItems).mockReturnValue({
+    items: [],
+    error: null,
+    isLoading: false,
+  });
+  vi.mocked(useItem).mockReturnValue({
+    item: null,
+    error: null,
+    isLoading: false,
+  });
+
+  mockCreateItem.mockResolvedValue("new-item-id");
+  mockUpdateItem.mockResolvedValue(undefined);
+  mockDeleteItem.mockResolvedValue(undefined);
+
+  capturedFormSheetProps = {};
+  capturedDeleteDialogProps = {};
+  capturedFiltersProps = {};
+});
+
+describe("CollectView", () => {
+  it("renders without crashing", () => {
+    render(<CollectView />);
+    expect(screen.getByText("collect.title")).toBeInTheDocument();
+  });
+
+  it("shows empty state when there are no items and no filters", () => {
+    render(<CollectView />);
+    expect(screen.getByTestId("item-empty-state")).toBeInTheDocument();
+  });
+
+  it("opens sheet in create mode when add button is clicked", async () => {
+    render(<CollectView />);
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+    expect(capturedFormSheetProps.open).toBe(true);
+    expect(capturedFormSheetProps.selectedTagIds).toEqual([]);
+    expect(capturedFormSheetProps.selectedTrickIds).toEqual([]);
+  });
+
+  it("creates an item with selected tags and tricks on submit", async () => {
+    render(<CollectView />);
+
+    // Open sheet
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+
+    // Select a tag and a trick via the captured handlers
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.(
+        "00000000-0000-4000-8000-00000000bb01" as TagId
+      );
+    });
+    act(() => {
+      capturedFormSheetProps.onToggleTrick?.(
+        "00000000-0000-4000-8000-00000000cc01" as TrickId
+      );
+    });
+
+    // Submit the form
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "Invisible Deck" })
+    );
+
+    expect(mockCreateItem).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Invisible Deck" }),
+      ["00000000-0000-4000-8000-00000000bb01"],
+      ["00000000-0000-4000-8000-00000000cc01"]
+    );
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("collect.itemCreated");
+    });
+  });
+
+  it("computes set-diff for tags in edit mode (add and remove)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const { useQuery } = await import("@powersync/react");
+
+    const item = makeItem(
+      "00000000-0000-4000-8000-0000000ed170",
+      "Ambitious Card"
+    );
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+
+    // The first useQuery call is the item_tags join — seed it with two existing tags
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM item_tags")) {
+        return {
+          data: [
+            {
+              item_id: "00000000-0000-4000-8000-0000000ed170",
+              tag_id: "00000000-0000-4000-8000-0000000000a1",
+              tag_name: "00000000-0000-4000-8000-0000000000a1",
+              color: null,
+            },
+            {
+              item_id: "00000000-0000-4000-8000-0000000ed170",
+              tag_id: "00000000-0000-4000-8000-0000000000a2",
+              tag_name: "00000000-0000-4000-8000-0000000000a2",
+              color: null,
+            },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    // Click edit — initial selectedTagIds should be [t1, t2]
+    await userEvent.click(
+      screen.getByTestId("edit-00000000-0000-4000-8000-0000000ed170")
+    );
+    expect(capturedFormSheetProps.selectedTagIds).toEqual([
+      "00000000-0000-4000-8000-0000000000a1",
+      "00000000-0000-4000-8000-0000000000a2",
+    ]);
+
+    // Remove t2 and add t3
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.(
+        "00000000-0000-4000-8000-0000000000a2" as TagId
+      );
+    });
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.(
+        "00000000-0000-4000-8000-0000000000a3" as TagId
+      );
+    });
+
+    // Submit — updateItem should be called with addTagIds=[t3], removeTagIds=[t2]
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "Ambitious Card" })
+    );
+
+    expect(mockUpdateItem).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-0000000ed170",
+      expect.any(Object),
+      ["00000000-0000-4000-8000-0000000000a3"],
+      ["00000000-0000-4000-8000-0000000000a2"],
+      [],
+      []
+    );
+  });
+
+  it("produces an empty diff when tags are reordered but unchanged", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const { useQuery } = await import("@powersync/react");
+
+    const item = makeItem("00000000-0000-4000-8000-0000000ed171", "Card Warp");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM item_tags")) {
+        return {
+          data: [
+            {
+              item_id: "00000000-0000-4000-8000-0000000ed171",
+              tag_id: "00000000-0000-4000-8000-0000000000a1",
+              tag_name: "00000000-0000-4000-8000-0000000000a1",
+              color: null,
+            },
+            {
+              item_id: "00000000-0000-4000-8000-0000000ed171",
+              tag_id: "00000000-0000-4000-8000-0000000000a2",
+              tag_name: "00000000-0000-4000-8000-0000000000a2",
+              color: null,
+            },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(
+      screen.getByTestId("edit-00000000-0000-4000-8000-0000000ed171")
+    );
+
+    // Toggle t1 off, t2 off, t2 on, t1 on — same set, different insert order
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.(
+        "00000000-0000-4000-8000-0000000000a1" as TagId
+      );
+    });
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.(
+        "00000000-0000-4000-8000-0000000000a2" as TagId
+      );
+    });
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.(
+        "00000000-0000-4000-8000-0000000000a2" as TagId
+      );
+    });
+    act(() => {
+      capturedFormSheetProps.onToggleTag?.(
+        "00000000-0000-4000-8000-0000000000a1" as TagId
+      );
+    });
+
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "Card Warp" })
+    );
+
+    expect(mockUpdateItem).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-0000000ed171",
+      expect.any(Object),
+      [],
+      [],
+      [],
+      []
+    );
+  });
+
+  it("propagates sort changes from ItemFilters to useItems", async () => {
+    const { useItems } = await import("../hooks/use-items");
+
+    render(<CollectView />);
+
+    // Initial render should use the "newest" default sort mapped to snake_case.
+    expect(vi.mocked(useItems)).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "newest" })
+    );
+
+    // Change to name-asc — passes the kebab-case FilterSortValue through to useItems unchanged
+    act(() => {
+      capturedFiltersProps.onSortChange?.("name-asc");
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(useItems)).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sort: "name-asc" })
+      );
+    });
+  });
+
+  it("fires a load-error toast with a stable id when items query fails", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    vi.mocked(useItems).mockReturnValue({
+      items: [],
+      error: new Error("boom"),
+      isLoading: false,
+    });
+
+    render(<CollectView />);
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "collect.loadError",
+        expect.objectContaining({ id: "collect-load-items-error" })
+      );
+    });
+  });
+
+  it("closes sheet and clears edit state when useItem reports an error", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const item = makeItem("item-err", "Broken");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+
+    // The hook reports an error — the sheet must NOT stay open on the "add new" form.
+    vi.mocked(useItem).mockReturnValue({
+      item: null,
+      error: new Error("load failed"),
+      isLoading: false,
+    });
+
+    render(<CollectView />);
+
+    // Attempt to open the edit sheet — the load-error effect should slam it shut.
+    await userEvent.click(screen.getByTestId("edit-item-err"));
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-edit-item-error" })
+    );
+  });
+
+  it("keeps the sheet open and shows an error toast when save fails", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const item = makeItem("item-save-fail", "Coin Warp");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+    mockUpdateItem.mockRejectedValueOnce(new Error("update failed"));
+
+    render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId("edit-item-save-fail"));
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    // The parent rethrows after toasting so the child ItemFormSheet sees the
+    // failure and skips its post-await dirty reset (per #14 fix).
+    await expect(
+      capturedFormSheetProps.onSubmit?.(makeFormValues({ name: "Coin Warp" }))
+    ).rejects.toThrow("update failed");
+
+    // Sheet remains open so the user can retry or cancel.
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("collect.saveFailed");
+    });
+  });
+
+  // Typed-error toast coverage. The mock re-exports the real error classes
+  // via importOriginal so `instanceof` checks in production code fire
+  // correctly across the mock boundary (finding #12/#18).
+  it("toasts validation.tooManyTags when MaxTagsError is thrown on save", async () => {
+    const { MaxTagsError } = await import("../hooks/use-item-mutations");
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const item = makeItem("item-tags", "Rope");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+    mockUpdateItem.mockRejectedValueOnce(new MaxTagsError());
+
+    render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId("edit-item-tags"));
+
+    await expect(
+      capturedFormSheetProps.onSubmit?.(makeFormValues({ name: "Rope" }))
+    ).rejects.toBeInstanceOf(MaxTagsError);
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "collect.validation.tooManyTags"
+      );
+    });
+    // Generic saveFailed must NOT fire when we've already shown the specific
+    // typed-error toast.
+    expect(toast.error).not.toHaveBeenCalledWith("collect.saveFailed");
+  });
+
+  it("toasts validation.tooManyTricks with the cap count when MaxTricksError is thrown on save", async () => {
+    const { MaxTricksError } = await import("../hooks/use-item-mutations");
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const item = makeItem("item-tricks", "Thimble");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+    mockUpdateItem.mockRejectedValueOnce(new MaxTricksError());
+
+    render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId("edit-item-tricks"));
+
+    await expect(
+      capturedFormSheetProps.onSubmit?.(makeFormValues({ name: "Thimble" }))
+    ).rejects.toBeInstanceOf(MaxTricksError);
+
+    const { toast } = await import("sonner");
+    // The translation key is parameterized with `{count}` — the global
+    // next-intl mock renders interpolation as "(count: N)", so we assert on
+    // the key prefix to stay decoupled from the exact cap value.
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining("collect.validation.tooManyTricks")
+      );
+    });
+    expect(toast.error).not.toHaveBeenCalledWith("collect.saveFailed");
+  });
+
+  it("toasts errors.itemMissing when ItemNotFoundError is thrown on delete", async () => {
+    const { ItemNotFoundError } = await import("../hooks/use-item-mutations");
+    const { useItems } = await import("../hooks/use-items");
+    const item = makeItem("item-missing", "Vanishing Silk");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    mockDeleteItem.mockRejectedValueOnce(new ItemNotFoundError());
+
+    render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId("delete-item-missing"));
+    expect(capturedDeleteDialogProps.open).toBe(true);
+    await userEvent.click(screen.getByTestId("confirm-delete"));
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("collect.errors.itemMissing");
+    });
+    // Generic deleteFailed must NOT fire when we've already shown the
+    // specific itemMissing toast.
+    expect(toast.error).not.toHaveBeenCalledWith("collect.deleteFailed");
+    // Dialog still clears in the finally block on typed-error path.
+    await waitFor(() => {
+      expect(capturedDeleteDialogProps.open).toBe(false);
+    });
+  });
+
+  it("clears delete state in finally block on success and failure", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const item = makeItem("item-del", "Silk");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+
+    render(<CollectView />);
+
+    // Success path
+    await userEvent.click(screen.getByTestId("delete-item-del"));
+    expect(capturedDeleteDialogProps.open).toBe(true);
+    await userEvent.click(screen.getByTestId("confirm-delete"));
+
+    await waitFor(() => {
+      expect(mockDeleteItem).toHaveBeenCalledWith("item-del");
+      expect(capturedDeleteDialogProps.open).toBe(false);
+    });
+
+    // Failure path — finally still clears state
+    mockDeleteItem.mockRejectedValueOnce(new Error("boom"));
+    await userEvent.click(screen.getByTestId("delete-item-del"));
+    expect(capturedDeleteDialogProps.open).toBe(true);
+    await userEvent.click(screen.getByTestId("confirm-delete"));
+
+    await waitFor(() => {
+      expect(capturedDeleteDialogProps.open).toBe(false);
+    });
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith("collect.deleteFailed");
+  });
+
+  it("rethrows when createTag fails (TagPicker owns the toast)", async () => {
+    const { useTagMutations } = await import(
+      "@/features/repertoire/hooks/use-tag-mutations"
+    );
+    const mockCreateTag = vi.fn().mockRejectedValue(new Error("tag boom"));
+    vi.mocked(useTagMutations).mockReturnValue({ createTag: mockCreateTag });
+
+    render(<CollectView />);
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+
+    await expect(
+      capturedFormSheetProps.onCreateTag?.("Mentalism")
+    ).rejects.toThrow("tag boom");
+
+    // collect-view no longer toasts here — TagPicker owns the user-facing toast
+    // to avoid double-toasting (per convergence finding #5).
+    const { toast } = await import("sonner");
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "collect.tagPicker.createFailed",
+      expect.anything()
+    );
+  });
+});

--- a/src/features/collect/components/collect-view.tsx
+++ b/src/features/collect/components/collect-view.tsx
@@ -1,0 +1,537 @@
+"use client";
+
+import { useQuery } from "@powersync/react";
+import { PlusIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { asTrickId, type ItemId, type TagId, type TrickId } from "@/db/types";
+import {
+  type FilterSortValue,
+  type ItemCondition,
+  type ItemType,
+  MAX_TRICKS_PER_ITEM,
+} from "@/features/collect/constants";
+import { useTagMutations } from "@/features/repertoire/hooks/use-tag-mutations";
+import { useTags } from "@/features/repertoire/hooks/use-tags";
+import { useItem } from "../hooks/use-item";
+import { useItemBrands } from "../hooks/use-item-brands";
+import { useItemLocations } from "../hooks/use-item-locations";
+import {
+  getMutationErrorKey,
+  useItemMutations,
+} from "../hooks/use-item-mutations";
+import { useItems } from "../hooks/use-items";
+import type { ItemFormValues } from "../schema";
+import type { ItemWithRelations, LinkedTrick } from "../types";
+import {
+  buildItemTagMap,
+  buildItemTrickMap,
+  type ItemTagRow,
+  type ItemTrickRow,
+} from "./collect-helpers";
+import { ItemDeleteDialog } from "./item-delete-dialog";
+import { ItemEmptyState } from "./item-empty-state";
+import { ItemFilters } from "./item-filters";
+import { ItemFormSheet } from "./item-form-sheet";
+import { ItemList } from "./item-list";
+
+/** Row shape for available tricks. */
+interface AvailableTrickRow {
+  id: string;
+  name: string;
+}
+
+/**
+ * UUID v1-v5 regex. Validates raw PowerSync row ids at the trust boundary
+ * before lifting them to branded IDs via `asTrickId` (type-only cast).
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Stable toast id for the items list load error (replaces rather than stacks). */
+const LOAD_ITEMS_ERROR_TOAST_ID = "collect-load-items-error";
+/** Stable toast id for the editing-item load error (separate so it doesn't clobber the items toast). */
+const LOAD_EDIT_ITEM_ERROR_TOAST_ID = "collect-load-edit-item-error";
+
+/** Debounce delay for the search input (milliseconds). */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Main orchestration component for the collection feature.
+ *
+ * Manages all state (filters, sheet, delete dialog, tag/trick selection)
+ * and wires up data hooks with child components.
+ */
+export function CollectView(): React.ReactElement {
+  const t = useTranslations("collect");
+
+  // ---------------------------------------------------------------------------
+  // Filter state
+  // ---------------------------------------------------------------------------
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState<ItemType | null>(null);
+  const [conditionFilter, setConditionFilter] = useState<ItemCondition | null>(
+    null
+  );
+  const [sort, setSort] = useState<FilterSortValue>("newest");
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [search]);
+
+  // ---------------------------------------------------------------------------
+  // Sheet state
+  // ---------------------------------------------------------------------------
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editingItemId, setEditingItemId] = useState<ItemId | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Delete dialog state
+  // ---------------------------------------------------------------------------
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deletingItemId, setDeletingItemId] = useState<ItemId | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Tag selection (local state for the form, not persisted until save)
+  // ---------------------------------------------------------------------------
+  const [selectedTagIds, setSelectedTagIds] = useState<TagId[]>([]);
+
+  // ---------------------------------------------------------------------------
+  // Trick selection (local state for the form, not persisted until save)
+  // ---------------------------------------------------------------------------
+  const [selectedTrickIds, setSelectedTrickIds] = useState<TrickId[]>([]);
+
+  // Snapshot of tag/trick IDs captured when edit form opens (stable diff baseline).
+  // Known cold-start race — if PowerSync join hasn't hydrated at click time, this
+  // starts empty. Tracked in a follow-up issue.
+  const [originalTagIds, setOriginalTagIds] = useState<TagId[]>([]);
+  const [originalTrickIds, setOriginalTrickIds] = useState<TrickId[]>([]);
+
+  // ---------------------------------------------------------------------------
+  // Data hooks
+  // ---------------------------------------------------------------------------
+  const { items, error: itemsError } = useItems({
+    search: debouncedSearch,
+    type: typeFilter,
+    condition: conditionFilter,
+    sort,
+  });
+
+  const { item: editingItem, error: editingItemError } = useItem(editingItemId);
+  const { tags } = useTags();
+  const { createItem, updateItem, deleteItem } = useItemMutations();
+  const { createTag } = useTagMutations();
+  const { brands: userBrands, error: brandsError } = useItemBrands();
+  const { locations: userLocations, error: locationsError } =
+    useItemLocations();
+
+  // ---------------------------------------------------------------------------
+  // Item-tags join query (build a Map<itemId, ParsedTag[]>)
+  // ---------------------------------------------------------------------------
+  const { data: itemTagRows, error: itemTagError } = useQuery<ItemTagRow>(
+    `SELECT it.item_id, t.id AS tag_id, t.name AS tag_name, t.color
+     FROM item_tags it
+     JOIN tags t ON it.tag_id = t.id
+     WHERE it.deleted_at IS NULL AND t.deleted_at IS NULL`
+  );
+
+  const itemTagMap = buildItemTagMap(itemTagRows);
+
+  // ---------------------------------------------------------------------------
+  // Item-tricks join query (build a Map<itemId, LinkedTrick[]>)
+  // ---------------------------------------------------------------------------
+  const { data: itemTrickRows, error: itemTrickError } = useQuery<ItemTrickRow>(
+    `SELECT itr.item_id, tr.id AS trick_id, tr.name AS trick_name
+     FROM item_tricks itr
+     JOIN tricks tr ON itr.trick_id = tr.id
+     WHERE itr.deleted_at IS NULL AND tr.deleted_at IS NULL`
+  );
+
+  const itemTrickMap = buildItemTrickMap(itemTrickRows);
+
+  // ---------------------------------------------------------------------------
+  // Available tricks for the trick picker (only when form sheet is open)
+  // ---------------------------------------------------------------------------
+  // Eager-load tricks for the picker. Local SQLite query cost is negligible,
+  // and gating on sheetOpen caused re-registration churn and an empty-picker
+  // flash while the async query hydrated after the sheet opened.
+  const { data: availableTrickRows, error: availableTricksError } =
+    useQuery<AvailableTrickRow>(
+      "SELECT id, name FROM tricks WHERE deleted_at IS NULL ORDER BY name ASC"
+    );
+
+  const availableTricks: LinkedTrick[] = availableTrickRows.flatMap((row) => {
+    if (typeof row.id !== "string" || !UUID_RE.test(row.id)) {
+      console.warn(
+        "[CollectView] Invalid trick id in availableTricks, skipping",
+        {
+          id: typeof row.id === "string" ? `${row.id.slice(0, 8)}...` : null,
+        }
+      );
+      return [];
+    }
+    return [{ id: asTrickId(row.id), name: row.name }];
+  });
+
+  // ---------------------------------------------------------------------------
+  // Editing item load failure — close the sheet rather than render "add new"
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (editingItemId && editingItemError) {
+      console.error("Failed to load item for editing:", editingItemError);
+      // Do NOT pass editingItemError.message as description — PowerSync/SQLite
+      // error messages can contain row context, query fragments, or user-supplied
+      // values. The full error is already in the console.error above for
+      // developer diagnostics. Matches the items-error toast shape (line ~224).
+      toast.error(t("loadError"), {
+        id: LOAD_EDIT_ITEM_ERROR_TOAST_ID,
+      });
+      setSheetOpen(false);
+      setEditingItemId(null);
+      setSelectedTagIds([]);
+      setSelectedTrickIds([]);
+      setOriginalTagIds([]);
+      setOriginalTrickIds([]);
+    }
+  }, [editingItemId, editingItemError, t]);
+
+  // ---------------------------------------------------------------------------
+  // Surface critical query errors as a single, replaceable toast.
+  // Supplementary queries (brands, locations, trick-join) only log.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (brandsError) {
+      console.error("Brands query error:", brandsError);
+    }
+    if (locationsError) {
+      console.error("Locations query error:", locationsError);
+    }
+    if (itemTagError) {
+      console.error("Item-tags query error:", itemTagError);
+    }
+    if (itemTrickError) {
+      console.error("Item-tricks query error:", itemTrickError);
+    }
+    if (availableTricksError) {
+      console.error("Available tricks query error:", availableTricksError);
+    }
+    if (itemsError) {
+      console.error("Items query error:", itemsError);
+      toast.error(t("loadError"), { id: LOAD_ITEMS_ERROR_TOAST_ID });
+    }
+  }, [
+    itemsError,
+    itemTagError,
+    itemTrickError,
+    availableTricksError,
+    brandsError,
+    locationsError,
+    t,
+  ]);
+
+  // ---------------------------------------------------------------------------
+  // Build items with relations
+  // ---------------------------------------------------------------------------
+  const itemsWithRelations: ItemWithRelations[] = items.map((item) => ({
+    ...item,
+    tags: itemTagMap.get(item.id) ?? [],
+    tricks: itemTrickMap.get(item.id) ?? [],
+  }));
+
+  // Resolve names for the delete dialog
+  const deletingItemName =
+    deletingItemId === null
+      ? null
+      : (items.find((item) => item.id === deletingItemId)?.name ?? null);
+
+  // Whether the tag selection has diverged from the snapshot (or is non-empty for new items)
+  const tagsDirty = editingItemId
+    ? selectedTagIds.length !== originalTagIds.length ||
+      selectedTagIds.some((id) => !originalTagIds.includes(id))
+    : selectedTagIds.length > 0;
+
+  // Whether the trick selection has diverged from the snapshot (or is non-empty for new items)
+  const tricksDirty = editingItemId
+    ? selectedTrickIds.length !== originalTrickIds.length ||
+      selectedTrickIds.some((id) => !originalTrickIds.includes(id))
+    : selectedTrickIds.length > 0;
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  function handleAddItem(): void {
+    setEditingItemId(null);
+    setSelectedTagIds([]);
+    setSelectedTrickIds([]);
+    setOriginalTagIds([]);
+    setOriginalTrickIds([]);
+    setSheetOpen(true);
+  }
+
+  function handleEditItem(id: ItemId): void {
+    setEditingItemId(id);
+
+    // Snapshot the current tag/trick IDs as the diff baseline for this edit session.
+    // Cold-start race: if the PowerSync join hasn't hydrated yet, both snapshot and
+    // selection start as []. Tracked as a follow-up issue.
+    const currentTags = itemTagMap.get(id) ?? [];
+    const currentTagIds = currentTags.map((tag) => tag.id);
+    setSelectedTagIds(currentTagIds);
+    setOriginalTagIds(currentTagIds);
+
+    const currentTricks = itemTrickMap.get(id) ?? [];
+    const currentTrickIds = currentTricks.map((trick) => trick.id);
+    setSelectedTrickIds(currentTrickIds);
+    setOriginalTrickIds(currentTrickIds);
+
+    setSheetOpen(true);
+  }
+
+  function handleSheetOpenChange(open: boolean): void {
+    setSheetOpen(open);
+    if (!open) {
+      setEditingItemId(null);
+      setSelectedTagIds([]);
+      setSelectedTrickIds([]);
+      setOriginalTagIds([]);
+      setOriginalTrickIds([]);
+    }
+  }
+
+  async function handleSubmit(data: ItemFormValues): Promise<void> {
+    try {
+      if (editingItemId) {
+        const originalTagSet = new Set(originalTagIds);
+        const currentTagSet = new Set(selectedTagIds);
+        const addTagIds = selectedTagIds.filter(
+          (id) => !originalTagSet.has(id)
+        );
+        const removeTagIds = originalTagIds.filter(
+          (id) => !currentTagSet.has(id)
+        );
+
+        const originalTrickSet = new Set(originalTrickIds);
+        const currentTrickSet = new Set(selectedTrickIds);
+        const addTrickIds = selectedTrickIds.filter(
+          (id) => !originalTrickSet.has(id)
+        );
+        const removeTrickIds = originalTrickIds.filter(
+          (id) => !currentTrickSet.has(id)
+        );
+
+        await updateItem(
+          editingItemId,
+          data,
+          addTagIds,
+          removeTagIds,
+          addTrickIds,
+          removeTrickIds
+        );
+        toast.success(t("itemUpdated"));
+      } else {
+        await createItem(data, selectedTagIds, selectedTrickIds);
+        toast.success(t("itemCreated"));
+      }
+
+      setSheetOpen(false);
+      setEditingItemId(null);
+      setSelectedTagIds([]);
+      setSelectedTrickIds([]);
+      setOriginalTagIds([]);
+      setOriginalTrickIds([]);
+    } catch (error) {
+      console.error("Item save failed:", error);
+      const errorKey = getMutationErrorKey(error);
+      if (errorKey === "validation.tooManyTricks") {
+        toast.error(t(errorKey, { count: MAX_TRICKS_PER_ITEM }));
+      } else if (errorKey) {
+        toast.error(t(errorKey));
+      } else {
+        toast.error(t("saveFailed"));
+      }
+      // Re-throw so the child ItemFormSheet's handleFormSubmit catches it and
+      // skips its post-await setFormDirty(false) — keeps RHF isDirty and the
+      // local formDirty mirror in sync when save fails.
+      throw error;
+    }
+  }
+
+  function handleDeleteItem(id: ItemId): void {
+    setDeletingItemId(id);
+    setDeleteDialogOpen(true);
+  }
+
+  async function handleConfirmDelete(): Promise<void> {
+    if (!deletingItemId) {
+      return;
+    }
+
+    try {
+      await deleteItem(deletingItemId);
+      toast.success(t("itemDeleted"));
+    } catch (error) {
+      console.error("Item delete failed:", error);
+      const errorKey = getMutationErrorKey(error);
+      if (errorKey) {
+        toast.error(t(errorKey));
+      } else {
+        toast.error(t("deleteFailed"));
+      }
+    } finally {
+      setDeleteDialogOpen(false);
+      setDeletingItemId(null);
+    }
+  }
+
+  function handleDeleteDialogOpenChange(open: boolean): void {
+    setDeleteDialogOpen(open);
+    if (!open) {
+      setDeletingItemId(null);
+    }
+  }
+
+  function handleToggleTag(tagId: TagId): void {
+    setSelectedTagIds((prev) =>
+      prev.includes(tagId)
+        ? prev.filter((id) => id !== tagId)
+        : [...prev, tagId]
+    );
+  }
+
+  async function handleCreateTag(name: string): Promise<TagId> {
+    try {
+      return await createTag(name);
+    } catch (error) {
+      // TagPicker owns the user-facing toast; we only log and rethrow so the
+      // child component can reset its UI state. Avoid duplicate toasts here.
+      console.error("Tag create failed:", error);
+      throw error;
+    }
+  }
+
+  function handleToggleTrick(trickId: TrickId): void {
+    setSelectedTrickIds((prev) =>
+      prev.includes(trickId)
+        ? prev.filter((id) => id !== trickId)
+        : [...prev, trickId]
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Determine which content to render
+  // ---------------------------------------------------------------------------
+  const hasActiveFilters = Boolean(
+    debouncedSearch || typeFilter || conditionFilter
+  );
+
+  function renderContent(): React.ReactElement {
+    if (itemsWithRelations.length > 0) {
+      return (
+        <ItemList
+          items={itemsWithRelations}
+          onDelete={handleDeleteItem}
+          onEdit={handleEditItem}
+        />
+      );
+    }
+
+    if (hasActiveFilters) {
+      return (
+        <p className="py-12 text-center text-muted-foreground" role="status">
+          {t("noResults")}
+        </p>
+      );
+    }
+
+    return <ItemEmptyState onAddItem={handleAddItem} />;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-semibold text-2xl tracking-tight">
+            {t("title")}
+          </h1>
+          <p className="text-muted-foreground">
+            {t("itemCount", { count: itemsWithRelations.length })}
+          </p>
+        </div>
+        <Button onClick={handleAddItem}>
+          <PlusIcon />
+          {t("addItem")}
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <ItemFilters
+        condition={conditionFilter}
+        onConditionChange={setConditionFilter}
+        onSearchChange={setSearch}
+        onSortChange={setSort}
+        onTypeChange={setTypeFilter}
+        search={search}
+        sort={sort}
+        type={typeFilter}
+      />
+
+      {/* Screen-reader-only summary that announces the filtered result count
+          after the debounced search settles. The full list wrapper is NOT an
+          aria-live region — announcing the entire list on every keystroke is
+          noisy; the "no results" paragraph below has its own role="status". */}
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        className="sr-only"
+        role="status"
+      >
+        {t("itemCount", { count: itemsWithRelations.length })}
+      </div>
+
+      {/* List or Empty State */}
+      <div>{renderContent()}</div>
+
+      {/* Form Sheet */}
+      <ItemFormSheet
+        availableTags={tags}
+        availableTricks={availableTricks}
+        item={editingItem}
+        onCreateTag={handleCreateTag}
+        onOpenChange={handleSheetOpenChange}
+        onSubmit={handleSubmit}
+        onToggleTag={handleToggleTag}
+        onToggleTrick={handleToggleTrick}
+        open={sheetOpen}
+        selectedTagIds={selectedTagIds}
+        selectedTrickIds={selectedTrickIds}
+        tagsDirty={tagsDirty}
+        tricksDirty={tricksDirty}
+        userBrands={userBrands}
+        userLocations={userLocations}
+      />
+
+      {/* Delete Dialog */}
+      <ItemDeleteDialog
+        itemName={deletingItemName}
+        onConfirm={handleConfirmDelete}
+        onOpenChange={handleDeleteDialogOpenChange}
+        open={deleteDialogOpen}
+      />
+    </div>
+  );
+}

--- a/src/features/collect/components/item-card.test.tsx
+++ b/src/features/collect/components/item-card.test.tsx
@@ -1,0 +1,558 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ItemId, TagId, TrickId } from "@/db/types";
+import type { ParsedTag } from "@/features/repertoire/types";
+import type { ItemWithRelations } from "../types";
+import {
+  getContrastColor,
+  HEX_COLOR_RE,
+  ItemCard,
+  MAX_VISIBLE_TAGS,
+} from "./item-card";
+
+// DropdownMenu mock renders all children synchronously since Radix portals
+// don't work in jsdom. asChild unwraps so the inner <button> is the trigger.
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    asChild: _asChild,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+    variant: _variant,
+  }: {
+    children: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    variant?: "default" | "destructive";
+  }) => (
+    <button onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+}));
+
+const EDIT_BUTTON_NAME = /^collect\.edit:/;
+const MENU_TRIGGER_NAME = "collect.cardActions";
+const EDIT_MENU_ITEM_NAME = "collect.edit";
+const DELETE_MENU_ITEM_NAME = "collect.delete";
+const QUANTITY_LABEL_RE = /^collect\.quantityLabel/;
+const LINKED_TRICKS_RE = /^collect\.linkedTricksCount/;
+const CONDITION_RE = /^collect\.condition\./;
+const OVERFLOW_BADGE_RE = /^\+\d+$/;
+const MENTALISM_RE = /mentalism/;
+
+function makeItem(
+  overrides: Partial<ItemWithRelations> = {}
+): ItemWithRelations {
+  return {
+    id: "item-1" as ItemId,
+    name: "Invisible Deck",
+    type: "deck",
+    description: null,
+    brand: null,
+    condition: null,
+    location: null,
+    notes: null,
+    purchaseDate: null,
+    purchasePrice: null,
+    quantity: 1,
+    creator: null,
+    url: null,
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    tags: [],
+    tricks: [],
+    ...overrides,
+  };
+}
+
+function makeTag(overrides: Partial<ParsedTag> = {}): ParsedTag {
+  return {
+    id: "tag-1" as TagId,
+    name: "Tag",
+    color: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("MAX_VISIBLE_TAGS", () => {
+  it("is 3", () => {
+    expect(MAX_VISIBLE_TAGS).toBe(3);
+  });
+});
+
+describe("HEX_COLOR_RE", () => {
+  it("matches lowercase 6-digit hex with leading #", () => {
+    expect(HEX_COLOR_RE.test("#ff00aa")).toBe(true);
+  });
+
+  it("matches uppercase hex (case insensitive)", () => {
+    expect(HEX_COLOR_RE.test("#FF00AA")).toBe(true);
+  });
+
+  it("matches mixed case hex", () => {
+    expect(HEX_COLOR_RE.test("#Ff00Aa")).toBe(true);
+  });
+
+  it("rejects 3-digit shorthand", () => {
+    expect(HEX_COLOR_RE.test("#fff")).toBe(false);
+  });
+
+  it("rejects hex without leading #", () => {
+    expect(HEX_COLOR_RE.test("ff00aa")).toBe(false);
+  });
+
+  it("rejects 8-digit hex with alpha channel", () => {
+    expect(HEX_COLOR_RE.test("#ff00aaff")).toBe(false);
+  });
+
+  it("rejects non-hex characters", () => {
+    expect(HEX_COLOR_RE.test("#zzzzzz")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(HEX_COLOR_RE.test("")).toBe(false);
+  });
+});
+
+describe("getContrastColor", () => {
+  it("returns near-white text on pure black background", () => {
+    expect(getContrastColor("#000000")).toBe("#ffffff");
+  });
+
+  it("returns near-black text on pure white background", () => {
+    expect(getContrastColor("#ffffff")).toBe("#000000");
+  });
+
+  it("returns black on yellow (high luminance)", () => {
+    expect(getContrastColor("#ffff00")).toBe("#000000");
+  });
+
+  it("returns white on dark blue (low luminance)", () => {
+    expect(getContrastColor("#000080")).toBe("#ffffff");
+  });
+
+  // #777777 sits near the WCAG luminance pivot — given the algorithm's
+  // tie-break (`contrastWithBlack >= contrastWithWhite`), mid-grey resolves
+  // to black text. Asserting one side guards against accidental flips.
+  it("returns black on mid-grey near the luminance pivot", () => {
+    expect(getContrastColor("#777777")).toBe("#000000");
+  });
+
+  it("handles uppercase hex input", () => {
+    expect(getContrastColor("#FFFFFF")).toBe("#000000");
+  });
+});
+
+describe("ItemCard rendering — basic", () => {
+  it("renders the item name", () => {
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={vi.fn()} />);
+    expect(screen.getByText("Invisible Deck")).toBeInTheDocument();
+  });
+
+  it("renders description when present", () => {
+    render(
+      <ItemCard
+        item={makeItem({ description: "A classic mentalism prop" })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.getByText("A classic mentalism prop")).toBeInTheDocument();
+  });
+
+  it("does not render description when null", () => {
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={vi.fn()} />);
+    // No description paragraph should exist
+    expect(screen.queryByText(MENTALISM_RE)).not.toBeInTheDocument();
+  });
+
+  it("renders the menu trigger button", () => {
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: MENU_TRIGGER_NAME })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the inner edit button labelled with the item name", () => {
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={vi.fn()} />);
+    const editButton = screen.getByRole("button", { name: EDIT_BUTTON_NAME });
+    expect(editButton).toHaveAttribute(
+      "aria-label",
+      "collect.edit: Invisible Deck"
+    );
+  });
+
+  // Phrasing-content rules forbid a real <h3> inside a <button>, but we still
+  // need the item name to be exposed as a heading for screen-reader H-key
+  // navigation. role="heading" + aria-level preserves the outline while
+  // keeping the markup HTML-valid.
+  it("exposes the item name as a level-3 heading for assistive tech", () => {
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={vi.fn()} />);
+    const heading = screen.getByRole("heading", {
+      name: "Invisible Deck",
+      level: 3,
+    });
+    expect(heading).toBeInTheDocument();
+  });
+});
+
+describe("ItemCard interactions", () => {
+  it("calls onEdit when the inner edit button is clicked", async () => {
+    const onEdit = vi.fn();
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={onEdit} />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: EDIT_BUTTON_NAME })
+    );
+
+    expect(onEdit).toHaveBeenCalledWith("item-1");
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onEdit when Enter is pressed on the edit button", async () => {
+    const onEdit = vi.fn();
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={onEdit} />);
+
+    const editButton = screen.getByRole("button", { name: EDIT_BUTTON_NAME });
+    editButton.focus();
+    await userEvent.keyboard("{Enter}");
+
+    expect(onEdit).toHaveBeenCalledWith("item-1");
+  });
+
+  it("calls onEdit when Space is pressed on the edit button", async () => {
+    const onEdit = vi.fn();
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={onEdit} />);
+
+    const editButton = screen.getByRole("button", { name: EDIT_BUTTON_NAME });
+    editButton.focus();
+    await userEvent.keyboard(" ");
+
+    // Native button activation on Space — should trigger onEdit. Browsers
+    // also call preventDefault internally so the page does not scroll.
+    expect(onEdit).toHaveBeenCalledWith("item-1");
+  });
+
+  it("does not call onEdit when the menu trigger is clicked", async () => {
+    const onEdit = vi.fn();
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={onEdit} />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: MENU_TRIGGER_NAME })
+    );
+
+    // Edit and trigger are siblings — clicking the trigger never bubbles
+    // through the edit button, so onEdit must not be called.
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it("calls onEdit when the dropdown Edit item is clicked", async () => {
+    const onEdit = vi.fn();
+    render(<ItemCard item={makeItem()} onDelete={vi.fn()} onEdit={onEdit} />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: EDIT_MENU_ITEM_NAME })
+    );
+
+    expect(onEdit).toHaveBeenCalledWith("item-1");
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDelete when the dropdown Delete item is clicked", async () => {
+    const onDelete = vi.fn();
+    render(<ItemCard item={makeItem()} onDelete={onDelete} onEdit={vi.fn()} />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: DELETE_MENU_ITEM_NAME })
+    );
+
+    expect(onDelete).toHaveBeenCalledWith("item-1");
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ItemCard tag overflow", () => {
+  it("renders no tag list when there are 0 tags", () => {
+    render(
+      <ItemCard
+        item={makeItem({ tags: [] })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
+  it("renders all tags and no overflow badge when count equals MAX_VISIBLE_TAGS", () => {
+    const tags = [
+      makeTag({ id: "t1" as TagId, name: "Tag1" }),
+      makeTag({ id: "t2" as TagId, name: "Tag2" }),
+      makeTag({ id: "t3" as TagId, name: "Tag3" }),
+    ];
+    render(
+      <ItemCard item={makeItem({ tags })} onDelete={vi.fn()} onEdit={vi.fn()} />
+    );
+
+    expect(screen.getByText("Tag1")).toBeInTheDocument();
+    expect(screen.getByText("Tag2")).toBeInTheDocument();
+    expect(screen.getByText("Tag3")).toBeInTheDocument();
+    expect(screen.queryByText(OVERFLOW_BADGE_RE)).not.toBeInTheDocument();
+  });
+
+  it("renders MAX_VISIBLE_TAGS badges plus +1 when 4 tags are provided", () => {
+    const tags = Array.from({ length: 4 }, (_, i) =>
+      makeTag({ id: `t${i + 1}` as TagId, name: `Tag${i + 1}` })
+    );
+    render(
+      <ItemCard item={makeItem({ tags })} onDelete={vi.fn()} onEdit={vi.fn()} />
+    );
+
+    expect(screen.getByText("Tag1")).toBeInTheDocument();
+    expect(screen.getByText("Tag2")).toBeInTheDocument();
+    expect(screen.getByText("Tag3")).toBeInTheDocument();
+    expect(screen.queryByText("Tag4")).not.toBeInTheDocument();
+    expect(screen.getByText("+1")).toBeInTheDocument();
+  });
+
+  it("renders MAX_VISIBLE_TAGS badges plus +7 when 10 tags are provided", () => {
+    const tags = Array.from({ length: 10 }, (_, i) =>
+      makeTag({ id: `t${i + 1}` as TagId, name: `Tag${i + 1}` })
+    );
+    render(
+      <ItemCard item={makeItem({ tags })} onDelete={vi.fn()} onEdit={vi.fn()} />
+    );
+
+    expect(screen.getByText("Tag1")).toBeInTheDocument();
+    expect(screen.getByText("Tag3")).toBeInTheDocument();
+    expect(screen.queryByText("Tag4")).not.toBeInTheDocument();
+    expect(screen.getByText("+7")).toBeInTheDocument();
+  });
+});
+
+describe("ItemCard tag color rendering", () => {
+  it("applies inline background style when tag color is a valid 6-digit hex", () => {
+    const tags = [
+      makeTag({ id: "t-red" as TagId, name: "Red", color: "#ff0000" }),
+    ];
+    render(
+      <ItemCard item={makeItem({ tags })} onDelete={vi.fn()} onEdit={vi.fn()} />
+    );
+
+    const badge = screen.getByText("Red");
+    expect(badge).toHaveStyle({ backgroundColor: "rgb(255, 0, 0)" });
+    // Pure red has luminance ~0.21 which makes black slightly more
+    // contrasting than white per the WCAG ratio — assert against the
+    // current algorithm's output rather than perceived "best".
+    expect(badge).toHaveStyle({ color: "rgb(0, 0, 0)" });
+  });
+
+  it("accepts uppercase hex (case-insensitive regex)", () => {
+    const tags = [
+      makeTag({ id: "t-up" as TagId, name: "Upper", color: "#FF0000" }),
+    ];
+    render(
+      <ItemCard item={makeItem({ tags })} onDelete={vi.fn()} onEdit={vi.fn()} />
+    );
+
+    const badge = screen.getByText("Upper");
+    expect(badge).toHaveStyle({ backgroundColor: "rgb(255, 0, 0)" });
+  });
+
+  it("falls back to plain badge when hex is missing # prefix", () => {
+    const tags = [
+      makeTag({ id: "t-bad" as TagId, name: "Bad", color: "ff0000" }),
+    ];
+    render(
+      <ItemCard item={makeItem({ tags })} onDelete={vi.fn()} onEdit={vi.fn()} />
+    );
+
+    const badge = screen.getByText("Bad");
+    expect(badge).not.toHaveStyle({ backgroundColor: "rgb(255, 0, 0)" });
+  });
+
+  it("falls back to plain badge for 3-digit shorthand", () => {
+    const tags = [
+      makeTag({ id: "t-3" as TagId, name: "Short", color: "#fff" }),
+    ];
+    render(
+      <ItemCard item={makeItem({ tags })} onDelete={vi.fn()} onEdit={vi.fn()} />
+    );
+
+    const badge = screen.getByText("Short");
+    expect(badge).not.toHaveStyle({ backgroundColor: "rgb(255, 255, 255)" });
+  });
+
+  it("falls back to plain badge for 8-digit hex with alpha", () => {
+    const tags = [
+      makeTag({ id: "t-a" as TagId, name: "Alpha", color: "#ff0000ff" }),
+    ];
+    render(
+      <ItemCard item={makeItem({ tags })} onDelete={vi.fn()} onEdit={vi.fn()} />
+    );
+
+    const badge = screen.getByText("Alpha");
+    expect(badge).not.toHaveStyle({ backgroundColor: "rgb(255, 0, 0)" });
+  });
+});
+
+describe("ItemCard brand/price/quantity row", () => {
+  it("does not render the row when all three are absent and quantity is 1", () => {
+    render(
+      <ItemCard
+        item={makeItem({ brand: null, purchasePrice: null, quantity: 1 })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    // None of the constituent text appears.
+    expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
+    expect(screen.queryByText(QUANTITY_LABEL_RE)).not.toBeInTheDocument();
+  });
+
+  it("renders only the brand when only brand is present", () => {
+    render(
+      <ItemCard
+        item={makeItem({ brand: "Bicycle" })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Bicycle")).toBeInTheDocument();
+  });
+
+  it("renders price formatted to 2 decimal places when only price is present", () => {
+    render(
+      <ItemCard
+        item={makeItem({ purchasePrice: 29.9 })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.getByText("$29.90")).toBeInTheDocument();
+  });
+
+  it("renders price of 0 (truthy condition uses !== null)", () => {
+    render(
+      <ItemCard
+        item={makeItem({ purchasePrice: 0 })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.getByText("$0.00")).toBeInTheDocument();
+  });
+
+  it("renders quantity label only when quantity > 1", () => {
+    render(
+      <ItemCard
+        item={makeItem({ quantity: 5 })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByText("collect.quantityLabel (count: 5)")
+    ).toBeInTheDocument();
+  });
+
+  it("does not render quantity label when quantity is exactly 1", () => {
+    render(
+      <ItemCard
+        item={makeItem({ quantity: 1, brand: "Bicycle" })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    // Brand renders, but quantity does not.
+    expect(screen.getByText("Bicycle")).toBeInTheDocument();
+    expect(
+      screen.queryByText("collect.quantityLabel (count: 1)")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders all three fields together when all are set", () => {
+    render(
+      <ItemCard
+        item={makeItem({ brand: "Bicycle", purchasePrice: 12.5, quantity: 3 })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Bicycle")).toBeInTheDocument();
+    expect(screen.getByText("$12.50")).toBeInTheDocument();
+    expect(
+      screen.getByText("collect.quantityLabel (count: 3)")
+    ).toBeInTheDocument();
+  });
+});
+
+describe("ItemCard linked tricks", () => {
+  it("does not render the linked-tricks row when no tricks are linked", () => {
+    render(
+      <ItemCard
+        item={makeItem({ tricks: [] })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(LINKED_TRICKS_RE)).not.toBeInTheDocument();
+  });
+
+  it("renders the linked-tricks count when tricks are linked", () => {
+    render(
+      <ItemCard
+        item={makeItem({
+          tricks: [
+            { id: "trick-1" as TrickId, name: "T1" },
+            { id: "trick-2" as TrickId, name: "T2" },
+          ],
+        })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByText("collect.linkedTricksCount (count: 2)")
+    ).toBeInTheDocument();
+  });
+});
+
+describe("ItemCard condition", () => {
+  it("renders the condition badge when condition is set", () => {
+    render(
+      <ItemCard
+        item={makeItem({ condition: "good" })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.getByText("collect.condition.good")).toBeInTheDocument();
+  });
+
+  it("does not render the condition badge when condition is null", () => {
+    render(
+      <ItemCard
+        item={makeItem({ condition: null })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(CONDITION_RE)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/collect/components/item-card.tsx
+++ b/src/features/collect/components/item-card.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { Edit, Link2, MoreHorizontal, Trash2 } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { ItemId } from "@/db/types";
+import type { ParsedTag } from "@/features/repertoire/types";
+import type { ItemWithRelations } from "../types";
+import { ItemConditionBadge } from "./item-condition-badge";
+import { ItemTypeBadge } from "./item-type-badge";
+
+interface ItemCardProps {
+  item: ItemWithRelations;
+  onDelete: (id: ItemId) => void;
+  onEdit: (id: ItemId) => void;
+}
+
+export const MAX_VISIBLE_TAGS = 3;
+
+export function ItemCard({
+  item,
+  onEdit,
+  onDelete,
+}: ItemCardProps): React.ReactElement {
+  const t = useTranslations("collect");
+  const locale = useLocale();
+
+  function handleEditClick(): void {
+    onEdit(item.id);
+  }
+
+  // Intl currency formatting so screen readers announce "twelve dollars and
+  // fifty cents" rather than the glyph. Currency defaults to USD — update when
+  // per-user currency is introduced.
+  const formattedPrice =
+    item.purchasePrice === null
+      ? null
+      : new Intl.NumberFormat(locale, {
+          style: "currency",
+          currency: "USD",
+        }).format(item.purchasePrice);
+
+  const visibleTags = item.tags.slice(0, MAX_VISIBLE_TAGS);
+  const hiddenTagCount = item.tags.length - MAX_VISIBLE_TAGS;
+
+  return (
+    // The Card is a visual container only — interactivity lives on the inner
+    // edit button and the dropdown trigger. Nesting interactive elements
+    // inside a role="button" Card is invalid HTML and confuses screen readers,
+    // so we avoid it by giving each action its own real <button>.
+    <Card className="hover:border-ring motion-safe:transition-colors">
+      <CardHeader className="relative">
+        <div className="flex items-start justify-between gap-2">
+          {/* Phrasing-only inside <button> per HTML spec — use <span> with heading styles.
+              The name span gets role="heading" aria-level={3} so screen-reader H-key
+              navigation still works and the document outline stays intact, matching
+              the semantic <h3> used in trick-card.tsx. */}
+          <button
+            aria-label={`${t("edit")}: ${item.name}`}
+            className="min-w-0 flex-1 cursor-pointer rounded-sm text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            onClick={handleEditClick}
+            type="button"
+          >
+            {/* biome-ignore lint/a11y/useSemanticElements: <h3> is phrasing-content-only and invalid inside <button>; the ARIA role preserves H-key nav without breaking HTML. */}
+            <span
+              aria-level={3}
+              className="block truncate font-semibold"
+              role="heading"
+            >
+              {item.name}
+            </span>
+            {item.description ? (
+              <span className="mt-1 line-clamp-2 block font-normal text-muted-foreground text-sm">
+                {item.description}
+              </span>
+            ) : null}
+          </button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                aria-label={t("cardActions")}
+                className="inline-flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 motion-safe:transition-colors"
+                type="button"
+              >
+                <MoreHorizontal aria-hidden="true" className="size-5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onEdit(item.id)}>
+                <Edit aria-hidden="true" />
+                {t("edit")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onDelete(item.id)}
+                variant="destructive"
+              >
+                <Trash2 aria-hidden="true" />
+                {t("delete")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-3">
+        {/* Type and condition badges */}
+        <div className="flex flex-wrap items-center gap-1.5">
+          <ItemTypeBadge type={item.type} />
+          {item.condition !== null && (
+            <ItemConditionBadge condition={item.condition} />
+          )}
+        </div>
+
+        {/* Brand, price, quantity */}
+        {(item.brand || item.purchasePrice !== null || item.quantity > 1) && (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground text-sm">
+            {item.brand && <span>{item.brand}</span>}
+            {formattedPrice !== null && (
+              <span>
+                <span className="sr-only">{t("field.purchasePrice")}: </span>
+                {formattedPrice}
+              </span>
+            )}
+            {item.quantity > 1 && (
+              <span>{t("quantityLabel", { count: item.quantity })}</span>
+            )}
+          </div>
+        )}
+
+        {/* Linked tricks count */}
+        {item.tricks.length > 0 && (
+          <div className="flex items-center gap-1.5 text-muted-foreground text-sm">
+            <Link2 aria-hidden="true" className="size-3.5" />
+            <span>{t("linkedTricksCount", { count: item.tricks.length })}</span>
+          </div>
+        )}
+
+        {/* Tags */}
+        {item.tags.length > 0 && (
+          <ul
+            aria-label={t("field.tags")}
+            className="flex flex-wrap items-center gap-1.5"
+          >
+            {visibleTags.map((tag) => (
+              <li key={tag.id}>
+                <TagBadge tag={tag} />
+              </li>
+            ))}
+            {hiddenTagCount > 0 && (
+              <li>
+                <Badge variant="outline">+{hiddenTagCount}</Badge>
+              </li>
+            )}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tag badge with optional color
+// ---------------------------------------------------------------------------
+
+export const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i;
+
+function TagBadge({ tag }: { tag: ParsedTag }): React.ReactElement {
+  if (tag.color && HEX_COLOR_RE.test(tag.color)) {
+    return (
+      <Badge
+        className="border-transparent"
+        style={{
+          backgroundColor: tag.color,
+          color: getContrastColor(tag.color),
+        }}
+      >
+        {tag.name}
+      </Badge>
+    );
+  }
+
+  return <Badge variant="secondary">{tag.name}</Badge>;
+}
+
+/**
+ * Returns black or white depending on which provides better contrast
+ * against the given hex background color.
+ */
+export function getContrastColor(hex: string): string {
+  const cleaned = hex.replace("#", "");
+  const r = Number.parseInt(cleaned.slice(0, 2), 16) / 255;
+  const g = Number.parseInt(cleaned.slice(2, 4), 16) / 255;
+  const b = Number.parseInt(cleaned.slice(4, 6), 16) / 255;
+
+  // WCAG relative luminance with sRGB gamma correction
+  const toLinear = (c: number): number =>
+    c <= 0.039_28 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  const luminance =
+    0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+
+  // WCAG contrast ratio: (L1 + 0.05) / (L2 + 0.05) where L1 > L2
+  const contrastWithWhite = (1 + 0.05) / (luminance + 0.05);
+  const contrastWithBlack = (luminance + 0.05) / (0 + 0.05);
+  return contrastWithBlack >= contrastWithWhite ? "#000000" : "#ffffff";
+}

--- a/src/features/collect/components/item-condition-badge.tsx
+++ b/src/features/collect/components/item-condition-badge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import { CONDITION_CONFIG, type ItemCondition } from "../constants";
+
+interface ItemConditionBadgeProps {
+  condition: ItemCondition;
+}
+
+export function ItemConditionBadge({
+  condition,
+}: ItemConditionBadgeProps): React.ReactElement {
+  const t = useTranslations("collect");
+  const config = CONDITION_CONFIG[condition];
+  const needsAttention = condition === "needs_repair";
+
+  // Adds a glyph so color-blind users and AT consumers can distinguish the
+  // warning state without relying on the destructive (red) variant alone.
+  return (
+    <Badge variant={config.variant}>
+      {needsAttention ? (
+        <AlertTriangle aria-hidden="true" className="size-3.5" />
+      ) : null}
+      {t(config.label)}
+    </Badge>
+  );
+}

--- a/src/features/collect/components/item-delete-dialog.test.tsx
+++ b/src/features/collect/components/item-delete-dialog.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ItemDeleteDialog } from "./item-delete-dialog";
+
+describe("ItemDeleteDialog", () => {
+  it("renders the title with the item name when open", () => {
+    render(
+      <ItemDeleteDialog
+        itemName="Invisible Deck"
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        open={true}
+      />
+    );
+    // The next-intl mock formats interpolated values as "key (param: value)".
+    expect(
+      screen.getByText("collect.deleteConfirmTitle (name: Invisible Deck)")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the description when open", () => {
+    render(
+      <ItemDeleteDialog
+        itemName="Invisible Deck"
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        open={true}
+      />
+    );
+    expect(
+      screen.getByText("collect.deleteConfirmDescription")
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to an empty name when itemName is null without crashing", () => {
+    // Exercises the `itemName ?? ""` guard — passing null directly to
+    // next-intl's t() with a `{name}` placeholder would otherwise throw.
+    render(
+      <ItemDeleteDialog
+        itemName={null}
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        open={true}
+      />
+    );
+    expect(
+      screen.getByText("collect.deleteConfirmTitle (name: )")
+    ).toBeInTheDocument();
+  });
+
+  it("does not render dialog content when closed", () => {
+    render(
+      <ItemDeleteDialog
+        itemName="Invisible Deck"
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        open={false}
+      />
+    );
+    expect(
+      screen.queryByText("collect.deleteConfirmDescription")
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onConfirm when the destructive action button is clicked", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <ItemDeleteDialog
+        itemName="Invisible Deck"
+        onConfirm={onConfirm}
+        onOpenChange={vi.fn()}
+        open={true}
+      />
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "collect.deleteConfirm" })
+    );
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onOpenChange with false when the cancel button is clicked", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ItemDeleteDialog
+        itemName="Invisible Deck"
+        onConfirm={vi.fn()}
+        onOpenChange={onOpenChange}
+        open={true}
+      />
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "collect.cancel" })
+    );
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/features/collect/components/item-delete-dialog.tsx
+++ b/src/features/collect/components/item-delete-dialog.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export interface ItemDeleteDialogProps {
+  itemName: string | null;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+
+export function ItemDeleteDialog({
+  itemName,
+  open,
+  onOpenChange,
+  onConfirm,
+}: ItemDeleteDialogProps): React.ReactElement {
+  const t = useTranslations("collect");
+
+  return (
+    <AlertDialog onOpenChange={onOpenChange} open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("deleteConfirmTitle", { name: itemName ?? "" })}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("deleteConfirmDescription")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} variant="destructive">
+            {t("deleteConfirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/features/collect/components/item-empty-state.tsx
+++ b/src/features/collect/components/item-empty-state.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Package } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+
+interface ItemEmptyStateProps {
+  onAddItem: () => void;
+}
+
+export function ItemEmptyState({
+  onAddItem,
+}: ItemEmptyStateProps): React.ReactElement {
+  const t = useTranslations("collect");
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
+      <div className="flex size-16 items-center justify-center rounded-2xl bg-muted">
+        <Package aria-hidden="true" className="size-8 text-muted-foreground" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <h2 className="font-semibold text-2xl tracking-tight">
+          {t("emptyTitle")}
+        </h2>
+        <p className="max-w-md text-muted-foreground">
+          {t("emptyDescription")}
+        </p>
+      </div>
+      <Button onClick={onAddItem}>{t("addItem")}</Button>
+    </div>
+  );
+}

--- a/src/features/collect/components/item-filters.test.tsx
+++ b/src/features/collect/components/item-filters.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ITEM_CONDITIONS, ITEM_SORTS, ITEM_TYPES } from "../constants";
+import { ItemFilters, type ItemFiltersProps } from "./item-filters";
+
+// Mock Radix Select to expose onValueChange as a testable native select
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    children,
+    onValueChange,
+    value,
+  }: {
+    children: React.ReactNode;
+    onValueChange?: (value: string) => void;
+    value?: string;
+  }) => (
+    <div>
+      <select
+        data-select-value={value}
+        onChange={(e) => onValueChange?.(e.target.value)}
+        value={value}
+      >
+        {children}
+      </select>
+    </div>
+  ),
+  SelectTrigger: ({
+    children,
+    "aria-label": ariaLabel,
+  }: {
+    children: React.ReactNode;
+    "aria-label"?: string;
+  }) => <fieldset aria-label={ariaLabel}>{children}</fieldset>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: string;
+  }) => <option value={value}>{children}</option>,
+}));
+
+function defaultProps(
+  overrides: Partial<ItemFiltersProps> = {}
+): ItemFiltersProps {
+  return {
+    condition: null,
+    onConditionChange: vi.fn(),
+    onSearchChange: vi.fn(),
+    onSortChange: vi.fn(),
+    onTypeChange: vi.fn(),
+    search: "",
+    sort: "newest",
+    type: null,
+    ...overrides,
+  };
+}
+
+describe("ItemFilters", () => {
+  it("type select defaults to the __all__ sentinel when type prop is null", () => {
+    render(<ItemFilters {...defaultProps({ type: null })} />);
+    const selects = screen.getAllByRole("combobox");
+    expect(selects[0]).toHaveValue("__all__");
+  });
+
+  it("calls onTypeChange with null when __all__ is selected", async () => {
+    const onTypeChange = vi.fn();
+    render(<ItemFilters {...defaultProps({ type: "prop", onTypeChange })} />);
+    const selects = screen.getAllByRole("combobox");
+    await userEvent.selectOptions(selects[0] as HTMLElement, "__all__");
+    expect(onTypeChange).toHaveBeenCalledWith(null);
+    expect(onTypeChange).not.toHaveBeenCalledWith("__all__");
+  });
+
+  it("calls onTypeChange with the typed value when a real type is selected", async () => {
+    const onTypeChange = vi.fn();
+    render(<ItemFilters {...defaultProps({ onTypeChange })} />);
+    const selects = screen.getAllByRole("combobox");
+    await userEvent.selectOptions(selects[0] as HTMLElement, "book");
+    expect(onTypeChange).toHaveBeenCalledWith("book");
+  });
+
+  it("calls onConditionChange with null when __all__ is selected", async () => {
+    const onConditionChange = vi.fn();
+    render(
+      <ItemFilters {...defaultProps({ condition: "new", onConditionChange })} />
+    );
+    const selects = screen.getAllByRole("combobox");
+    await userEvent.selectOptions(selects[1] as HTMLElement, "__all__");
+    expect(onConditionChange).toHaveBeenCalledWith(null);
+    expect(onConditionChange).not.toHaveBeenCalledWith("__all__");
+  });
+
+  it("calls onConditionChange with the typed value when a real condition is selected", async () => {
+    const onConditionChange = vi.fn();
+    render(<ItemFilters {...defaultProps({ onConditionChange })} />);
+    const selects = screen.getAllByRole("combobox");
+    await userEvent.selectOptions(selects[1] as HTMLElement, "good");
+    expect(onConditionChange).toHaveBeenCalledWith("good");
+  });
+
+  it("renders a SelectItem for every ITEM_TYPES value", () => {
+    render(<ItemFilters {...defaultProps()} />);
+    for (const itemType of ITEM_TYPES) {
+      expect(
+        screen.getByRole("option", { name: `collect.type.${itemType}` })
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("renders a SelectItem for every ITEM_CONDITIONS value", () => {
+    render(<ItemFilters {...defaultProps()} />);
+    for (const cond of ITEM_CONDITIONS) {
+      expect(
+        screen.getByRole("option", { name: `collect.condition.${cond}` })
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("renders sort SelectItems whose values match ITEM_SORTS exactly", () => {
+    render(<ItemFilters {...defaultProps()} />);
+    const selects = screen.getAllByRole("combobox");
+    const sortSelect = selects[2] as HTMLSelectElement;
+    const sortValues = Array.from(sortSelect.options).map(
+      (option) => option.value
+    );
+    expect(sortValues).toEqual([...ITEM_SORTS]);
+  });
+
+  it("calls onSearchChange with the raw string value (no internal debounce)", async () => {
+    const onSearchChange = vi.fn();
+    render(<ItemFilters {...defaultProps({ onSearchChange })} />);
+    const input = screen.getByRole("searchbox", {
+      name: "collect.searchPlaceholder",
+    });
+    await userEvent.type(input, "a");
+    // Single keystroke fires exactly one call with the raw string — no debounce at this layer.
+    expect(onSearchChange).toHaveBeenCalledTimes(1);
+    expect(onSearchChange).toHaveBeenCalledWith("a");
+  });
+});

--- a/src/features/collect/components/item-filters.tsx
+++ b/src/features/collect/components/item-filters.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  CONDITION_CONFIG,
+  type FilterSortValue,
+  ITEM_CONDITIONS,
+  ITEM_SORTS,
+  ITEM_TYPES,
+  type ItemCondition,
+  type ItemType,
+  isFilterSortValue,
+  isItemCondition,
+  isItemType,
+  TYPE_CONFIG,
+} from "../constants";
+
+/** Sentinel value representing "all" (no filter). */
+const ALL = "__all__";
+
+const SORT_LABEL_KEYS: Record<FilterSortValue, string> = {
+  newest: "sort.newest",
+  oldest: "sort.oldest",
+  "name-asc": "sort.nameAsc",
+  "name-desc": "sort.nameDesc",
+  "price-asc": "sort.priceAsc",
+  "price-desc": "sort.priceDesc",
+  "type-asc": "sort.type",
+};
+
+export interface ItemFiltersProps {
+  condition: ItemCondition | null;
+  onConditionChange: (value: ItemCondition | null) => void;
+  onSearchChange: (value: string) => void;
+  onSortChange: (value: FilterSortValue) => void;
+  onTypeChange: (value: ItemType | null) => void;
+  search: string;
+  sort: FilterSortValue;
+  type: ItemType | null;
+}
+
+export function ItemFilters({
+  search,
+  onSearchChange,
+  type,
+  onTypeChange,
+  condition,
+  onConditionChange,
+  sort,
+  onSortChange,
+}: ItemFiltersProps): React.ReactElement {
+  const t = useTranslations("collect");
+
+  function handleTypeChange(value: string): void {
+    if (value === ALL) {
+      onTypeChange(null);
+      return;
+    }
+    if (isItemType(value)) {
+      onTypeChange(value);
+    }
+  }
+
+  function handleConditionChange(value: string): void {
+    if (value === ALL) {
+      onConditionChange(null);
+      return;
+    }
+    if (isItemCondition(value)) {
+      onConditionChange(value);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+      {/* Search input */}
+      <div className="relative w-full sm:flex-1">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          aria-label={t("searchPlaceholder")}
+          className="pl-9"
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder={t("searchPlaceholder")}
+          type="search"
+          value={search}
+        />
+      </div>
+
+      {/* Filter row */}
+      <div className="flex flex-wrap items-center gap-2">
+        {/* Type filter */}
+        <Select onValueChange={handleTypeChange} value={type ?? ALL}>
+          <SelectTrigger
+            aria-label={t("filterByType")}
+            className="w-full min-w-[140px] sm:w-auto"
+          >
+            <SelectValue placeholder={t("allTypes")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>{t("allTypes")}</SelectItem>
+            {ITEM_TYPES.map((itemType) => (
+              <SelectItem key={itemType} value={itemType}>
+                {t(TYPE_CONFIG[itemType].label)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* Condition filter */}
+        <Select onValueChange={handleConditionChange} value={condition ?? ALL}>
+          <SelectTrigger
+            aria-label={t("filterByCondition")}
+            className="w-full min-w-[140px] sm:w-auto"
+          >
+            <SelectValue placeholder={t("allConditions")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>{t("allConditions")}</SelectItem>
+            {ITEM_CONDITIONS.map((cond) => (
+              <SelectItem key={cond} value={cond}>
+                {t(CONDITION_CONFIG[cond].label)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* Sort */}
+        <Select
+          onValueChange={(value) => {
+            if (isFilterSortValue(value)) {
+              onSortChange(value);
+            }
+          }}
+          value={sort}
+        >
+          <SelectTrigger
+            aria-label={t("sortBy")}
+            className="w-full min-w-[140px] sm:w-auto"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ITEM_SORTS.map((value) => (
+              <SelectItem key={value} value={value}>
+                {t(SORT_LABEL_KEYS[value])}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/src/features/collect/components/item-form-sheet.test.tsx
+++ b/src/features/collect/components/item-form-sheet.test.tsx
@@ -1,0 +1,581 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ItemId, TagId } from "@/db/types";
+import type { ParsedItem } from "../types";
+import { ItemFormSheet, type ItemFormSheetProps } from "./item-form-sheet";
+
+// Capture the props passed to ItemForm so we can assert on toFormDefaults output
+const capturedItemFormProps = vi.fn();
+const capturedSheetOnOpenChange = vi.fn();
+// Holds the AlertDialog's onOpenChange so the mocked AlertDialogCancel can
+// invoke it (mirrors Radix's behavior where Cancel closes the dialog).
+const capturedAlertDialogOnOpenChange = vi.fn();
+
+vi.mock("./item-form", () => ({
+  ItemForm: (props: Record<string, unknown>) => {
+    capturedItemFormProps(props);
+    return <div data-testid="item-form" />;
+  },
+}));
+
+// Sheet/AlertDialog mocks: Radix Dialog renders into a portal which jsdom
+// handles inconsistently for our use case (we need to assert on the Sheet's
+// onOpenChange callback firing in response to escape/click-outside without
+// rendering the full Radix overlay tree). The capturedSheetOnOpenChange
+// pattern lets tests simulate Radix invoking onOpenChange directly.
+// If we ever migrate to the trick-form-sheet pattern (real Radix +
+// flushRadixTimers + pointerDown overlay), this mock can be removed.
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: ReactNode;
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
+    if (onOpenChange) {
+      capturedSheetOnOpenChange.mockImplementation(onOpenChange);
+    }
+    return open ? <div data-testid="sheet">{children}</div> : null;
+  },
+  SheetContent: ({
+    children,
+    onEscapeKeyDown,
+    onInteractOutside,
+  }: {
+    children: ReactNode;
+    onEscapeKeyDown?: (e: Event) => void;
+    onInteractOutside?: (e: Event) => void;
+  }) => (
+    <div
+      data-escape={onEscapeKeyDown ? "bound" : undefined}
+      data-interact-outside={onInteractOutside ? "bound" : undefined}
+      data-testid="sheet-content"
+    >
+      {children}
+    </div>
+  ),
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetDescription: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SheetFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+// AlertDialog mock: the real Radix AlertDialog handles its own open state via
+// onOpenChange when the user clicks the AlertDialogCancel — we approximate by
+// capturing the AlertDialog's onOpenChange in a module-level fn and invoking
+// it from the AlertDialogCancel mock. This lets tests verify that clicking
+// Cancel closes the dialog WITHOUT invoking the parent's onOpenChange handler.
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: ReactNode;
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
+    if (onOpenChange) {
+      capturedAlertDialogOnOpenChange.mockImplementation(onOpenChange);
+    }
+    return open ? <div data-testid="discard-dialog">{children}</div> : null;
+  },
+  AlertDialogContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogCancel: ({ children }: { children: ReactNode }) => (
+    <button
+      data-testid="discard-cancel"
+      onClick={() => capturedAlertDialogOnOpenChange(false)}
+      type="button"
+    >
+      {children}
+    </button>
+  ),
+  AlertDialogAction: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button data-testid="discard-confirm" onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    type,
+    ...rest
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    type?: string;
+    form?: string;
+    variant?: string;
+  }) => (
+    <button
+      data-variant={rest.variant}
+      onClick={onClick}
+      type={type as "button" | "submit"}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+function defaultProps(
+  overrides?: Partial<ItemFormSheetProps>
+): ItemFormSheetProps {
+  return {
+    availableTags: [],
+    availableTricks: [],
+    item: null,
+    onCreateTag: vi.fn().mockResolvedValue("tag-1" as TagId),
+    onOpenChange: vi.fn(),
+    onSubmit: vi.fn(),
+    onToggleTag: vi.fn(),
+    onToggleTrick: vi.fn(),
+    open: true,
+    selectedTagIds: [],
+    selectedTrickIds: [],
+    userBrands: [],
+    userLocations: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/** Extract the defaultValues prop passed to the mocked ItemForm. */
+function getFormDefaults(): Record<string, unknown> | undefined {
+  const call = capturedItemFormProps.mock.calls[0] as
+    | [Record<string, unknown>]
+    | undefined;
+  return call?.[0]?.defaultValues as Record<string, unknown> | undefined;
+}
+
+describe("toFormDefaults (via ItemFormSheet)", () => {
+  it("converts a fully populated ParsedItem to form defaults", () => {
+    const item: ParsedItem = {
+      id: "item-full" as ItemId,
+      name: "Invisible Deck",
+      type: "deck",
+      description: "A classic mentalism prop",
+      brand: "Bicycle",
+      condition: "new",
+      location: "Close-up case",
+      notes: "Keep dry",
+      purchaseDate: "2025-01-15",
+      purchasePrice: 29.99,
+      quantity: 2,
+      creator: "Bob Ostin",
+      url: "https://example.com/deck",
+      createdAt: "2025-01-15T12:00:00.000Z",
+      updatedAt: "2025-01-15T12:00:00.000Z",
+    };
+
+    render(<ItemFormSheet {...defaultProps({ item })} />);
+
+    expect(capturedItemFormProps).toHaveBeenCalled();
+    const defaultValues = getFormDefaults();
+    expect(defaultValues).toEqual({
+      brand: "Bicycle",
+      condition: "new",
+      creator: "Bob Ostin",
+      description: "A classic mentalism prop",
+      location: "Close-up case",
+      name: "Invisible Deck",
+      notes: "Keep dry",
+      purchaseDate: "2025-01-15",
+      purchasePrice: "29.99",
+      quantity: 2,
+      type: "deck",
+      url: "https://example.com/deck",
+    });
+  });
+
+  it("converts a minimal ParsedItem with null optionals to empty strings", () => {
+    const item: ParsedItem = {
+      id: "item-1" as ParsedItem["id"],
+      name: "Simple Prop",
+      type: "prop",
+      description: null,
+      brand: null,
+      condition: null,
+      location: null,
+      notes: null,
+      purchaseDate: null,
+      purchasePrice: null,
+      quantity: 1,
+      creator: null,
+      url: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    };
+
+    render(<ItemFormSheet {...defaultProps({ item })} />);
+
+    const defaultValues = getFormDefaults();
+    expect(defaultValues).toEqual({
+      brand: "",
+      condition: null,
+      creator: "",
+      description: "",
+      location: "",
+      name: "Simple Prop",
+      notes: "",
+      purchaseDate: "",
+      purchasePrice: "",
+      quantity: 1,
+      type: "prop",
+      url: "",
+    });
+  });
+
+  it("converts purchasePrice of 0 to the string '0'", () => {
+    const item: ParsedItem = {
+      id: "item-2" as ParsedItem["id"],
+      name: "Free Sample",
+      type: "prop",
+      description: null,
+      brand: null,
+      condition: "good",
+      location: null,
+      notes: null,
+      purchaseDate: null,
+      purchasePrice: 0,
+      quantity: 1,
+      creator: null,
+      url: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    };
+
+    render(<ItemFormSheet {...defaultProps({ item })} />);
+
+    const defaultValues = getFormDefaults();
+    expect(defaultValues?.purchasePrice).toBe("0");
+  });
+
+  it("passes undefined defaultValues when item is null (create mode)", () => {
+    render(<ItemFormSheet {...defaultProps({ item: null })} />);
+
+    const defaultValues = getFormDefaults();
+    expect(defaultValues).toBeUndefined();
+  });
+
+  it("converts empty-string optional fields from ParsedItem", () => {
+    const item: ParsedItem = {
+      id: "item-3" as ParsedItem["id"],
+      name: "Blank Fields",
+      type: "book",
+      description: "",
+      brand: "",
+      condition: "worn",
+      location: "",
+      notes: "",
+      purchaseDate: "",
+      purchasePrice: null,
+      quantity: 0,
+      creator: "",
+      url: "",
+      createdAt: "2025-02-01T00:00:00.000Z",
+      updatedAt: "2025-02-01T00:00:00.000Z",
+    };
+
+    render(<ItemFormSheet {...defaultProps({ item })} />);
+
+    const defaultValues = getFormDefaults();
+    expect(defaultValues?.description).toBe("");
+    expect(defaultValues?.brand).toBe("");
+    expect(defaultValues?.quantity).toBe(0);
+    expect(defaultValues?.purchasePrice).toBe("");
+  });
+});
+
+describe("ItemFormSheet rendering", () => {
+  it("does not render when open is false", () => {
+    render(<ItemFormSheet {...defaultProps({ open: false })} />);
+
+    expect(screen.queryByTestId("sheet")).not.toBeInTheDocument();
+  });
+
+  it("renders the sheet when open is true", () => {
+    render(<ItemFormSheet {...defaultProps({ open: true })} />);
+
+    expect(screen.getByTestId("sheet")).toBeInTheDocument();
+    expect(screen.getByTestId("item-form")).toBeInTheDocument();
+  });
+
+  it("shows 'add' title when item is null", () => {
+    render(<ItemFormSheet {...defaultProps({ item: null })} />);
+
+    expect(screen.getByText("collect.addItem")).toBeInTheDocument();
+  });
+
+  it("shows 'edit' title when item is provided", () => {
+    const item: ParsedItem = {
+      id: "item-edit" as ParsedItem["id"],
+      name: "Editing",
+      type: "prop",
+      description: null,
+      brand: null,
+      condition: null,
+      location: null,
+      notes: null,
+      purchaseDate: null,
+      purchasePrice: null,
+      quantity: 1,
+      creator: null,
+      url: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    };
+
+    render(<ItemFormSheet {...defaultProps({ item })} />);
+
+    expect(screen.getByText("collect.editItem")).toBeInTheDocument();
+  });
+});
+
+describe("unsaved changes guard", () => {
+  it("calls onOpenChange when cancel is clicked and form is clean", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(<ItemFormSheet {...defaultProps({ onOpenChange })} />);
+
+    const cancelButton = screen.getByText("collect.cancel");
+    await user.click(cancelButton);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows discard dialog when cancel is clicked with dirty tags", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ItemFormSheet {...defaultProps({ onOpenChange, tagsDirty: true })} />
+    );
+
+    const cancelButton = screen.getByText("collect.cancel");
+    await user.click(cancelButton);
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(screen.getByTestId("discard-dialog")).toBeInTheDocument();
+  });
+
+  it("shows discard dialog when cancel is clicked with dirty tricks", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ItemFormSheet {...defaultProps({ onOpenChange, tricksDirty: true })} />
+    );
+
+    const cancelButton = screen.getByText("collect.cancel");
+    await user.click(cancelButton);
+
+    expect(screen.getByTestId("discard-dialog")).toBeInTheDocument();
+  });
+
+  it("closes sheet when discard is confirmed", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ItemFormSheet {...defaultProps({ onOpenChange, tagsDirty: true })} />
+    );
+
+    // Trigger the discard dialog via cancel button
+    await user.click(screen.getByText("collect.cancel"));
+
+    // Confirm discard
+    const discardButton = screen.getByTestId("discard-confirm");
+    await user.click(discardButton);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows discard dialog when Sheet onOpenChange fires while tags are dirty", () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <ItemFormSheet {...defaultProps({ onOpenChange, tagsDirty: true })} />
+    );
+
+    // Simulate Escape key or click-outside — Sheet calls onOpenChange(false)
+    act(() => {
+      capturedSheetOnOpenChange(false);
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(screen.getByTestId("discard-dialog")).toBeInTheDocument();
+  });
+
+  it("shows discard dialog when Sheet onOpenChange fires while tricks are dirty", () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <ItemFormSheet {...defaultProps({ onOpenChange, tricksDirty: true })} />
+    );
+
+    act(() => {
+      capturedSheetOnOpenChange(false);
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(screen.getByTestId("discard-dialog")).toBeInTheDocument();
+  });
+
+  it("calls onOpenChange when Sheet onOpenChange fires while form is clean", () => {
+    const onOpenChange = vi.fn();
+
+    render(<ItemFormSheet {...defaultProps({ onOpenChange })} />);
+
+    act(() => {
+      capturedSheetOnOpenChange(false);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.queryByTestId("discard-dialog")).not.toBeInTheDocument();
+  });
+
+  it("leaves sheet open when AlertDialogCancel inside discard dialog is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ItemFormSheet {...defaultProps({ onOpenChange, tagsDirty: true })} />
+    );
+
+    // Open the discard dialog by clicking the sheet's cancel button
+    await user.click(screen.getByText("collect.cancel"));
+    expect(screen.getByTestId("discard-dialog")).toBeInTheDocument();
+
+    // Click the AlertDialogCancel inside the discard dialog
+    await user.click(screen.getByTestId("discard-cancel"));
+
+    // The parent's onOpenChange must NOT be called with false
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    // The sheet (and its discard dialog) should still be open / not closed via parent
+    expect(screen.getByTestId("sheet")).toBeInTheDocument();
+  });
+});
+
+describe("handleFormSubmit", () => {
+  /** Extract the onSubmit handler the sheet passed to the (mocked) ItemForm. */
+  function getCapturedOnSubmit(): (data: unknown) => Promise<void> {
+    const call = capturedItemFormProps.mock.calls[0] as
+      | [Record<string, unknown>]
+      | undefined;
+    const handler = call?.[0]?.onSubmit;
+    if (typeof handler !== "function") {
+      throw new Error("Expected ItemForm to receive an onSubmit handler");
+    }
+    return handler as (data: unknown) => Promise<void>;
+  }
+
+  it("calls the parent onSubmit with the form data", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<ItemFormSheet {...defaultProps({ onSubmit })} />);
+
+    const handleSubmit = getCapturedOnSubmit();
+    await act(async () => {
+      await handleSubmit({ name: "Test" });
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({ name: "Test" });
+  });
+
+  it("recovers cleanly when onSubmit rejects (no crash, no rethrow)", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // suppress expected error log
+    });
+    const onSubmit = vi.fn().mockRejectedValue(new Error("server down"));
+
+    render(<ItemFormSheet {...defaultProps({ onSubmit })} />);
+
+    const handleSubmit = getCapturedOnSubmit();
+    // Must not throw — handleFormSubmit catches internally
+    await act(async () => {
+      await expect(handleSubmit({ name: "Test" })).resolves.toBeUndefined();
+    });
+
+    // Sheet remains rendered (open)
+    expect(screen.getByTestId("sheet")).toBeInTheDocument();
+    // Save button is no longer disabled (isSubmitting reset in finally)
+    const saveButton = screen.getByText("collect.save");
+    expect(saveButton).not.toBeDisabled();
+    // Defensive log fired
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("clears the local dirty mirror after a successful submit", async () => {
+    const onOpenChange = vi.fn();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(<ItemFormSheet {...defaultProps({ onOpenChange, onSubmit })} />);
+
+    // Simulate the form going dirty, then submitting successfully
+    const propsBeforeSubmit = capturedItemFormProps.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    const onDirtyChange = propsBeforeSubmit?.onDirtyChange as
+      | ((dirty: boolean) => void)
+      | undefined;
+    if (!onDirtyChange) {
+      throw new Error("onDirtyChange not passed to ItemForm");
+    }
+    act(() => {
+      onDirtyChange(true);
+    });
+
+    const handleSubmit = getCapturedOnSubmit();
+    await act(async () => {
+      await handleSubmit({ name: "Test" });
+    });
+
+    // After successful submit, simulating a Sheet-driven close should not
+    // trigger the discard dialog (formDirty was cleared).
+    act(() => {
+      capturedSheetOnOpenChange(false);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.queryByTestId("discard-dialog")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/collect/components/item-form-sheet.tsx
+++ b/src/features/collect/components/item-form-sheet.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import type { TagId, TrickId } from "@/db/types";
+import type { ParsedTag } from "@/features/repertoire/types";
+import type { ItemFormValues } from "../schema";
+import type { LinkedTrick, ParsedItem } from "../types";
+import { ItemForm } from "./item-form";
+
+const FORM_ID = "item-form";
+
+interface ItemFormSheetProps {
+  availableTags: ParsedTag[];
+  availableTricks: LinkedTrick[];
+  item: ParsedItem | null;
+  onCreateTag: (name: string) => Promise<TagId>;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: ItemFormValues) => void | Promise<void>;
+  onToggleTag: (tagId: TagId) => void;
+  onToggleTrick: (trickId: TrickId) => void;
+  open: boolean;
+  selectedTagIds: TagId[];
+  selectedTrickIds: TrickId[];
+  tagsDirty?: boolean;
+  tricksDirty?: boolean;
+  userBrands: string[];
+  userLocations: string[];
+}
+
+/** Convert a ParsedItem to partial form default values. */
+function toFormDefaults(item: ParsedItem): Partial<ItemFormValues> {
+  return {
+    brand: item.brand ?? "",
+    condition: item.condition,
+    creator: item.creator ?? "",
+    description: item.description ?? "",
+    location: item.location ?? "",
+    name: item.name,
+    notes: item.notes ?? "",
+    purchaseDate: item.purchaseDate ?? "",
+    purchasePrice:
+      item.purchasePrice === null ? "" : String(item.purchasePrice),
+    quantity: item.quantity,
+    type: item.type,
+    url: item.url ?? "",
+  };
+}
+
+function ItemFormSheet({
+  open,
+  onOpenChange,
+  item,
+  selectedTagIds,
+  availableTags,
+  onToggleTag,
+  onCreateTag,
+  selectedTrickIds,
+  availableTricks,
+  onToggleTrick,
+  onSubmit,
+  userBrands,
+  userLocations,
+  tagsDirty = false,
+  tricksDirty = false,
+}: ItemFormSheetProps): React.ReactElement {
+  const t = useTranslations("collect");
+  const isEditing = item !== null;
+  const [formDirty, setFormDirty] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showDiscardDialog, setShowDiscardDialog] = useState(false);
+
+  // Reset form dirty state when the sheet opens (new item or different edit target).
+  // The key prop on ItemForm already handles React-level remounting, but the
+  // local formDirty state must also be reset.
+  useEffect(() => {
+    if (open) {
+      setFormDirty(false);
+      setIsSubmitting(false);
+    }
+  }, [open]);
+
+  const isDirty = formDirty || tagsDirty || tricksDirty;
+
+  function handleDiscard(): void {
+    setShowDiscardDialog(false);
+    onOpenChange(false);
+  }
+
+  async function handleFormSubmit(data: ItemFormValues): Promise<void> {
+    setIsSubmitting(true);
+    try {
+      await onSubmit(data);
+      // Clear local dirty mirror so the discard dialog doesn't fire if the
+      // parent's close path routes through Sheet's onOpenChange after save.
+      setFormDirty(false);
+    } catch (error) {
+      // Parent (collect-view) owns user-facing toast; log defensively here so
+      // a forgotten parent try/catch doesn't leave the UI stuck submitting.
+      console.error("Item form submit failed:", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <Sheet
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen && isDirty) {
+            setShowDiscardDialog(true);
+            return;
+          }
+          onOpenChange(nextOpen);
+        }}
+        open={open}
+      >
+        <SheetContent
+          className="flex flex-col gap-0 p-0 sm:max-w-md"
+          side="right"
+        >
+          <SheetHeader className="border-b px-4 py-4">
+            <SheetTitle>{isEditing ? t("editItem") : t("addItem")}</SheetTitle>
+            <SheetDescription className="sr-only">
+              {isEditing ? t("editItemDescription") : t("addItemDescription")}
+            </SheetDescription>
+          </SheetHeader>
+
+          <ScrollArea className="flex-1 overflow-y-auto">
+            <div className="p-4">
+              <ItemForm
+                availableTags={availableTags}
+                availableTricks={availableTricks}
+                defaultValues={item ? toFormDefaults(item) : undefined}
+                formId={FORM_ID}
+                key={item?.id ?? "new"}
+                onCreateTag={onCreateTag}
+                onDirtyChange={setFormDirty}
+                onSubmit={handleFormSubmit}
+                onToggleTag={onToggleTag}
+                onToggleTrick={onToggleTrick}
+                selectedTagIds={selectedTagIds}
+                selectedTrickIds={selectedTrickIds}
+                userBrands={userBrands}
+                userLocations={userLocations}
+              />
+            </div>
+          </ScrollArea>
+
+          <SheetFooter className="flex-row justify-end gap-2 border-t px-4 py-4">
+            <Button
+              onClick={() => {
+                if (isDirty) {
+                  setShowDiscardDialog(true);
+                  return;
+                }
+                onOpenChange(false);
+              }}
+              type="button"
+              variant="ghost"
+            >
+              {t("cancel")}
+            </Button>
+            <Button disabled={isSubmitting} form={FORM_ID} type="submit">
+              {t("save")}
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      <AlertDialog onOpenChange={setShowDiscardDialog} open={showDiscardDialog}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("discardChangesTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("unsavedChanges")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDiscard} variant="destructive">
+              {t("discardAction")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+export type { ItemFormSheetProps };
+export { ItemFormSheet };

--- a/src/features/collect/components/item-form.test.tsx
+++ b/src/features/collect/components/item-form.test.tsx
@@ -1,0 +1,354 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  hasDetailsValues,
+  hasPurchaseValues,
+  hasReferenceValues,
+  ItemForm,
+} from "./item-form";
+
+const VALIDATION_MESSAGE_PATTERN = /collect\.validation/;
+
+// cmdk (used by CategoryCombobox) requires these in jsdom
+beforeAll(() => {
+  if (!("ResizeObserver" in globalThis)) {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe(): void {
+        // noop
+      }
+      unobserve(): void {
+        // noop
+      }
+      disconnect(): void {
+        // noop
+      }
+    };
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => undefined;
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.scrollTo) {
+    Element.prototype.scrollTo = () => undefined;
+  }
+});
+
+const defaultProps = {
+  availableTags: [],
+  availableTricks: [],
+  formId: "test-item-form",
+  onCreateTag: vi.fn(),
+  onSubmit: vi.fn(),
+  onToggleTag: vi.fn(),
+  onToggleTrick: vi.fn(),
+  selectedTagIds: [],
+  selectedTrickIds: [],
+  userBrands: [],
+  userLocations: [],
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("hasDetailsValues", () => {
+  it("returns false for undefined input", () => {
+    expect(hasDetailsValues(undefined)).toBe(false);
+  });
+
+  it("returns false when all detail fields are empty/default", () => {
+    expect(
+      hasDetailsValues({
+        brand: "",
+        creator: "",
+        condition: null,
+        location: "",
+        quantity: 1,
+      })
+    ).toBe(false);
+  });
+
+  it("returns true when brand is non-empty", () => {
+    expect(hasDetailsValues({ brand: "Bicycle" })).toBe(true);
+  });
+
+  it("returns true when creator is non-empty", () => {
+    expect(hasDetailsValues({ creator: "Tamariz" })).toBe(true);
+  });
+
+  it("returns true when condition is set", () => {
+    expect(hasDetailsValues({ condition: "good" })).toBe(true);
+  });
+
+  it("returns true when location is non-empty", () => {
+    expect(hasDetailsValues({ location: "Stage case" })).toBe(true);
+  });
+
+  it("returns true when quantity differs from default of 1", () => {
+    expect(hasDetailsValues({ quantity: 5 })).toBe(true);
+    expect(hasDetailsValues({ quantity: 0 })).toBe(true);
+  });
+});
+
+describe("hasPurchaseValues", () => {
+  it("returns false for undefined input", () => {
+    expect(hasPurchaseValues(undefined)).toBe(false);
+  });
+
+  it("returns false when both purchase fields are empty", () => {
+    expect(hasPurchaseValues({ purchaseDate: "", purchasePrice: "" })).toBe(
+      false
+    );
+  });
+
+  it("returns true when purchaseDate is set", () => {
+    expect(hasPurchaseValues({ purchaseDate: "2024-01-15" })).toBe(true);
+  });
+
+  it("returns true when purchasePrice is set", () => {
+    expect(hasPurchaseValues({ purchasePrice: "29.99" })).toBe(true);
+  });
+});
+
+describe("hasReferenceValues", () => {
+  it("returns false for undefined input", () => {
+    expect(hasReferenceValues(undefined)).toBe(false);
+  });
+
+  it("returns false when url is empty", () => {
+    expect(hasReferenceValues({ url: "" })).toBe(false);
+  });
+
+  it("returns true when url is set", () => {
+    expect(hasReferenceValues({ url: "https://example.com" })).toBe(true);
+  });
+});
+
+describe("ItemForm", () => {
+  it("renders without crashing", () => {
+    render(<ItemForm {...defaultProps} />);
+    expect(document.getElementById("test-item-form")).toBeInTheDocument();
+  });
+
+  it("renders the essentials section", () => {
+    render(<ItemForm {...defaultProps} />);
+    expect(screen.getByText("collect.section.essentials")).toBeInTheDocument();
+  });
+
+  it("renders the name field", () => {
+    render(<ItemForm {...defaultProps} />);
+    expect(
+      screen.getByRole("textbox", { name: "collect.field.name" })
+    ).toBeInTheDocument();
+  });
+
+  describe("creatorLabel swap", () => {
+    it("uses 'Author' label when type is 'book'", () => {
+      render(
+        <ItemForm
+          {...defaultProps}
+          defaultValues={{ type: "book", creator: "x" }}
+        />
+      );
+      expect(
+        screen.getByText("collect.field.creatorLabelBook")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("collect.field.creatorLabelDefault")
+      ).not.toBeInTheDocument();
+    });
+
+    it("uses 'Creator' label for non-book types", () => {
+      render(
+        <ItemForm
+          {...defaultProps}
+          defaultValues={{ type: "prop", creator: "x" }}
+        />
+      );
+      expect(
+        screen.getByText("collect.field.creatorLabelDefault")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("collect.field.creatorLabelBook")
+      ).not.toBeInTheDocument();
+    });
+
+    it("uses 'Creator' label for type 'gimmick'", () => {
+      render(
+        <ItemForm
+          {...defaultProps}
+          defaultValues={{ type: "gimmick", creator: "x" }}
+        />
+      );
+      expect(
+        screen.getByText("collect.field.creatorLabelDefault")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("quantity NaN guard", () => {
+    it("does not propagate NaN when the quantity input is cleared", async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <ItemForm
+          {...defaultProps}
+          defaultValues={{ name: "Item", type: "prop", quantity: 5 }}
+          onSubmit={onSubmit}
+        />
+      );
+
+      const quantityInput = screen.getByRole("spinbutton", {
+        name: "collect.field.quantity",
+      });
+
+      // Clear the input — valueAsNumber becomes NaN
+      await user.clear(quantityInput);
+
+      // The displayed value should fall back (the field value should never become NaN)
+      const form = document.getElementById("test-item-form");
+      if (!(form instanceof HTMLFormElement)) {
+        throw new Error("Expected form element");
+      }
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+      const submittedQuantity = onSubmit.mock.calls[0]?.[0]?.quantity;
+      expect(Number.isNaN(submittedQuantity)).toBe(false);
+    });
+  });
+
+  describe("NONE condition sentinel", () => {
+    it("preserves null condition for items without condition set", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <ItemForm
+          {...defaultProps}
+          defaultValues={{ name: "Item", type: "prop", condition: null }}
+          onSubmit={onSubmit}
+        />
+      );
+
+      const form = document.getElementById("test-item-form");
+      if (!(form instanceof HTMLFormElement)) {
+        throw new Error("Expected form element");
+      }
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+      // condition should be null (sentinel never reaches the form values)
+      expect(onSubmit.mock.calls[0]?.[0]?.condition).toBeNull();
+    });
+
+    it("preserves a non-null condition through to onSubmit unchanged", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <ItemForm
+          {...defaultProps}
+          defaultValues={{ name: "Item", type: "prop", condition: "good" }}
+          onSubmit={onSubmit}
+        />
+      );
+
+      const form = document.getElementById("test-item-form");
+      if (!(form instanceof HTMLFormElement)) {
+        throw new Error("Expected form element");
+      }
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+      expect(onSubmit.mock.calls[0]?.[0]?.condition).toBe("good");
+    });
+  });
+
+  describe("section auto-expand", () => {
+    it("opens details section when defaultValues contain non-default detail values", () => {
+      render(
+        <ItemForm {...defaultProps} defaultValues={{ brand: "Bicycle" }} />
+      );
+      // The brand field is inside the details collapsible — visible only when open
+      expect(
+        screen.getByRole("combobox", {
+          name: "collect.field.brandPlaceholder",
+        })
+      ).toBeInTheDocument();
+    });
+
+    it("opens purchase section when defaultValues contain purchase values", () => {
+      render(
+        <ItemForm
+          {...defaultProps}
+          defaultValues={{ purchaseDate: "2024-06-01" }}
+        />
+      );
+      expect(screen.getByDisplayValue("2024-06-01")).toBeInTheDocument();
+    });
+
+    it("opens reference section when defaultValues contain a url", () => {
+      render(
+        <ItemForm
+          {...defaultProps}
+          defaultValues={{ url: "https://example.com/item" }}
+        />
+      );
+      expect(
+        screen.getByDisplayValue("https://example.com/item")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("isDirty → onDirtyChange", () => {
+    it("calls onDirtyChange(false) on mount when form is clean", () => {
+      const onDirtyChange = vi.fn();
+      render(<ItemForm {...defaultProps} onDirtyChange={onDirtyChange} />);
+      expect(onDirtyChange).toHaveBeenCalledWith(false);
+    });
+
+    it("calls onDirtyChange(true) when a field changes", async () => {
+      const onDirtyChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(<ItemForm {...defaultProps} onDirtyChange={onDirtyChange} />);
+
+      const nameInput = screen.getByRole("textbox", {
+        name: "collect.field.name",
+      });
+      await user.type(nameInput, "X");
+
+      await waitFor(() => {
+        expect(onDirtyChange).toHaveBeenCalledWith(true);
+      });
+    });
+  });
+
+  describe("FormMessage Zod-key translation", () => {
+    it("translates a 'validation.*' message via the collect namespace", async () => {
+      render(<ItemForm {...defaultProps} />);
+
+      const form = document.getElementById("test-item-form");
+      if (!(form instanceof HTMLFormElement)) {
+        throw new Error("Expected form element");
+      }
+      // Submit empty — name is required, will produce "validation.nameRequired"
+      fireEvent.submit(form);
+
+      // The translated message should be rendered with the namespace prefix
+      // (per the global next-intl mock that returns "namespace.key").
+      await waitFor(() => {
+        expect(
+          screen.getByText(VALIDATION_MESSAGE_PATTERN)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/features/collect/components/item-form.tsx
+++ b/src/features/collect/components/item-form.tsx
@@ -1,0 +1,537 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslations } from "next-intl";
+import { useEffect } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import type { z } from "zod";
+import {
+  FormMessage as BaseFormMessage,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  useFormField,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type { TagId, TrickId } from "@/db/types";
+import { CategoryCombobox } from "@/features/repertoire/components/category-combobox";
+import { FormSection } from "@/features/repertoire/components/form-section";
+import { TagPicker } from "@/features/repertoire/components/tag-picker";
+import type { ParsedTag } from "@/features/repertoire/types";
+import {
+  CONDITION_CONFIG,
+  ITEM_CONDITIONS,
+  ITEM_TYPES,
+  isItemCondition,
+  MAX_TAGS_PER_ITEM,
+  MAX_TRICKS_PER_ITEM,
+  SUGGESTED_BRANDS,
+  SUGGESTED_LOCATIONS,
+  TYPE_CONFIG,
+} from "../constants";
+import { type ItemFormValues, itemFormSchema } from "../schema";
+import type { LinkedTrick } from "../types";
+import { PriceInput } from "./price-input";
+import { TrickPicker } from "./trick-picker";
+
+/**
+ * Schema input type — fields with `.optional().default(...)` are `T | undefined`
+ * before parsing (the resolver fills in defaults to produce ItemFormValues).
+ * RHF stores this input shape; handleSubmit receives the parsed output.
+ */
+type ItemFormInput = z.input<typeof itemFormSchema>;
+
+/** Sentinel value for nullable Select fields (Radix Select doesn't support empty string values). */
+const NONE = "__none__";
+
+/**
+ * FormMessage wrapper that translates Zod validation keys (e.g. "validation.nameRequired")
+ * via the collect i18n namespace so users see localized text instead of raw keys.
+ */
+function FormMessage(
+  props: React.ComponentProps<typeof BaseFormMessage>
+): React.ReactElement | null {
+  const t = useTranslations("collect");
+  const { error, formMessageId } = useFormField();
+  const raw = error?.message;
+
+  if (raw && typeof raw === "string" && raw.startsWith("validation.")) {
+    return (
+      <p
+        className="text-destructive text-sm"
+        data-slot="form-message"
+        id={formMessageId}
+        role="alert"
+      >
+        {t(raw)}
+      </p>
+    );
+  }
+
+  return <BaseFormMessage {...props} />;
+}
+
+interface ItemFormProps {
+  availableTags: ParsedTag[];
+  availableTricks: LinkedTrick[];
+  defaultValues?: Partial<ItemFormValues>;
+  formId: string;
+  onCreateTag: (name: string) => Promise<TagId>;
+  onDirtyChange?: (dirty: boolean) => void;
+  onSubmit: (data: ItemFormValues) => void;
+  onToggleTag: (tagId: TagId) => void;
+  onToggleTrick: (trickId: TrickId) => void;
+  selectedTagIds: TagId[];
+  selectedTrickIds: TrickId[];
+  userBrands: string[];
+  userLocations: string[];
+}
+
+function hasDetailsValues(
+  values: Partial<ItemFormValues> | undefined
+): boolean {
+  if (!values) {
+    return false;
+  }
+  return (
+    (values.brand !== undefined && values.brand !== "") ||
+    (values.creator !== undefined && values.creator !== "") ||
+    (values.condition !== undefined && values.condition !== null) ||
+    (values.location !== undefined && values.location !== "") ||
+    (values.quantity !== undefined && values.quantity !== 1)
+  );
+}
+
+function hasPurchaseValues(
+  values: Partial<ItemFormValues> | undefined
+): boolean {
+  if (!values) {
+    return false;
+  }
+  return (
+    (values.purchaseDate !== undefined && values.purchaseDate !== "") ||
+    (values.purchasePrice !== undefined && values.purchasePrice !== "")
+  );
+}
+
+function hasReferenceValues(
+  values: Partial<ItemFormValues> | undefined
+): boolean {
+  if (!values) {
+    return false;
+  }
+  return values.url !== undefined && values.url !== "";
+}
+
+function ItemForm({
+  defaultValues,
+  onSubmit,
+  formId,
+  selectedTagIds,
+  availableTags,
+  onToggleTag,
+  onCreateTag,
+  selectedTrickIds,
+  availableTricks,
+  onToggleTrick,
+  onDirtyChange,
+  userBrands,
+  userLocations,
+}: ItemFormProps): React.ReactElement {
+  const t = useTranslations("collect");
+  const form = useForm<ItemFormInput, unknown, ItemFormValues>({
+    defaultValues: {
+      name: "",
+      type: "prop",
+      description: "",
+      brand: "",
+      creator: "",
+      condition: null,
+      location: "",
+      quantity: 1,
+      purchaseDate: "",
+      purchasePrice: "",
+      url: "",
+      notes: "",
+      ...defaultValues,
+    },
+    resolver: zodResolver(itemFormSchema),
+  });
+
+  const currentType = useWatch({ control: form.control, name: "type" });
+
+  const { isDirty } = form.formState;
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+
+  const creatorLabel =
+    currentType === "book"
+      ? t("field.creatorLabelBook")
+      : t("field.creatorLabelDefault");
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex flex-col gap-4"
+        id={formId}
+        onSubmit={form.handleSubmit(onSubmit)}
+      >
+        {/* Essentials */}
+        <FormSection defaultOpen title={t("section.essentials")}>
+          <div className="flex flex-col gap-4 px-2 pb-2">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.name")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("field.namePlaceholder")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.type")}</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {ITEM_TYPES.map((itemType) => (
+                        <SelectItem key={itemType} value={itemType}>
+                          {t(TYPE_CONFIG[itemType].label)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.description")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("field.descriptionPlaceholder")}
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        {/* Details */}
+        <FormSection
+          defaultOpen={hasDetailsValues(defaultValues)}
+          title={t("section.details")}
+        >
+          <div className="flex flex-col gap-4 px-2 pb-2">
+            <FormField
+              control={form.control}
+              name="brand"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.brand")}</FormLabel>
+                  <FormControl>
+                    <CategoryCombobox
+                      onChange={field.onChange}
+                      placeholder={t("field.brandPlaceholder")}
+                      suggestions={SUGGESTED_BRANDS}
+                      translationNamespace="collect"
+                      userValues={userBrands}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="creator"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{creatorLabel}</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("field.creatorPlaceholder")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="condition"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.condition")}</FormLabel>
+                  <Select
+                    onValueChange={(value) => {
+                      if (value === NONE) {
+                        field.onChange(null);
+                        return;
+                      }
+                      if (isItemCondition(value)) {
+                        field.onChange(value);
+                        return;
+                      }
+                      // Unreachable: SelectItem values are constrained to
+                      // NONE | ITEM_CONDITIONS. If this fires, SelectItem
+                      // and ITEM_CONDITIONS have drifted.
+                      if (process.env.NODE_ENV !== "production") {
+                        console.warn(
+                          "Condition Select received unknown value:",
+                          value
+                        );
+                      }
+                    }}
+                    value={field.value ?? NONE}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value={NONE}>{t("noneSelected")}</SelectItem>
+                      {ITEM_CONDITIONS.map((cond) => (
+                        <SelectItem key={cond} value={cond}>
+                          {t(CONDITION_CONFIG[cond].label)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="location"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.location")}</FormLabel>
+                  <FormControl>
+                    <CategoryCombobox
+                      onChange={field.onChange}
+                      placeholder={t("field.locationPlaceholder")}
+                      suggestions={SUGGESTED_LOCATIONS}
+                      translationNamespace="collect"
+                      userValues={userLocations}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="quantity"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.quantity")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      inputMode="numeric"
+                      max={9999}
+                      min={0}
+                      type="number"
+                      {...field}
+                      onChange={(event) => {
+                        const val = event.target.valueAsNumber;
+                        field.onChange(Number.isNaN(val) ? 0 : val);
+                      }}
+                      value={
+                        typeof field.value === "number" &&
+                        !Number.isNaN(field.value)
+                          ? field.value
+                          : 1
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        {/* Purchase Info */}
+        <FormSection
+          defaultOpen={hasPurchaseValues(defaultValues)}
+          title={t("section.purchase")}
+        >
+          <div className="flex flex-col gap-4 px-2 pb-2">
+            <FormField
+              control={form.control}
+              name="purchaseDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.purchaseDate")}</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="purchasePrice"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.purchasePrice")}</FormLabel>
+                  <FormControl>
+                    <PriceInput
+                      onChange={field.onChange}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        {/* Reference */}
+        <FormSection
+          defaultOpen={hasReferenceValues(defaultValues)}
+          title={t("section.reference")}
+        >
+          <div className="flex flex-col gap-4 px-2 pb-2">
+            <FormField
+              control={form.control}
+              name="url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.url")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("field.urlPlaceholder")}
+                      type="url"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        {/* Organization */}
+        <FormSection
+          defaultOpen={selectedTagIds.length > 0 || selectedTrickIds.length > 0}
+          title={t("section.organization")}
+        >
+          <div className="flex flex-col gap-4 px-2 pb-2">
+            <fieldset
+              aria-describedby="tags-limit-help"
+              className="grid gap-2 border-none p-0"
+            >
+              <legend className="font-medium text-sm">{t("field.tags")}</legend>
+              <TagPicker
+                availableTags={availableTags}
+                maxTags={MAX_TAGS_PER_ITEM}
+                onCreateTag={onCreateTag}
+                onToggleTag={onToggleTag}
+                selectedTagIds={selectedTagIds}
+                translationNamespace="collect"
+              />
+              <p className="text-muted-foreground text-xs" id="tags-limit-help">
+                {selectedTagIds.length}/{MAX_TAGS_PER_ITEM}{" "}
+                {t("field.tags").toLowerCase()}
+              </p>
+            </fieldset>
+
+            <fieldset
+              aria-describedby="tricks-limit-help"
+              className="grid gap-2 border-none p-0"
+            >
+              <legend className="font-medium text-sm">
+                {t("field.linkedTricks")}
+              </legend>
+              <TrickPicker
+                availableTricks={availableTricks}
+                maxTricks={MAX_TRICKS_PER_ITEM}
+                onToggleTrick={onToggleTrick}
+                selectedTrickIds={selectedTrickIds}
+              />
+              <p
+                className="text-muted-foreground text-xs"
+                id="tricks-limit-help"
+              >
+                {selectedTrickIds.length}/{MAX_TRICKS_PER_ITEM}{" "}
+                {t("field.linkedTricks").toLowerCase()}
+              </p>
+            </fieldset>
+
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("field.notes")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("field.notesPlaceholder")}
+                      rows={5}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+      </form>
+    </Form>
+  );
+}
+
+export type { ItemFormProps };
+export { hasDetailsValues, hasPurchaseValues, hasReferenceValues, ItemForm };

--- a/src/features/collect/components/item-list.tsx
+++ b/src/features/collect/components/item-list.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { ItemId } from "@/db/types";
+import type { ItemWithRelations } from "../types";
+import { ItemCard } from "./item-card";
+
+interface ItemListProps {
+  items: ItemWithRelations[];
+  onDelete: (id: ItemId) => void;
+  onEdit: (id: ItemId) => void;
+}
+
+/**
+ * Renders item cards in a responsive grid layout.
+ *
+ * Stateless presentational component -- all interaction is delegated
+ * to the parent via `onEdit` and `onDelete` callbacks.
+ */
+export function ItemList({
+  items,
+  onEdit,
+  onDelete,
+}: ItemListProps): React.ReactElement {
+  const t = useTranslations("collect");
+
+  return (
+    <ul
+      aria-label={t("title")}
+      className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+    >
+      {items.map((item) => (
+        <li key={item.id}>
+          <ItemCard item={item} onDelete={onDelete} onEdit={onEdit} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/collect/components/item-type-badge.tsx
+++ b/src/features/collect/components/item-type-badge.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import { type ItemType, TYPE_CONFIG } from "../constants";
+
+interface ItemTypeBadgeProps {
+  type: ItemType;
+}
+
+export function ItemTypeBadge({
+  type,
+}: ItemTypeBadgeProps): React.ReactElement {
+  const t = useTranslations("collect");
+  const config = TYPE_CONFIG[type];
+
+  return <Badge variant={config.variant}>{t(config.label)}</Badge>;
+}

--- a/src/features/collect/components/price-input.tsx
+++ b/src/features/collect/components/price-input.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Input } from "@/components/ui/input";
+
+interface PriceInputProps
+  extends Omit<
+    React.ComponentProps<typeof Input>,
+    "inputMode" | "onChange" | "placeholder" | "value"
+  > {
+  onChange: (value: string) => void;
+  value: string;
+}
+
+/**
+ * Text input for purchase price with mobile-friendly decimal keyboard.
+ *
+ * Uses `inputMode="decimal"` to show a numeric keypad on mobile devices
+ * while keeping the underlying input as text to preserve formatting
+ * (e.g. leading zeros, decimal places).
+ *
+ * Forwards `id`, `aria-describedby`, and `aria-invalid` from FormControl
+ * so the label association is preserved.
+ */
+export function PriceInput({
+  value,
+  onChange,
+  ...rest
+}: PriceInputProps): React.ReactElement {
+  const t = useTranslations("collect");
+
+  return (
+    <Input
+      inputMode="decimal"
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={t("field.pricePlaceholder")}
+      value={value}
+      {...rest}
+    />
+  );
+}

--- a/src/features/collect/components/trick-picker.test.tsx
+++ b/src/features/collect/components/trick-picker.test.tsx
@@ -1,0 +1,268 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TrickId } from "@/db/types";
+
+const trickId = (id: string) => id as TrickId;
+const REMOVE_LABEL_PATTERN = /trickPicker\.remove/;
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) => {
+    if (params) {
+      return Object.entries(params).reduce(
+        (str, [k, v]) => str.replace(`{${k}}`, String(v)),
+        key
+      );
+    }
+    return key;
+  },
+}));
+
+// Minimal mocks for shadcn/ui — render children directly
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & Record<string, unknown>) => (
+    <span {...props}>{children}</span>
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <div data-testid="popover-trigger">{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/command", () => ({
+  Command: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CommandEmpty: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CommandGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CommandInput: (props: Record<string, unknown>) => (
+    <input data-testid="command-input" {...props} />
+  ),
+  CommandItem: ({
+    children,
+    onSelect,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      data-testid="command-item"
+      disabled={disabled}
+      onClick={onSelect}
+      type="button"
+    >
+      {children}
+    </button>
+  ),
+  CommandList: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+// Suppress lucide-react icons
+vi.mock("lucide-react", () => ({
+  CheckIcon: () => null,
+  SearchIcon: () => null,
+  XIcon: () => null,
+}));
+
+describe("TrickPicker", () => {
+  async function getComponent() {
+    const { TrickPicker } = await import("./trick-picker");
+    return TrickPicker;
+  }
+
+  const tricks = [
+    { id: trickId("t1"), name: "Ambitious Card" },
+    { id: trickId("t2"), name: "Triumph" },
+    { id: trickId("t3"), name: "Invisible Deck" },
+  ];
+
+  /** Find the CommandItem button containing the given trick name. */
+  function getItemByName(name: string): HTMLElement {
+    const items = screen.getAllByTestId("command-item");
+    const match = items.find((el) => el.textContent?.includes(name));
+    if (!match) {
+      throw new Error(`No CommandItem button for trick "${name}"`);
+    }
+    return match;
+  }
+
+  it("calls onToggleTrick when selecting an unselected trick", async () => {
+    const TrickPicker = await getComponent();
+    const onToggle = vi.fn();
+
+    render(
+      <TrickPicker
+        availableTricks={tricks}
+        onToggleTrick={onToggle}
+        selectedTrickIds={[]}
+      />
+    );
+
+    fireEvent.click(getItemByName("Ambitious Card"));
+
+    expect(onToggle).toHaveBeenCalledWith(trickId("t1"));
+  });
+
+  it("calls onToggleTrick when deselecting a selected trick", async () => {
+    const TrickPicker = await getComponent();
+    const onToggle = vi.fn();
+
+    render(
+      <TrickPicker
+        availableTricks={tricks}
+        onToggleTrick={onToggle}
+        selectedTrickIds={[trickId("t1")]}
+      />
+    );
+
+    fireEvent.click(getItemByName("Ambitious Card"));
+
+    expect(onToggle).toHaveBeenCalledWith(trickId("t1"));
+  });
+
+  it("does NOT call onToggleTrick when at max limit for unselected trick", async () => {
+    const TrickPicker = await getComponent();
+    const onToggle = vi.fn();
+
+    render(
+      <TrickPicker
+        availableTricks={tricks}
+        maxTricks={2}
+        onToggleTrick={onToggle}
+        selectedTrickIds={[trickId("t1"), trickId("t2")]}
+      />
+    );
+
+    // Try clicking the third trick (not selected, but at limit)
+    fireEvent.click(getItemByName("Invisible Deck"));
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("disables CommandItems for unselected tricks when at the maxTricks limit", async () => {
+    const TrickPicker = await getComponent();
+    const onToggle = vi.fn();
+
+    render(
+      <TrickPicker
+        availableTricks={tricks}
+        maxTricks={2}
+        onToggleTrick={onToggle}
+        selectedTrickIds={[trickId("t1"), trickId("t2")]}
+      />
+    );
+
+    // The unselected one (Invisible Deck) is disabled at the limit
+    expect(getItemByName("Invisible Deck")).toBeDisabled();
+    // Selected items remain enabled so users can deselect
+    expect(getItemByName("Ambitious Card")).not.toBeDisabled();
+    expect(getItemByName("Triumph")).not.toBeDisabled();
+  });
+
+  it("still allows deselecting when at max limit", async () => {
+    const TrickPicker = await getComponent();
+    const onToggle = vi.fn();
+
+    render(
+      <TrickPicker
+        availableTricks={tricks}
+        maxTricks={2}
+        onToggleTrick={onToggle}
+        selectedTrickIds={[trickId("t1"), trickId("t2")]}
+      />
+    );
+
+    // Click a selected trick — should still allow deselection
+    fireEvent.click(getItemByName("Ambitious Card"));
+
+    expect(onToggle).toHaveBeenCalledWith(trickId("t1"));
+  });
+
+  it("renders selected tricks as removable badges", async () => {
+    const TrickPicker = await getComponent();
+    const onToggle = vi.fn();
+
+    render(
+      <TrickPicker
+        availableTricks={tricks}
+        onToggleTrick={onToggle}
+        selectedTrickIds={[trickId("t1")]}
+      />
+    );
+
+    // The aria-label includes the trick name via the {name} placeholder
+    const removeButton = screen.getByLabelText(REMOVE_LABEL_PATTERN);
+    expect(removeButton).toBeInTheDocument();
+  });
+
+  it("renders CommandEmpty content when availableTricks is empty", async () => {
+    const TrickPicker = await getComponent();
+    const onToggle = vi.fn();
+
+    render(
+      <TrickPicker
+        availableTricks={[]}
+        onToggleTrick={onToggle}
+        selectedTrickIds={[]}
+      />
+    );
+
+    expect(screen.getByText("trickPicker.noResults")).toBeInTheDocument();
+  });
+
+  it("treats maxTricks={undefined} as unbounded — no item is disabled", async () => {
+    const TrickPicker = await getComponent();
+    const onToggle = vi.fn();
+
+    render(
+      <TrickPicker
+        availableTricks={tricks}
+        onToggleTrick={onToggle}
+        selectedTrickIds={[trickId("t1"), trickId("t2"), trickId("t3")]}
+      />
+    );
+
+    // Even with all selected, none are disabled because no maxTricks
+    expect(getItemByName("Ambitious Card")).not.toBeDisabled();
+    expect(getItemByName("Triumph")).not.toBeDisabled();
+    expect(getItemByName("Invisible Deck")).not.toBeDisabled();
+  });
+});

--- a/src/features/collect/components/trick-picker.tsx
+++ b/src/features/collect/components/trick-picker.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { CheckIcon, SearchIcon, XIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { TrickId } from "@/db/types";
+import { cn } from "@/lib/utils";
+import type { LinkedTrick } from "../types";
+
+interface TrickPickerProps {
+  availableTricks: LinkedTrick[];
+  maxTricks?: number;
+  onToggleTrick: (trickId: TrickId) => void;
+  selectedTrickIds: TrickId[];
+}
+
+function TrickPicker({
+  selectedTrickIds,
+  availableTricks,
+  onToggleTrick,
+  maxTricks,
+}: TrickPickerProps): React.ReactElement {
+  const t = useTranslations("collect");
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const announcementRef = useRef<HTMLDivElement>(null);
+
+  const selectedSet = new Set(selectedTrickIds);
+  const atLimit =
+    maxTricks !== undefined && selectedTrickIds.length >= maxTricks;
+
+  const trimmedSearch = search.trim();
+
+  const filteredTricks = trimmedSearch
+    ? availableTricks.filter((trick) =>
+        trick.name.toLowerCase().includes(trimmedSearch.toLowerCase())
+      )
+    : availableTricks;
+
+  const selectedTricks = availableTricks.filter((trick) =>
+    selectedSet.has(trick.id)
+  );
+
+  function announce(message: string): void {
+    if (announcementRef.current) {
+      announcementRef.current.textContent = message;
+    }
+  }
+
+  function handleToggle(trick: LinkedTrick): void {
+    const isSelected = selectedSet.has(trick.id);
+
+    if (!isSelected && atLimit) {
+      return;
+    }
+
+    onToggleTrick(trick.id);
+    announce(
+      isSelected
+        ? t("trickPicker.removedTrick", { name: trick.name })
+        : t("trickPicker.addedTrick", { name: trick.name })
+    );
+  }
+
+  function handleRemove(trick: LinkedTrick): void {
+    onToggleTrick(trick.id);
+    announce(t("trickPicker.removedTrick", { name: trick.name }));
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        aria-live="polite"
+        className="sr-only"
+        ref={announcementRef}
+        role="status"
+      />
+
+      <Popover onOpenChange={setOpen} open={open}>
+        <PopoverTrigger asChild>
+          <Button
+            aria-expanded={open}
+            aria-label={t("trickPicker.search")}
+            className="min-h-11 w-full justify-between"
+            variant="outline"
+          >
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <SearchIcon className="size-4" />
+              <span>{t("trickPicker.search")}</span>
+            </span>
+            {selectedTrickIds.length > 0 && (
+              <Badge className="ml-auto" variant="secondary">
+                {selectedTrickIds.length}
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+          <Command shouldFilter={false}>
+            <CommandInput
+              onValueChange={setSearch}
+              placeholder={t("trickPicker.search")}
+              value={search}
+            />
+            <CommandList>
+              <CommandEmpty>{t("trickPicker.noResults")}</CommandEmpty>
+              <CommandGroup>
+                {filteredTricks.map((trick) => {
+                  const isSelected = selectedSet.has(trick.id);
+                  const isDisabled = !isSelected && atLimit;
+
+                  return (
+                    <CommandItem
+                      className="min-h-11"
+                      disabled={isDisabled}
+                      key={trick.id}
+                      onSelect={() => handleToggle(trick)}
+                    >
+                      <CheckIcon
+                        className={cn(
+                          "size-4",
+                          isSelected ? "opacity-100" : "opacity-0"
+                        )}
+                      />
+                      <span>{trick.name}</span>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {selectedTricks.length > 0 && (
+        <ul
+          aria-label={t("trickPicker.selectedTricks")}
+          className="flex flex-wrap gap-1.5"
+        >
+          {selectedTricks.map((trick) => (
+            <li key={trick.id}>
+              <Badge
+                className="gap-1 overflow-visible py-1 pr-1 pl-2"
+                variant="secondary"
+              >
+                <span>{trick.name}</span>
+                <button
+                  aria-label={t("trickPicker.remove", { name: trick.name })}
+                  className="relative flex min-h-11 min-w-11 items-center justify-center rounded-sm p-1.5 hover:bg-accent"
+                  onClick={() => handleRemove(trick)}
+                  type="button"
+                >
+                  <XIcon className="size-3" />
+                </button>
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export type { TrickPickerProps };
+export { TrickPicker };

--- a/src/features/collect/constants.test.ts
+++ b/src/features/collect/constants.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONDITION_CONFIG,
+  ITEM_CONDITIONS,
+  ITEM_TYPES,
+  MAX_TAGS_PER_ITEM,
+  MAX_TRICKS_PER_ITEM,
+  SUGGESTED_BRANDS,
+  SUGGESTED_LOCATIONS,
+  TYPE_CONFIG,
+} from "./constants";
+
+const TYPE_LABEL_RE = /^type\./;
+const CONDITION_LABEL_RE = /^condition\./;
+
+describe("TYPE_CONFIG", () => {
+  it("has an entry for every ITEM_TYPE", () => {
+    for (const type of ITEM_TYPES) {
+      expect(TYPE_CONFIG).toHaveProperty(type);
+    }
+  });
+
+  it("has no extra entries beyond ITEM_TYPES", () => {
+    expect(Object.keys(TYPE_CONFIG)).toHaveLength(ITEM_TYPES.length);
+  });
+
+  it("every entry has a label string and a valid variant", () => {
+    const validVariants = ["default", "secondary", "destructive", "outline"];
+    for (const type of ITEM_TYPES) {
+      const config = TYPE_CONFIG[type];
+      expect(typeof config.label).toBe("string");
+      expect(config.label.length).toBeGreaterThan(0);
+      expect(validVariants).toContain(config.variant);
+    }
+  });
+
+  it("labels are namespaced with type. prefix", () => {
+    for (const type of ITEM_TYPES) {
+      expect(TYPE_CONFIG[type].label).toMatch(TYPE_LABEL_RE);
+    }
+  });
+});
+
+describe("CONDITION_CONFIG", () => {
+  it("has an entry for every ITEM_CONDITION", () => {
+    for (const condition of ITEM_CONDITIONS) {
+      expect(CONDITION_CONFIG).toHaveProperty(condition);
+    }
+  });
+
+  it("has no extra entries beyond ITEM_CONDITIONS", () => {
+    expect(Object.keys(CONDITION_CONFIG)).toHaveLength(ITEM_CONDITIONS.length);
+  });
+
+  it("every entry has a label string and a valid variant", () => {
+    const validVariants = ["default", "secondary", "destructive", "outline"];
+    for (const condition of ITEM_CONDITIONS) {
+      const config = CONDITION_CONFIG[condition];
+      expect(typeof config.label).toBe("string");
+      expect(config.label.length).toBeGreaterThan(0);
+      expect(validVariants).toContain(config.variant);
+    }
+  });
+
+  it("labels are namespaced with condition. prefix", () => {
+    for (const condition of ITEM_CONDITIONS) {
+      expect(CONDITION_CONFIG[condition].label).toMatch(CONDITION_LABEL_RE);
+    }
+  });
+});
+
+describe("ITEM_TYPES", () => {
+  it("contains all expected item types", () => {
+    expect(ITEM_TYPES).toContain("prop");
+    expect(ITEM_TYPES).toContain("book");
+    expect(ITEM_TYPES).toContain("gimmick");
+    expect(ITEM_TYPES).toContain("dvd");
+    expect(ITEM_TYPES).toContain("download");
+    expect(ITEM_TYPES).toContain("deck");
+    expect(ITEM_TYPES).toContain("clothing");
+    expect(ITEM_TYPES).toContain("consumable");
+    expect(ITEM_TYPES).toContain("accessory");
+    expect(ITEM_TYPES).toContain("other");
+  });
+
+  it("has exactly 10 entries", () => {
+    expect(ITEM_TYPES).toHaveLength(10);
+  });
+
+  it("has unique values", () => {
+    const unique = new Set(ITEM_TYPES);
+    expect(unique.size).toBe(ITEM_TYPES.length);
+  });
+});
+
+describe("ITEM_CONDITIONS", () => {
+  it("contains all expected condition values", () => {
+    expect(ITEM_CONDITIONS).toContain("new");
+    expect(ITEM_CONDITIONS).toContain("good");
+    expect(ITEM_CONDITIONS).toContain("worn");
+    expect(ITEM_CONDITIONS).toContain("needs_repair");
+  });
+
+  it("has exactly 4 entries", () => {
+    expect(ITEM_CONDITIONS).toHaveLength(4);
+  });
+
+  it("has unique values", () => {
+    const unique = new Set(ITEM_CONDITIONS);
+    expect(unique.size).toBe(ITEM_CONDITIONS.length);
+  });
+});
+
+describe("SUGGESTED_BRANDS", () => {
+  it("is non-empty", () => {
+    expect(SUGGESTED_BRANDS.length).toBeGreaterThan(0);
+  });
+
+  it("contains well-known magic brands", () => {
+    expect(SUGGESTED_BRANDS).toContain("Bicycle");
+    expect(SUGGESTED_BRANDS).toContain("Theory11");
+    expect(SUGGESTED_BRANDS).toContain("Ellusionist");
+  });
+
+  it("has unique values", () => {
+    const unique = new Set(SUGGESTED_BRANDS);
+    expect(unique.size).toBe(SUGGESTED_BRANDS.length);
+  });
+});
+
+describe("SUGGESTED_LOCATIONS", () => {
+  it("is non-empty", () => {
+    expect(SUGGESTED_LOCATIONS.length).toBeGreaterThan(0);
+  });
+
+  it("contains common storage locations", () => {
+    expect(SUGGESTED_LOCATIONS).toContain("Close-up case");
+    expect(SUGGESTED_LOCATIONS).toContain("Stage case");
+  });
+
+  it("has unique values", () => {
+    const unique = new Set(SUGGESTED_LOCATIONS);
+    expect(unique.size).toBe(SUGGESTED_LOCATIONS.length);
+  });
+});
+
+describe("MAX_TAGS_PER_ITEM", () => {
+  it("is a positive integer", () => {
+    expect(typeof MAX_TAGS_PER_ITEM).toBe("number");
+    expect(MAX_TAGS_PER_ITEM).toBeGreaterThan(0);
+    expect(Number.isInteger(MAX_TAGS_PER_ITEM)).toBe(true);
+  });
+
+  it("is 20", () => {
+    expect(MAX_TAGS_PER_ITEM).toBe(20);
+  });
+});
+
+describe("MAX_TRICKS_PER_ITEM", () => {
+  it("is a positive integer", () => {
+    expect(typeof MAX_TRICKS_PER_ITEM).toBe("number");
+    expect(MAX_TRICKS_PER_ITEM).toBeGreaterThan(0);
+    expect(Number.isInteger(MAX_TRICKS_PER_ITEM)).toBe(true);
+  });
+
+  it("is 50", () => {
+    expect(MAX_TRICKS_PER_ITEM).toBe(50);
+  });
+});

--- a/src/features/collect/constants.ts
+++ b/src/features/collect/constants.ts
@@ -1,0 +1,124 @@
+const ITEM_TYPES = [
+  "prop",
+  "book",
+  "gimmick",
+  "dvd",
+  "download",
+  "deck",
+  "clothing",
+  "consumable",
+  "accessory",
+  "other",
+] as const;
+
+type ItemType = (typeof ITEM_TYPES)[number];
+
+interface TypeConfig {
+  readonly label: string;
+  readonly variant: "default" | "secondary" | "destructive" | "outline";
+}
+
+const TYPE_CONFIG = {
+  prop: { label: "type.prop", variant: "default" },
+  book: { label: "type.book", variant: "secondary" },
+  gimmick: { label: "type.gimmick", variant: "default" },
+  dvd: { label: "type.dvd", variant: "outline" },
+  download: { label: "type.download", variant: "outline" },
+  deck: { label: "type.deck", variant: "secondary" },
+  clothing: { label: "type.clothing", variant: "outline" },
+  consumable: { label: "type.consumable", variant: "outline" },
+  accessory: { label: "type.accessory", variant: "secondary" },
+  other: { label: "type.other", variant: "outline" },
+} as const satisfies Record<ItemType, TypeConfig>;
+
+const ITEM_CONDITIONS = ["new", "good", "worn", "needs_repair"] as const;
+
+type ItemCondition = (typeof ITEM_CONDITIONS)[number];
+
+interface ConditionConfig {
+  readonly label: string;
+  readonly variant: "default" | "secondary" | "destructive" | "outline";
+}
+
+const CONDITION_CONFIG = {
+  new: { label: "condition.new", variant: "default" },
+  good: { label: "condition.good", variant: "secondary" },
+  worn: { label: "condition.worn", variant: "outline" },
+  needs_repair: { label: "condition.needs_repair", variant: "destructive" },
+} as const satisfies Record<ItemCondition, ConditionConfig>;
+
+const SUGGESTED_BRANDS = [
+  "Bicycle",
+  "Theory11",
+  "Ellusionist",
+  "Murphy's Magic",
+  "Penguin Magic",
+  "Vanishing Inc.",
+  "Card-Shark",
+  "TCC",
+] as const;
+
+const SUGGESTED_LOCATIONS = [
+  "Close-up case",
+  "Stage case",
+  "Home office",
+  "Storage room",
+  "Car trunk",
+  "Performing bag",
+] as const;
+
+const MAX_TAGS_PER_ITEM = 20;
+const MAX_TRICKS_PER_ITEM = 50;
+
+/**
+ * Canonical sort keys shared by ItemFilters (UI), useItems (hook), and
+ * collect-view (orchestration). Kebab-case to match SelectItem `value` props.
+ */
+const ITEM_SORTS = [
+  "newest",
+  "oldest",
+  "name-asc",
+  "name-desc",
+  "price-asc",
+  "price-desc",
+  "type-asc",
+] as const;
+
+type FilterSortValue = (typeof ITEM_SORTS)[number];
+
+function isItemType(value: unknown): value is ItemType {
+  return (
+    typeof value === "string" &&
+    (ITEM_TYPES as readonly string[]).includes(value)
+  );
+}
+
+function isItemCondition(value: unknown): value is ItemCondition {
+  return (
+    typeof value === "string" &&
+    (ITEM_CONDITIONS as readonly string[]).includes(value)
+  );
+}
+
+function isFilterSortValue(value: unknown): value is FilterSortValue {
+  return (
+    typeof value === "string" &&
+    (ITEM_SORTS as readonly string[]).includes(value)
+  );
+}
+
+export type { FilterSortValue, ItemCondition, ItemType };
+export {
+  CONDITION_CONFIG,
+  ITEM_CONDITIONS,
+  ITEM_SORTS,
+  ITEM_TYPES,
+  isFilterSortValue,
+  isItemCondition,
+  isItemType,
+  MAX_TAGS_PER_ITEM,
+  MAX_TRICKS_PER_ITEM,
+  SUGGESTED_BRANDS,
+  SUGGESTED_LOCATIONS,
+  TYPE_CONFIG,
+};

--- a/src/features/collect/hooks/parse-item.test.ts
+++ b/src/features/collect/hooks/parse-item.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import type { ParsedItem } from "../types";
+import type { ItemRow } from "./parse-item";
+import { parseItemRow } from "./parse-item";
+
+// parseItemRow now returns ParsedItem | null (rejects rows with invalid UUIDs).
+// Test helper: assert non-null and narrow for the happy-path tests where
+// fixtures use a valid UUID. Tests that exercise the rejection path call
+// parseItemRow directly and check for null.
+function parseRowOrFail(row: ItemRow): ParsedItem {
+  const result = parseItemRow(row);
+  if (result === null) {
+    throw new Error("parseItemRow returned null for a valid fixture");
+  }
+  return result;
+}
+
+describe("parseItemRow", () => {
+  function createMinimalRow(overrides?: Partial<ItemRow>): ItemRow {
+    return {
+      id: "00000000-0000-4000-8000-000000000001",
+      brand: "Bicycle",
+      condition: "new",
+      created_at: "2025-01-15T12:00:00.000Z",
+      creator: "Bob Ostin",
+      description: "A classic deck",
+      location: "Close-up case",
+      name: "Invisible Deck",
+      notes: "Keep dry",
+      purchase_date: "2025-01-10",
+      purchase_price: "29.99",
+      quantity: 2,
+      type: "deck",
+      updated_at: "2025-01-15T13:00:00.000Z",
+      url: "https://example.com",
+      ...overrides,
+    };
+  }
+
+  it("maps snake_case to camelCase fields", () => {
+    const result = parseRowOrFail(createMinimalRow());
+
+    expect(result.createdAt).toBe("2025-01-15T12:00:00.000Z");
+    expect(result.updatedAt).toBe("2025-01-15T13:00:00.000Z");
+    expect(result.purchaseDate).toBe("2025-01-10");
+    expect(result.purchasePrice).toBe(29.99);
+  });
+
+  it("preserves all scalar fields", () => {
+    const result = parseRowOrFail(createMinimalRow());
+
+    expect(result.id).toBe("00000000-0000-4000-8000-000000000001");
+    expect(result.name).toBe("Invisible Deck");
+    expect(result.brand).toBe("Bicycle");
+    expect(result.condition).toBe("new");
+    expect(result.creator).toBe("Bob Ostin");
+    expect(result.description).toBe("A classic deck");
+    expect(result.location).toBe("Close-up case");
+    expect(result.notes).toBe("Keep dry");
+    expect(result.quantity).toBe(2);
+    expect(result.type).toBe("deck");
+    expect(result.url).toBe("https://example.com");
+  });
+
+  it("unknown type defaults to 'other'", () => {
+    const result = parseRowOrFail(createMinimalRow({ type: "furniture" }));
+    expect(result.type).toBe("other");
+  });
+
+  it("accepts all valid ITEM_TYPES without defaulting", () => {
+    const validTypes = [
+      "prop",
+      "book",
+      "gimmick",
+      "dvd",
+      "download",
+      "deck",
+      "clothing",
+      "consumable",
+      "accessory",
+      "other",
+    ] as const;
+    for (const type of validTypes) {
+      const result = parseRowOrFail(createMinimalRow({ type }));
+      expect(result.type).toBe(type);
+    }
+  });
+
+  it("unknown condition defaults to null", () => {
+    const result = parseRowOrFail(createMinimalRow({ condition: "perfect" }));
+    expect(result.condition).toBeNull();
+  });
+
+  it("null condition stays null", () => {
+    const result = parseRowOrFail(createMinimalRow({ condition: null }));
+    expect(result.condition).toBeNull();
+  });
+
+  it("accepts all valid ITEM_CONDITIONS without defaulting to null", () => {
+    const validConditions = ["new", "good", "worn", "needs_repair"] as const;
+    for (const condition of validConditions) {
+      const result = parseRowOrFail(createMinimalRow({ condition }));
+      expect(result.condition).toBe(condition);
+    }
+  });
+
+  it("null purchase_price returns null", () => {
+    const result = parseRowOrFail(createMinimalRow({ purchase_price: null }));
+    expect(result.purchasePrice).toBeNull();
+  });
+
+  it("valid purchase_price string converts to number", () => {
+    const result = parseRowOrFail(
+      createMinimalRow({ purchase_price: "49.95" })
+    );
+    expect(result.purchasePrice).toBe(49.95);
+  });
+
+  it("integer purchase_price string converts to number", () => {
+    const result = parseRowOrFail(createMinimalRow({ purchase_price: "100" }));
+    expect(result.purchasePrice).toBe(100);
+  });
+
+  it("purchase_price of '0' converts to 0", () => {
+    const result = parseRowOrFail(createMinimalRow({ purchase_price: "0" }));
+    expect(result.purchasePrice).toBe(0);
+  });
+
+  it("invalid purchase_price string (NaN) returns null", () => {
+    const result = parseRowOrFail(createMinimalRow({ purchase_price: "abc" }));
+    expect(result.purchasePrice).toBeNull();
+  });
+
+  it("null quantity defaults to 1", () => {
+    const result = parseRowOrFail(createMinimalRow({ quantity: null }));
+    expect(result.quantity).toBe(1);
+  });
+
+  it("explicit quantity of 0 is preserved", () => {
+    const result = parseRowOrFail(createMinimalRow({ quantity: 0 }));
+    expect(result.quantity).toBe(0);
+  });
+
+  it("string quantity is parsed to number (PowerSync WASM bridge)", () => {
+    const result = parseRowOrFail(createMinimalRow({ quantity: "5" }));
+    expect(result.quantity).toBe(5);
+  });
+
+  it("string quantity '0' is parsed to 0", () => {
+    const result = parseRowOrFail(createMinimalRow({ quantity: "0" }));
+    expect(result.quantity).toBe(0);
+  });
+
+  it("non-numeric string quantity defaults to 1", () => {
+    const result = parseRowOrFail(createMinimalRow({ quantity: "abc" }));
+    expect(result.quantity).toBe(1);
+  });
+
+  it("empty string quantity defaults to 1", () => {
+    const result = parseRowOrFail(createMinimalRow({ quantity: "" }));
+    expect(result.quantity).toBe(1);
+  });
+
+  it("handles fully null optional fields", () => {
+    const result = parseRowOrFail(
+      createMinimalRow({
+        brand: null,
+        condition: null,
+        creator: null,
+        description: null,
+        location: null,
+        notes: null,
+        purchase_date: null,
+        purchase_price: null,
+        url: null,
+      })
+    );
+
+    expect(result.brand).toBeNull();
+    expect(result.condition).toBeNull();
+    expect(result.creator).toBeNull();
+    expect(result.description).toBeNull();
+    expect(result.location).toBeNull();
+    expect(result.notes).toBeNull();
+    expect(result.purchaseDate).toBeNull();
+    expect(result.purchasePrice).toBeNull();
+    expect(result.url).toBeNull();
+  });
+});

--- a/src/features/collect/hooks/parse-item.ts
+++ b/src/features/collect/hooks/parse-item.ts
@@ -1,0 +1,134 @@
+import { asItemId } from "@/db/types";
+import {
+  type ItemCondition,
+  type ItemType,
+  isItemCondition,
+  isItemType,
+} from "../constants";
+import type { ParsedItem } from "../types";
+
+/**
+ * UUID v1-v5 regex. Validates at the trust boundary where untyped strings
+ * from PowerSync's local SQLite enter the typed domain — the brand
+ * constructors (asItemId, asTagId, asTrickId) are deliberately type-only
+ * casts, so runtime validation lives here.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface ItemRow {
+  brand: string | null;
+  condition: string | null;
+  created_at: string;
+  creator: string | null;
+  description: string | null;
+  id: string;
+  location: string | null;
+  name: string;
+  notes: string | null;
+  purchase_date: string | null;
+  /** Stored as text in PowerSync to preserve numeric(10,2) precision. */
+  purchase_price: string | null;
+  /**
+   * Defensively typed as `number | string | null` because the PowerSync WASM
+   * bridge has been observed to return integer columns as strings in some
+   * environments. The server schema declares this NOT NULL with default 1, but
+   * the test suite (parse-item.test.ts) actively exercises both string and
+   * null inputs via the bridge — keep this type until the upstream behavior
+   * is verified consistent across all SDK versions.
+   */
+  quantity: number | string | null;
+  type: string;
+  updated_at: string;
+  url: string | null;
+}
+
+function parseQuantity(value: number | string | null, rowId: string): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (value === null) {
+    return 1;
+  }
+  const parsed = Number.parseInt(String(value), 10);
+  if (Number.isNaN(parsed)) {
+    console.warn("[parseItemRow] NaN quantity coerced to 1", {
+      id: rowId,
+      field: "quantity",
+    });
+    return 1;
+  }
+  return parsed;
+}
+
+/**
+ * Parses a raw PowerSync `items` row into a typed `ParsedItem`.
+ *
+ * Returns `null` when `row.id` is not a valid UUID — callers must filter
+ * these out (e.g. `rows.map(parseItemRow).filter((x) => x !== null)`). The
+ * contract change from `ParsedItem` to `ParsedItem | null` closes the trust
+ * gap at the sync boundary that the brand constructors deliberately leave
+ * open (they're documented as type-only casts).
+ */
+export function parseItemRow(row: ItemRow): ParsedItem | null {
+  if (typeof row.id !== "string" || !UUID_RE.test(row.id)) {
+    console.warn("[parseItemRow] Invalid item id, skipping row", {
+      id: typeof row.id === "string" ? `${row.id.slice(0, 8)}...` : null,
+    });
+    return null;
+  }
+
+  let type: ItemType;
+  if (isItemType(row.type)) {
+    type = row.type;
+  } else {
+    console.warn("[parseItemRow] Unknown type coerced to 'other'", {
+      id: row.id,
+      field: "type",
+    });
+    type = "other";
+  }
+
+  let condition: ItemCondition | null = null;
+  if (row.condition !== null) {
+    if (isItemCondition(row.condition)) {
+      condition = row.condition;
+    } else {
+      console.warn("[parseItemRow] Unknown condition coerced to null", {
+        id: row.id,
+        field: "condition",
+      });
+    }
+  }
+
+  let purchasePrice: number | null = null;
+  if (row.purchase_price !== null) {
+    const parsed = Number.parseFloat(row.purchase_price);
+    if (Number.isNaN(parsed)) {
+      console.warn("[parseItemRow] NaN purchase_price coerced to null", {
+        id: row.id,
+        field: "purchase_price",
+      });
+    } else {
+      purchasePrice = parsed;
+    }
+  }
+
+  return {
+    brand: row.brand,
+    condition,
+    createdAt: row.created_at,
+    creator: row.creator,
+    description: row.description,
+    id: asItemId(row.id),
+    location: row.location,
+    name: row.name,
+    notes: row.notes,
+    purchaseDate: row.purchase_date,
+    purchasePrice,
+    quantity: parseQuantity(row.quantity, row.id),
+    type,
+    updatedAt: row.updated_at,
+    url: row.url,
+  };
+}

--- a/src/features/collect/hooks/use-item-brands.test.ts
+++ b/src/features/collect/hooks/use-item-brands.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}));
+
+vi.mock("@powersync/react", () => ({
+  useQuery: mockUseQuery,
+  usePowerSync: vi.fn(),
+}));
+
+import { useItemBrands } from "./use-item-brands";
+
+describe("useItemBrands hook", () => {
+  it("returns empty brands when data is empty", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    const { result } = renderHook(() => useItemBrands());
+    expect(result.current.brands).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("maps row.brand to a string array", () => {
+    mockUseQuery.mockReturnValue({
+      data: [{ brand: "Bicycle" }, { brand: "Theory11" }, { brand: "TCC" }],
+      isLoading: false,
+      error: null,
+    });
+    const { result } = renderHook(() => useItemBrands());
+    expect(result.current.brands).toEqual(["Bicycle", "Theory11", "TCC"]);
+  });
+
+  it("surfaces useQuery error", () => {
+    const err = new Error("query failed");
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: err });
+    const { result } = renderHook(() => useItemBrands());
+    expect(result.current.error).toBe(err);
+  });
+
+  it("returns null error when useQuery error is undefined", () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const { result } = renderHook(() => useItemBrands());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("issues a SQL query that selects DISTINCT non-empty brands", () => {
+    mockUseQuery.mockClear();
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    renderHook(() => useItemBrands());
+
+    const sql = mockUseQuery.mock.calls[0]?.[0] as string;
+    expect(sql).toContain("SELECT DISTINCT brand FROM items");
+    expect(sql).toContain("deleted_at IS NULL");
+    expect(sql).toContain("brand IS NOT NULL");
+    expect(sql).toContain("brand != ''");
+    expect(sql).toContain("ORDER BY brand ASC");
+  });
+});

--- a/src/features/collect/hooks/use-item-brands.ts
+++ b/src/features/collect/hooks/use-item-brands.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQuery } from "@powersync/react";
+
+interface BrandRow {
+  brand: string;
+}
+
+interface UseItemBrandsResult {
+  brands: string[];
+  error: Error | null;
+}
+
+/**
+ * Returns a reactive list of distinct brand values from the user's items.
+ * Used for combobox suggestions in the item form.
+ */
+export function useItemBrands(): UseItemBrandsResult {
+  const { data, error } = useQuery<BrandRow>(
+    "SELECT DISTINCT brand FROM items WHERE deleted_at IS NULL AND brand IS NOT NULL AND brand != '' ORDER BY brand ASC"
+  );
+
+  return { brands: data.map((row) => row.brand), error: error ?? null };
+}

--- a/src/features/collect/hooks/use-item-locations.test.ts
+++ b/src/features/collect/hooks/use-item-locations.test.ts
@@ -1,0 +1,70 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}));
+
+vi.mock("@powersync/react", () => ({
+  useQuery: mockUseQuery,
+  usePowerSync: vi.fn(),
+}));
+
+import { useItemLocations } from "./use-item-locations";
+
+describe("useItemLocations hook", () => {
+  it("returns empty locations when data is empty", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    const { result } = renderHook(() => useItemLocations());
+    expect(result.current.locations).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("maps row.location to a string array", () => {
+    mockUseQuery.mockReturnValue({
+      data: [
+        { location: "Close-up case" },
+        { location: "Stage case" },
+        { location: "Storage room" },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    const { result } = renderHook(() => useItemLocations());
+    expect(result.current.locations).toEqual([
+      "Close-up case",
+      "Stage case",
+      "Storage room",
+    ]);
+  });
+
+  it("surfaces useQuery error", () => {
+    const err = new Error("query failed");
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: err });
+    const { result } = renderHook(() => useItemLocations());
+    expect(result.current.error).toBe(err);
+  });
+
+  it("returns null error when useQuery error is undefined", () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const { result } = renderHook(() => useItemLocations());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("issues a SQL query that selects DISTINCT non-empty locations", () => {
+    mockUseQuery.mockClear();
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    renderHook(() => useItemLocations());
+
+    const sql = mockUseQuery.mock.calls[0]?.[0] as string;
+    expect(sql).toContain("SELECT DISTINCT location FROM items");
+    expect(sql).toContain("deleted_at IS NULL");
+    expect(sql).toContain("location IS NOT NULL");
+    expect(sql).toContain("location != ''");
+    expect(sql).toContain("ORDER BY location ASC");
+  });
+});

--- a/src/features/collect/hooks/use-item-locations.ts
+++ b/src/features/collect/hooks/use-item-locations.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQuery } from "@powersync/react";
+
+interface LocationRow {
+  location: string;
+}
+
+interface UseItemLocationsResult {
+  error: Error | null;
+  locations: string[];
+}
+
+/**
+ * Returns a reactive list of distinct location values from the user's items.
+ * Used for combobox suggestions in the item form.
+ */
+export function useItemLocations(): UseItemLocationsResult {
+  const { data, error } = useQuery<LocationRow>(
+    "SELECT DISTINCT location FROM items WHERE deleted_at IS NULL AND location IS NOT NULL AND location != '' ORDER BY location ASC"
+  );
+
+  return { locations: data.map((row) => row.location), error: error ?? null };
+}

--- a/src/features/collect/hooks/use-item-mutations.test.ts
+++ b/src/features/collect/hooks/use-item-mutations.test.ts
@@ -1,0 +1,1533 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ItemId, TagId, TrickId } from "@/db/types";
+
+/** Cast a string literal to a branded ID type for test convenience. */
+const itemId = (id: string) => id as ItemId;
+const tagId = (id: string) => id as TagId;
+const trickId = (id: string) => id as TrickId;
+
+// --- Mocks -----------------------------------------------------------
+
+const mockExecute = vi.fn().mockResolvedValue({ rowsAffected: 1 });
+const mockWriteTransaction = vi.fn(
+  async (cb: (tx: { execute: typeof mockExecute }) => Promise<void>) => {
+    await cb({ execute: mockExecute });
+  }
+);
+
+vi.mock("@powersync/react", () => ({
+  usePowerSync: vi.fn(() => ({
+    execute: mockExecute,
+    writeTransaction: mockWriteTransaction,
+  })),
+}));
+
+vi.mock("@/auth/client", () => ({
+  authClient: {
+    useSession: vi.fn(() => ({
+      data: { user: { id: "user-123" } },
+      isPending: false,
+    })),
+  },
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
+// Stable UUID for predictable assertions
+let uuidCounter = 0;
+vi.stubGlobal("crypto", {
+  ...globalThis.crypto,
+  randomUUID: () => `uuid-${++uuidCounter}`,
+});
+
+// --- Test suite -------------------------------------------------------
+
+describe("use-item-mutations", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-15T12:00:00.000Z"));
+    uuidCounter = 0;
+
+    // Restore authenticated session (may have been nulled by a previous test)
+    const { authClient } = await import("@/auth/client");
+    vi.mocked(authClient.useSession).mockReturnValue({
+      data: { user: { id: "user-123" } },
+      isPending: false,
+    } as ReturnType<typeof authClient.useSession>);
+
+    // Restore default writeTransaction behavior
+    mockWriteTransaction.mockImplementation(
+      async (cb: (tx: { execute: typeof mockExecute }) => Promise<void>) => {
+        await cb({ execute: mockExecute });
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function getHookExports() {
+    return import("./use-item-mutations");
+  }
+
+  // --- createItem tests -----------------------------------------------
+
+  describe("createItem", () => {
+    it("executes INSERT SQL within a write transaction", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Invisible Deck",
+          type: "deck",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        []
+      );
+
+      expect(mockWriteTransaction).toHaveBeenCalledOnce();
+      expect(mockExecute).toHaveBeenCalledOnce();
+
+      const sql = mockExecute.mock.calls[0]?.[0] as string;
+      expect(sql).toContain("INSERT INTO items");
+    });
+
+    it("returns the generated UUID", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      const id = await createItem(
+        {
+          name: "Invisible Deck",
+          type: "deck",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        []
+      );
+
+      expect(id).toBe("uuid-1");
+    });
+
+    it("produces INSERT params in correct column order", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Ambitious Card",
+          type: "deck",
+          description: "A classic effect",
+          brand: "Bicycle",
+          creator: "Bob Ostin",
+          condition: "new",
+          location: "Close-up case",
+          quantity: 2,
+          purchaseDate: "2025-01-10",
+          purchasePrice: "29.99",
+          url: "https://example.com",
+          notes: "Keep dry",
+        },
+        [],
+        []
+      );
+
+      const params = mockExecute.mock.calls[0]?.[1] as unknown[];
+      expect(params).toHaveLength(16);
+
+      expect(params[0]).toBe("uuid-1"); // id
+      expect(params[1]).toBe("user-123"); // user_id
+      expect(params[2]).toBe("Ambitious Card"); // name
+      expect(params[3]).toBe("deck"); // type
+      expect(params[4]).toBe("A classic effect"); // description
+      expect(params[5]).toBe("Bicycle"); // brand
+      expect(params[6]).toBe("new"); // condition
+      expect(params[7]).toBe("Close-up case"); // location
+      expect(params[8]).toBe("Keep dry"); // notes
+      expect(params[9]).toBe("2025-01-10"); // purchase_date
+      expect(params[10]).toBe("29.99"); // purchase_price
+      expect(params[11]).toBe(2); // quantity
+      expect(params[12]).toBe("Bob Ostin"); // creator
+      expect(params[13]).toBe("https://example.com"); // url
+      expect(params[14]).toBe("2025-01-15T12:00:00.000Z"); // created_at
+      expect(params[15]).toBe("2025-01-15T12:00:00.000Z"); // updated_at
+    });
+
+    it("converts empty string fields to null in SQL params", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        []
+      );
+
+      const params = mockExecute.mock.calls[0]?.[1] as unknown[];
+      // description (4), brand (5), location (7), notes (8), purchase_date (9),
+      // purchase_price (10), creator (12), url (13)
+      expect(params[4]).toBeNull(); // description
+      expect(params[5]).toBeNull(); // brand
+      expect(params[7]).toBeNull(); // location
+      expect(params[8]).toBeNull(); // notes
+      expect(params[9]).toBeNull(); // purchase_date
+      expect(params[10]).toBeNull(); // purchase_price
+      expect(params[12]).toBeNull(); // creator
+      expect(params[13]).toBeNull(); // url
+    });
+
+    it("converts null condition to null in SQL params", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        []
+      );
+
+      const params = mockExecute.mock.calls[0]?.[1] as unknown[];
+      expect(params[6]).toBeNull(); // condition
+    });
+
+    it("inserts tag junction rows when tagIds are provided", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [tagId("tag-a"), tagId("tag-b")],
+        []
+      );
+
+      // 1 item INSERT + 2 tag junction INSERTs
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+
+      const junctionSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(junctionSql).toContain("INSERT INTO item_tags");
+
+      const junctionParams1 = mockExecute.mock.calls[1]?.[1] as unknown[];
+      expect(junctionParams1).toContain("tag-a");
+
+      const junctionParams2 = mockExecute.mock.calls[2]?.[1] as unknown[];
+      expect(junctionParams2).toContain("tag-b");
+    });
+
+    it("includes user_id and item_id in tag junction params", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [tagId("tag-a")],
+        []
+      );
+
+      const junctionParams = mockExecute.mock.calls[1]?.[1] as unknown[];
+      // (id, user_id, item_id, tag_id, created_at, updated_at)
+      expect(junctionParams[1]).toBe("user-123"); // user_id
+      expect(junctionParams[2]).toBe("uuid-1"); // item_id (same as created item)
+      expect(junctionParams[3]).toBe("tag-a"); // tag_id
+    });
+
+    it("inserts trick junction rows when trickIds are provided", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        [trickId("trick-a"), trickId("trick-b")]
+      );
+
+      // 1 item INSERT + 2 trick junction INSERTs
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+
+      const junctionSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(junctionSql).toContain("INSERT INTO item_tricks");
+
+      const junctionParams2 = mockExecute.mock.calls[2]?.[1] as unknown[];
+      expect(junctionParams2).toContain("trick-b");
+    });
+
+    it("inserts both tag and trick junction rows", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [tagId("tag-a")],
+        [trickId("trick-a")]
+      );
+
+      // 1 item INSERT + 1 tag junction + 1 trick junction
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+    });
+
+    it("tracks item_created event with type on success", async () => {
+      const { trackEvent } = await import("@/lib/analytics");
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Item",
+          type: "book",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        []
+      );
+
+      expect(trackEvent).toHaveBeenCalledWith("item_created", { type: "book" });
+    });
+
+    it("wraps transaction errors with descriptive message", async () => {
+      mockWriteTransaction.mockRejectedValueOnce(new Error("DB locked"));
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await expect(
+        createItem(
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [],
+          []
+        )
+      ).rejects.toThrow("Failed to create item: DB locked");
+    });
+
+    it("throws when no authenticated user", async () => {
+      const { authClient } = await import("@/auth/client");
+      vi.mocked(authClient.useSession).mockReturnValue({
+        data: null,
+        isPending: false,
+      } as ReturnType<typeof authClient.useSession>);
+
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await expect(
+        createItem(
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [],
+          []
+        )
+      ).rejects.toThrow("Cannot mutate items without an authenticated user");
+    });
+
+    it("throws when tagIds exceed MAX_TAGS_PER_ITEM", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      const tooManyTags = Array.from({ length: 21 }, (_, i) =>
+        tagId(`tag-${i}`)
+      );
+
+      await expect(
+        createItem(
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          tooManyTags,
+          []
+        )
+      ).rejects.toThrow("MAX_TAGS");
+      expect(mockWriteTransaction).not.toHaveBeenCalled();
+    });
+
+    it("wraps non-Error exceptions with unknown error message", async () => {
+      mockWriteTransaction.mockRejectedValueOnce(42);
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await expect(
+        createItem(
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [],
+          []
+        )
+      ).rejects.toThrow("Failed to create item: Unknown error creating item");
+    });
+
+    it("converts whitespace-only fields to null via emptyToNull", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      await createItem(
+        {
+          name: "Item",
+          type: "prop",
+          description: "   ",
+          brand: "\t",
+          creator: "\n",
+          condition: null,
+          location: "  \t  ",
+          quantity: 1,
+          purchaseDate: " ",
+          purchasePrice: "  ",
+          url: "   ",
+          notes: "\n\t",
+        },
+        [],
+        []
+      );
+
+      const params = mockExecute.mock.calls[0]?.[1] as unknown[];
+      expect(params[4]).toBeNull(); // description
+      expect(params[5]).toBeNull(); // brand
+      expect(params[7]).toBeNull(); // location
+      expect(params[8]).toBeNull(); // notes
+      expect(params[9]).toBeNull(); // purchase_date
+      expect(params[10]).toBeNull(); // purchase_price
+      expect(params[12]).toBeNull(); // creator
+      expect(params[13]).toBeNull(); // url
+    });
+
+    it("accepts exactly MAX_TAGS_PER_ITEM tags without throwing", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      const exactLimitTags = Array.from({ length: 20 }, (_, i) =>
+        tagId(`tag-${i}`)
+      );
+
+      await createItem(
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        exactLimitTags,
+        []
+      );
+
+      // 1 item INSERT + 20 tag junction INSERTs
+      expect(mockExecute).toHaveBeenCalledTimes(21);
+    });
+
+    it("throws when trickIds exceed MAX_TRICKS_PER_ITEM", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { createItem } = useItemMutations();
+
+      const tooManyTricks = Array.from({ length: 51 }, (_, i) =>
+        trickId(`trick-${i}`)
+      );
+
+      await expect(
+        createItem(
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [],
+          tooManyTricks
+        )
+      ).rejects.toThrow("MAX_TRICKS");
+      expect(mockWriteTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- updateItem tests -----------------------------------------------
+
+  describe("updateItem", () => {
+    it("executes UPDATE SQL within a write transaction", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Updated Item",
+          type: "book",
+          description: "Updated description",
+          brand: "Theory11",
+          creator: "Someone",
+          condition: "good",
+          location: "Stage case",
+          quantity: 3,
+          purchaseDate: "2025-02-01",
+          purchasePrice: "49.99",
+          url: "https://example.com/updated",
+          notes: "Updated notes",
+        },
+        [],
+        [],
+        [],
+        []
+      );
+
+      expect(mockWriteTransaction).toHaveBeenCalledOnce();
+      const sql = mockExecute.mock.calls[0]?.[0] as string;
+      expect(sql).toContain("UPDATE items SET");
+      expect(sql).toContain(
+        "WHERE id = ? AND user_id = ? AND deleted_at IS NULL"
+      );
+    });
+
+    it("places item id and user_id as last WHERE clause params", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        [],
+        [],
+        []
+      );
+
+      const params = mockExecute.mock.calls[0]?.[1] as unknown[];
+      expect(params.at(-2)).toBe("item-1"); // id
+      expect(params.at(-1)).toBe("user-123"); // user_id
+    });
+
+    it("soft-deletes removed tag associations", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        [tagId("tag-remove")],
+        [],
+        []
+      );
+
+      // 1 UPDATE item + 1 soft-delete tag
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+      const removeSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(removeSql).toContain("UPDATE item_tags SET deleted_at = ?");
+      const removeParams = mockExecute.mock.calls[1]?.[1] as unknown[];
+      expect(removeParams).toContain("tag-remove");
+      expect(removeParams).toContain("item-1");
+    });
+
+    it("restores soft-deleted tag association instead of inserting", async () => {
+      // When the restore UPDATE affects a row, no INSERT should follow
+      mockExecute
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // item UPDATE
+        .mockResolvedValueOnce({ rowsAffected: 1 }); // restore UPDATE hits a row
+
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [tagId("tag-restore")],
+        [],
+        [],
+        []
+      );
+
+      // 1 UPDATE item + 1 restore UPDATE (no INSERT because rowsAffected > 0)
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+      const restoreSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(restoreSql).toContain("UPDATE item_tags SET deleted_at = NULL");
+      const restoreParams = mockExecute.mock.calls[1]?.[1] as unknown[];
+      expect(restoreParams).toContain("tag-restore");
+    });
+
+    it("inserts new tag association when no soft-deleted row exists", async () => {
+      mockExecute
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // item UPDATE
+        .mockResolvedValueOnce({ rowsAffected: 0 }); // restore UPDATE finds no row
+
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [tagId("tag-add")],
+        [],
+        [],
+        []
+      );
+
+      // 1 UPDATE item + 1 restore attempt (UPDATE item_tags) + 1 INSERT tag junction
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+      const restoreSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(restoreSql).toContain("UPDATE item_tags SET deleted_at = NULL");
+      const addSql = mockExecute.mock.calls[2]?.[0] as string;
+      expect(addSql).toContain("INSERT INTO item_tags");
+      const addParams = mockExecute.mock.calls[2]?.[1] as unknown[];
+      expect(addParams).toContain("tag-add");
+    });
+
+    it("soft-deletes removed trick associations", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        [],
+        [],
+        [trickId("trick-remove")]
+      );
+
+      // 1 UPDATE item + 1 soft-delete trick
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+      const removeSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(removeSql).toContain("UPDATE item_tricks SET deleted_at = ?");
+      const removeParams = mockExecute.mock.calls[1]?.[1] as unknown[];
+      expect(removeParams).toContain("trick-remove");
+      expect(removeParams).toContain("item-1");
+    });
+
+    it("restores soft-deleted trick association instead of inserting", async () => {
+      mockExecute
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // item UPDATE
+        .mockResolvedValueOnce({ rowsAffected: 1 }); // restore UPDATE hits a row
+
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        [],
+        [trickId("trick-restore")],
+        []
+      );
+
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+      const restoreSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(restoreSql).toContain("UPDATE item_tricks SET deleted_at = NULL");
+      const restoreParams = mockExecute.mock.calls[1]?.[1] as unknown[];
+      expect(restoreParams).toContain("trick-restore");
+    });
+
+    it("inserts new trick association when no soft-deleted row exists", async () => {
+      mockExecute
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // item UPDATE
+        .mockResolvedValueOnce({ rowsAffected: 0 }); // restore UPDATE finds no row
+
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        [],
+        [trickId("trick-add")],
+        []
+      );
+
+      // 1 UPDATE item + 1 restore attempt + 1 INSERT trick junction
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+      const addSql = mockExecute.mock.calls[2]?.[0] as string;
+      expect(addSql).toContain("INSERT INTO item_tricks");
+      const addParams = mockExecute.mock.calls[2]?.[1] as unknown[];
+      expect(addParams).toContain("trick-add");
+    });
+
+    it("tracks item_updated event on success", async () => {
+      const { trackEvent } = await import("@/lib/analytics");
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        [],
+        [],
+        []
+      );
+
+      expect(trackEvent).toHaveBeenCalledWith("item_updated");
+    });
+
+    it("wraps transaction errors with descriptive message", async () => {
+      mockWriteTransaction.mockRejectedValueOnce(new Error("DB locked"));
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await expect(
+        updateItem(
+          itemId("item-1"),
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [],
+          [],
+          [],
+          []
+        )
+      ).rejects.toThrow("Failed to update item: DB locked");
+    });
+
+    it("throws when no authenticated user", async () => {
+      const { authClient } = await import("@/auth/client");
+      vi.mocked(authClient.useSession).mockReturnValue({
+        data: null,
+        isPending: false,
+      } as ReturnType<typeof authClient.useSession>);
+
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await expect(
+        updateItem(
+          itemId("item-1"),
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [],
+          [],
+          [],
+          []
+        )
+      ).rejects.toThrow("Cannot mutate items without an authenticated user");
+    });
+
+    it("throws when item not found or already deleted", async () => {
+      mockExecute.mockResolvedValueOnce({ rowsAffected: 0 });
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await expect(
+        updateItem(
+          itemId("item-1"),
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [],
+          [],
+          [],
+          []
+        )
+      ).rejects.toThrow("ITEM_NOT_FOUND");
+    });
+
+    it("applies combined tag and trick add+remove diffs without cross-contamination", async () => {
+      mockExecute
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // 0: item UPDATE
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // 1: soft-delete tag-remove
+        .mockResolvedValueOnce({ rowsAffected: 0 }) // 2: restore tag-add (no row)
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // 3: INSERT tag-add
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // 4: soft-delete trick-remove
+        .mockResolvedValueOnce({ rowsAffected: 0 }) // 5: restore trick-add (no row)
+        .mockResolvedValueOnce({ rowsAffected: 1 }); // 6: INSERT trick-add
+
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [tagId("tag-add")],
+        [tagId("tag-remove")],
+        [trickId("trick-add")],
+        [trickId("trick-remove")]
+      );
+
+      expect(mockExecute).toHaveBeenCalledTimes(7);
+
+      // Item UPDATE first
+      expect(mockExecute.mock.calls[0]?.[0]).toContain("UPDATE items SET");
+
+      // Tag operations: remove first, then restore-attempt, then INSERT
+      const tagRemoveSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(tagRemoveSql).toContain("UPDATE item_tags SET deleted_at = ?");
+      expect(mockExecute.mock.calls[1]?.[1]).toContain("tag-remove");
+
+      const tagRestoreSql = mockExecute.mock.calls[2]?.[0] as string;
+      expect(tagRestoreSql).toContain("UPDATE item_tags SET deleted_at = NULL");
+      expect(mockExecute.mock.calls[2]?.[1]).toContain("tag-add");
+
+      const tagInsertSql = mockExecute.mock.calls[3]?.[0] as string;
+      expect(tagInsertSql).toContain("INSERT INTO item_tags");
+      expect(mockExecute.mock.calls[3]?.[1]).toContain("tag-add");
+
+      // Trick operations: remove first, then restore-attempt, then INSERT
+      const trickRemoveSql = mockExecute.mock.calls[4]?.[0] as string;
+      expect(trickRemoveSql).toContain("UPDATE item_tricks SET deleted_at = ?");
+      expect(mockExecute.mock.calls[4]?.[1]).toContain("trick-remove");
+
+      const trickRestoreSql = mockExecute.mock.calls[5]?.[0] as string;
+      expect(trickRestoreSql).toContain(
+        "UPDATE item_tricks SET deleted_at = NULL"
+      );
+      expect(mockExecute.mock.calls[5]?.[1]).toContain("trick-add");
+
+      const trickInsertSql = mockExecute.mock.calls[6]?.[0] as string;
+      expect(trickInsertSql).toContain("INSERT INTO item_tricks");
+      expect(mockExecute.mock.calls[6]?.[1]).toContain("trick-add");
+    });
+
+    it("handles same trick ID in both addTrickIds and removeTrickIds (soft-deletes then restores)", async () => {
+      mockExecute
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // item UPDATE
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // soft-delete trick-a
+        .mockResolvedValueOnce({ rowsAffected: 1 }); // restore trick-a
+
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [],
+        [],
+        [trickId("trick-a")],
+        [trickId("trick-a")]
+      );
+
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+
+      const softDeleteSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(softDeleteSql).toContain("UPDATE item_tricks SET deleted_at = ?");
+      expect(mockExecute.mock.calls[1]?.[1]).toContain("trick-a");
+
+      const restoreSql = mockExecute.mock.calls[2]?.[0] as string;
+      expect(restoreSql).toContain("UPDATE item_tricks SET deleted_at = NULL");
+      expect(mockExecute.mock.calls[2]?.[1]).toContain("trick-a");
+    });
+
+    it("short-circuits junction operations when item UPDATE rowsAffected is 0", async () => {
+      mockExecute.mockResolvedValueOnce({ rowsAffected: 0 });
+
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await expect(
+        updateItem(
+          itemId("item-1"),
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [tagId("tag-a")],
+          [tagId("tag-b")],
+          [trickId("trick-a")],
+          [trickId("trick-b")]
+        )
+      ).rejects.toThrow("ITEM_NOT_FOUND");
+
+      // Only the item UPDATE should have run; junction diffs must not execute
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      expect(mockExecute.mock.calls[0]?.[0]).toContain("UPDATE items SET");
+    });
+
+    it("handles same tag ID in both addTagIds and removeTagIds (soft-deletes then restores)", async () => {
+      mockExecute
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // item UPDATE
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // soft-delete tag-a
+        .mockResolvedValueOnce({ rowsAffected: 1 }); // restore tag-a (hits the just-deleted row)
+
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Item",
+          type: "prop",
+          description: "",
+          brand: "",
+          creator: "",
+          condition: null,
+          location: "",
+          quantity: 1,
+          purchaseDate: "",
+          purchasePrice: "",
+          url: "",
+          notes: "",
+        },
+        [tagId("tag-a")],
+        [tagId("tag-a")],
+        [],
+        []
+      );
+
+      // 1 item UPDATE + 1 soft-delete + 1 restore (no INSERT since restore succeeded)
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+
+      const softDeleteSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(softDeleteSql).toContain("UPDATE item_tags SET deleted_at = ?");
+      const softDeleteParams = mockExecute.mock.calls[1]?.[1] as unknown[];
+      expect(softDeleteParams).toContain("tag-a");
+
+      const restoreSql = mockExecute.mock.calls[2]?.[0] as string;
+      expect(restoreSql).toContain("UPDATE item_tags SET deleted_at = NULL");
+      const restoreParams = mockExecute.mock.calls[2]?.[1] as unknown[];
+      expect(restoreParams).toContain("tag-a");
+    });
+
+    it("produces UPDATE params in correct column order", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await updateItem(
+        itemId("item-1"),
+        {
+          name: "Ambitious Card",
+          type: "deck",
+          description: "A classic effect",
+          brand: "Bicycle",
+          creator: "Bob Ostin",
+          condition: "new",
+          location: "Close-up case",
+          quantity: 2,
+          purchaseDate: "2025-01-10",
+          purchasePrice: "29.99",
+          url: "https://example.com",
+          notes: "Keep dry",
+        },
+        [],
+        [],
+        [],
+        []
+      );
+
+      const params = mockExecute.mock.calls[0]?.[1] as unknown[];
+      expect(params).toHaveLength(16);
+
+      expect(params[0]).toBe("user-123"); // user_id
+      expect(params[1]).toBe("Ambitious Card"); // name
+      expect(params[2]).toBe("deck"); // type
+      expect(params[3]).toBe("A classic effect"); // description
+      expect(params[4]).toBe("Bicycle"); // brand
+      expect(params[5]).toBe("new"); // condition
+      expect(params[6]).toBe("Close-up case"); // location
+      expect(params[7]).toBe("Keep dry"); // notes
+      expect(params[8]).toBe("2025-01-10"); // purchase_date
+      expect(params[9]).toBe("29.99"); // purchase_price
+      expect(params[10]).toBe(2); // quantity
+      expect(params[11]).toBe("Bob Ostin"); // creator
+      expect(params[12]).toBe("https://example.com"); // url
+      expect(params[13]).toBe("2025-01-15T12:00:00.000Z"); // updated_at
+      expect(params[14]).toBe("item-1"); // id (WHERE)
+      expect(params[15]).toBe("user-123"); // user_id (WHERE)
+    });
+
+    it("wraps non-Error exceptions with unknown error message", async () => {
+      mockWriteTransaction.mockRejectedValueOnce("string error");
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      await expect(
+        updateItem(
+          itemId("item-1"),
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [],
+          [],
+          [],
+          []
+        )
+      ).rejects.toThrow("Failed to update item: Unknown error updating item");
+    });
+
+    it("throws when addTagIds exceed MAX_TAGS_PER_ITEM", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      const tooManyTags = Array.from({ length: 21 }, (_, i) =>
+        tagId(`tag-${i}`)
+      );
+
+      await expect(
+        updateItem(
+          itemId("item-1"),
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          tooManyTags,
+          [],
+          [],
+          []
+        )
+      ).rejects.toThrow("MAX_TAGS");
+      expect(mockWriteTransaction).not.toHaveBeenCalled();
+    });
+
+    it("throws when addTrickIds exceed MAX_TRICKS_PER_ITEM", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { updateItem } = useItemMutations();
+
+      const tooManyTricks = Array.from({ length: 51 }, (_, i) =>
+        trickId(`trick-${i}`)
+      );
+
+      await expect(
+        updateItem(
+          itemId("item-1"),
+          {
+            name: "Item",
+            type: "prop",
+            description: "",
+            brand: "",
+            creator: "",
+            condition: null,
+            location: "",
+            quantity: 1,
+            purchaseDate: "",
+            purchasePrice: "",
+            url: "",
+            notes: "",
+          },
+          [],
+          [],
+          tooManyTricks,
+          []
+        )
+      ).rejects.toThrow("MAX_TRICKS");
+      expect(mockWriteTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- deleteItem tests -----------------------------------------------
+
+  describe("deleteItem", () => {
+    it("soft-deletes item, item_tags, and item_tricks in one transaction", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await deleteItem(itemId("item-1"));
+
+      // 1 item soft-delete + 1 item_tags cascade + 1 item_tricks cascade
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+    });
+
+    it("soft-deletes the item row with correct params", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await deleteItem(itemId("item-1"));
+
+      const itemSql = mockExecute.mock.calls[0]?.[0] as string;
+      expect(itemSql).toContain("UPDATE items SET deleted_at = ?");
+      expect(itemSql).toContain("WHERE id = ?");
+      expect(itemSql).toContain("user_id = ?");
+
+      const itemParams = mockExecute.mock.calls[0]?.[1] as unknown[];
+      expect(itemParams[0]).toBe("2025-01-15T12:00:00.000Z"); // deleted_at
+      expect(itemParams[1]).toBe("2025-01-15T12:00:00.000Z"); // updated_at
+      expect(itemParams[2]).toBe("item-1"); // id
+      expect(itemParams[3]).toBe("user-123"); // user_id
+    });
+
+    it("soft-deletes item_tags rows with correct params", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await deleteItem(itemId("item-1"));
+
+      const tagsSql = mockExecute.mock.calls[1]?.[0] as string;
+      expect(tagsSql).toContain("UPDATE item_tags SET deleted_at = ?");
+      expect(tagsSql).toContain("WHERE item_id = ?");
+      expect(tagsSql).toContain("user_id = ?");
+
+      const tagsParams = mockExecute.mock.calls[1]?.[1] as unknown[];
+      expect(tagsParams).toContain("item-1"); // item_id
+      expect(tagsParams).toContain("user-123"); // user_id
+    });
+
+    it("soft-deletes item_tricks rows with correct params", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await deleteItem(itemId("item-1"));
+
+      const tricksSql = mockExecute.mock.calls[2]?.[0] as string;
+      expect(tricksSql).toContain("UPDATE item_tricks SET deleted_at = ?");
+      expect(tricksSql).toContain("WHERE item_id = ?");
+      expect(tricksSql).toContain("user_id = ?");
+
+      const tricksParams = mockExecute.mock.calls[2]?.[1] as unknown[];
+      expect(tricksParams).toContain("item-1"); // item_id
+      expect(tricksParams).toContain("user-123"); // user_id
+    });
+
+    it("sets deleted_at only on non-deleted rows", async () => {
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await deleteItem(itemId("item-1"));
+
+      const itemSql = mockExecute.mock.calls[0]?.[0] as string;
+      expect(itemSql).toContain("deleted_at IS NULL");
+    });
+
+    it("throws when item not found or already deleted", async () => {
+      mockExecute.mockResolvedValueOnce({ rowsAffected: 0 });
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await expect(deleteItem(itemId("item-1"))).rejects.toThrow(
+        "ITEM_NOT_FOUND"
+      );
+    });
+
+    it("tracks item_deleted event on success", async () => {
+      const { trackEvent } = await import("@/lib/analytics");
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await deleteItem(itemId("item-1"));
+
+      expect(trackEvent).toHaveBeenCalledWith("item_deleted");
+    });
+
+    it("wraps execution errors with descriptive message", async () => {
+      mockExecute.mockRejectedValueOnce(new Error("Connection lost"));
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await expect(deleteItem(itemId("item-1"))).rejects.toThrow(
+        "Failed to delete item: Connection lost"
+      );
+    });
+
+    it("wraps non-Error exceptions with unknown error message", async () => {
+      mockWriteTransaction.mockRejectedValueOnce("something went wrong");
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await expect(deleteItem(itemId("item-1"))).rejects.toThrow(
+        "Failed to delete item: Unknown error deleting item"
+      );
+    });
+
+    it("throws when no authenticated user", async () => {
+      const { authClient } = await import("@/auth/client");
+      vi.mocked(authClient.useSession).mockReturnValue({
+        data: null,
+        isPending: false,
+      } as ReturnType<typeof authClient.useSession>);
+
+      const { useItemMutations } = await getHookExports();
+      const { deleteItem } = useItemMutations();
+
+      await expect(deleteItem(itemId("item-1"))).rejects.toThrow(
+        "Cannot mutate items without an authenticated user"
+      );
+    });
+  });
+
+  // Direct unit tests for the pure helper. Previously it was only exercised
+  // transitively through collect-view, which meant the null-fallback path
+  // and non-Error inputs had no coverage. The `satisfies` exhaustiveness
+  // check protects compile time — these tests protect runtime.
+  describe("getMutationErrorKey", () => {
+    it("maps MaxTagsError to validation.tooManyTags", async () => {
+      const { getMutationErrorKey, MaxTagsError } = await getHookExports();
+      expect(getMutationErrorKey(new MaxTagsError())).toBe(
+        "validation.tooManyTags"
+      );
+    });
+
+    it("maps MaxTricksError to validation.tooManyTricks", async () => {
+      const { getMutationErrorKey, MaxTricksError } = await getHookExports();
+      expect(getMutationErrorKey(new MaxTricksError())).toBe(
+        "validation.tooManyTricks"
+      );
+    });
+
+    it("maps ItemNotFoundError to errors.itemMissing", async () => {
+      const { getMutationErrorKey, ItemNotFoundError } = await getHookExports();
+      expect(getMutationErrorKey(new ItemNotFoundError())).toBe(
+        "errors.itemMissing"
+      );
+    });
+
+    it("returns null for a generic Error", async () => {
+      const { getMutationErrorKey } = await getHookExports();
+      expect(getMutationErrorKey(new Error("boom"))).toBeNull();
+    });
+
+    it("returns null for non-Error values", async () => {
+      const { getMutationErrorKey } = await getHookExports();
+      expect(getMutationErrorKey(null)).toBeNull();
+      expect(getMutationErrorKey(undefined)).toBeNull();
+      expect(getMutationErrorKey("string error")).toBeNull();
+      expect(getMutationErrorKey({ tag: "MAX_TAGS" })).toBeNull();
+      expect(getMutationErrorKey(42)).toBeNull();
+    });
+  });
+});

--- a/src/features/collect/hooks/use-item-mutations.ts
+++ b/src/features/collect/hooks/use-item-mutations.ts
@@ -1,0 +1,447 @@
+"use client";
+
+import { usePowerSync } from "@powersync/react";
+import { authClient } from "@/auth/client";
+import {
+  asItemId,
+  asUserId,
+  type ItemId,
+  type TagId,
+  type TrickId,
+  type UserId,
+} from "@/db/types";
+import { trackEvent } from "@/lib/analytics";
+import { MAX_TAGS_PER_ITEM, MAX_TRICKS_PER_ITEM } from "../constants";
+import type { ItemFormValues } from "../schema";
+
+interface UseItemMutationsReturn {
+  createItem: (
+    data: ItemFormValues,
+    tagIds: TagId[],
+    trickIds: TrickId[]
+  ) => Promise<ItemId>;
+  deleteItem: (id: ItemId) => Promise<void>;
+  updateItem: (
+    id: ItemId,
+    data: ItemFormValues,
+    addTagIds: TagId[],
+    removeTagIds: TagId[],
+    addTrickIds: TrickId[],
+    removeTrickIds: TrickId[]
+  ) => Promise<void>;
+}
+
+/**
+ * Typed mutation errors. The `tag` field discriminates error kinds so the
+ * UI toast boundary can map each tag to a localized message without relying
+ * on the English `message` text.
+ */
+class MaxTagsError extends Error {
+  readonly tag = "MAX_TAGS" as const;
+  constructor() {
+    super("MAX_TAGS");
+    this.name = "MaxTagsError";
+  }
+}
+
+class MaxTricksError extends Error {
+  readonly tag = "MAX_TRICKS" as const;
+  constructor() {
+    super("MAX_TRICKS");
+    this.name = "MaxTricksError";
+  }
+}
+
+class ItemNotFoundError extends Error {
+  readonly tag = "ITEM_NOT_FOUND" as const;
+  constructor() {
+    super("ITEM_NOT_FOUND");
+    this.name = "ItemNotFoundError";
+  }
+}
+
+type TypedMutationError = MaxTagsError | MaxTricksError | ItemNotFoundError;
+
+function isTypedMutationError(error: unknown): error is TypedMutationError {
+  return (
+    error instanceof MaxTagsError ||
+    error instanceof MaxTricksError ||
+    error instanceof ItemNotFoundError
+  );
+}
+
+type TypedMutationErrorTag = TypedMutationError["tag"];
+
+/**
+ * Maps each typed error tag to an i18n key. The `satisfies` clause makes
+ * this map exhaustive at compile time — adding a new typed error class
+ * without updating this map fails `tsc`.
+ */
+const MUTATION_ERROR_I18N_KEYS = {
+  MAX_TAGS: "validation.tooManyTags",
+  MAX_TRICKS: "validation.tooManyTricks",
+  ITEM_NOT_FOUND: "errors.itemMissing",
+} as const satisfies Record<TypedMutationErrorTag, string>;
+
+/**
+ * Maps a caught mutation error to its i18n key, or `null` if it's not a
+ * typed mutation error. Consumers use this at toast boundaries to replace
+ * the `instanceof` chain duplication across call sites.
+ */
+export function getMutationErrorKey(error: unknown): string | null {
+  if (!isTypedMutationError(error)) {
+    return null;
+  }
+  return MUTATION_ERROR_I18N_KEYS[error.tag];
+}
+
+export { ItemNotFoundError, MaxTagsError, MaxTricksError };
+
+/** Converts an empty string to null for nullable text columns. */
+function emptyToNull(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Builds the flat array of SQL parameter values from form data for INSERT.
+ *
+ * **Column order must exactly match `ITEM_COLUMNS`:**
+ *
+ * | Index | Column         | Source                 |
+ * |------:|----------------|------------------------|
+ * |     0 | id             | id                     |
+ * |     1 | user_id        | userId                 |
+ * |     2 | name           | data.name              |
+ * |     3 | type           | data.type              |
+ * |     4 | description    | data.description       |
+ * |     5 | brand          | data.brand             |
+ * |     6 | condition      | data.condition         |
+ * |     7 | location       | data.location          |
+ * |     8 | notes          | data.notes             |
+ * |     9 | purchase_date  | data.purchaseDate      |
+ * |    10 | purchase_price | data.purchasePrice     |
+ * |    11 | quantity       | data.quantity           |
+ * |    12 | creator        | data.creator           |
+ * |    13 | url            | data.url               |
+ * |    14 | created_at     | now                    |
+ * |    15 | updated_at     | now                    |
+ */
+function buildItemParams(
+  data: ItemFormValues,
+  userId: UserId,
+  id: ItemId,
+  now: string
+): (string | number | null)[] {
+  return [
+    id, // 0  id
+    userId, // 1  user_id
+    data.name, // 2  name
+    data.type, // 3  type
+    emptyToNull(data.description), // 4  description
+    emptyToNull(data.brand), // 5  brand
+    data.condition ?? null, // 6  condition
+    emptyToNull(data.location), // 7  location
+    emptyToNull(data.notes), // 8  notes
+    emptyToNull(data.purchaseDate), // 9  purchase_date
+    emptyToNull(data.purchasePrice), // 10 purchase_price
+    data.quantity ?? 1, // 11 quantity
+    emptyToNull(data.creator), // 12 creator
+    emptyToNull(data.url), // 13 url
+    now, // 14 created_at
+    now, // 15 updated_at
+  ];
+}
+
+/**
+ * Narrowed transaction interface for junction table operations.
+ *
+ * PowerSync's `Transaction` (from `@powersync/common`) extends `LockContext`
+ * which extends `SqlExecutor`. `SqlExecutor.execute` uses `params?: any[]`
+ * and returns `Promise<QueryResult>`, which includes `rowsAffected` plus
+ * extra fields (insertId, rows) we don't need here. Using the PowerSync
+ * `Transaction` type directly would work, but it also exposes `commit()`,
+ * `rollback()`, `getAll()`, `getOptional()`, `get()`, `executeBatch()`, and
+ * `executeRaw()` — none of which junction diffs should call. This minimal
+ * interface keeps the contract narrow on purpose.
+ */
+interface JunctionTransaction {
+  execute(sql: string, params: unknown[]): Promise<{ rowsAffected: number }>;
+}
+
+/** Discriminated config for type-safe junction table diffs. */
+type JunctionDiffConfig =
+  | {
+      table: "item_tags";
+      fkColumn: "tag_id";
+      addIds: TagId[];
+      removeIds: TagId[];
+    }
+  | {
+      table: "item_tricks";
+      fkColumn: "trick_id";
+      addIds: TrickId[];
+      removeIds: TrickId[];
+    };
+
+/** Applies junction table diffs (soft-delete removed, restore/insert added). */
+async function applyJunctionDiff(
+  tx: JunctionTransaction,
+  config: JunctionDiffConfig,
+  itemId: ItemId,
+  userId: UserId,
+  now: string
+): Promise<void> {
+  const { table, fkColumn, addIds, removeIds } = config;
+
+  for (const fkId of removeIds) {
+    await tx.execute(
+      `UPDATE ${table} SET deleted_at = ?, updated_at = ? WHERE item_id = ? AND ${fkColumn} = ? AND user_id = ? AND deleted_at IS NULL`,
+      [now, now, itemId, fkId, userId]
+    );
+  }
+
+  for (const fkId of addIds) {
+    const restored = await tx.execute(
+      `UPDATE ${table} SET deleted_at = NULL, updated_at = ? WHERE item_id = ? AND ${fkColumn} = ? AND user_id = ? AND deleted_at IS NOT NULL`,
+      [now, itemId, fkId, userId]
+    );
+    if (!restored.rowsAffected) {
+      const junctionId = crypto.randomUUID();
+      await tx.execute(
+        `INSERT INTO ${table} (id, user_id, item_id, ${fkColumn}, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+        [junctionId, userId, itemId, fkId, now, now]
+      );
+    }
+  }
+}
+
+const ITEM_COLUMNS = [
+  "id",
+  "user_id",
+  "name",
+  "type",
+  "description",
+  "brand",
+  "condition",
+  "location",
+  "notes",
+  "purchase_date",
+  "purchase_price",
+  "quantity",
+  "creator",
+  "url",
+  "created_at",
+  "updated_at",
+] as const;
+
+const ITEM_INSERT_SQL = `
+  INSERT INTO items (${ITEM_COLUMNS.join(", ")})
+  VALUES (${ITEM_COLUMNS.map(() => "?").join(", ")})
+`;
+
+/** Columns excluded from UPDATE SET — they're immutable after INSERT. */
+const ITEM_UPDATE_EXCLUDE = new Set(["id", "created_at"]);
+
+const ITEM_UPDATE_COLUMNS = ITEM_COLUMNS.filter(
+  (col) => !ITEM_UPDATE_EXCLUDE.has(col)
+);
+
+const ITEM_UPDATE_SQL = `
+  UPDATE items SET
+    ${ITEM_UPDATE_COLUMNS.map((col) => `${col} = ?`).join(",\n    ")}
+  WHERE id = ? AND user_id = ? AND deleted_at IS NULL
+`;
+
+/**
+ * Provides mutation functions for creating, updating, and deleting items
+ * in the local PowerSync SQLite database.
+ *
+ * Writes are queued by PowerSync and synced to Neon Postgres in the background.
+ * The caller is responsible for showing toast notifications on success/error.
+ */
+export function useItemMutations(): UseItemMutationsReturn {
+  const db = usePowerSync();
+  const { data: session } = authClient.useSession();
+
+  function getUserId(): UserId {
+    const userId = session?.user?.id;
+    if (!userId) {
+      throw new Error("Cannot mutate items without an authenticated user");
+    }
+    return asUserId(userId);
+  }
+
+  async function createItem(
+    data: ItemFormValues,
+    tagIds: TagId[],
+    trickIds: TrickId[]
+  ): Promise<ItemId> {
+    if (tagIds.length > MAX_TAGS_PER_ITEM) {
+      throw new MaxTagsError();
+    }
+    if (trickIds.length > MAX_TRICKS_PER_ITEM) {
+      throw new MaxTricksError();
+    }
+
+    const userId = getUserId();
+    const id = asItemId(crypto.randomUUID());
+    const now = new Date().toISOString();
+
+    try {
+      await db.writeTransaction(async (tx) => {
+        await tx.execute(
+          ITEM_INSERT_SQL,
+          buildItemParams(data, userId, id, now)
+        );
+
+        for (const tagId of tagIds) {
+          const junctionId = crypto.randomUUID();
+          await tx.execute(
+            "INSERT INTO item_tags (id, user_id, item_id, tag_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+            [junctionId, userId, id, tagId, now, now]
+          );
+        }
+
+        for (const trickId of trickIds) {
+          const junctionId = crypto.randomUUID();
+          await tx.execute(
+            "INSERT INTO item_tricks (id, user_id, item_id, trick_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+            [junctionId, userId, id, trickId, now, now]
+          );
+        }
+      });
+
+      trackEvent("item_created", { type: data.type });
+
+      return id;
+    } catch (error: unknown) {
+      if (isTypedMutationError(error)) {
+        throw error;
+      }
+      const message =
+        error instanceof Error ? error.message : "Unknown error creating item";
+      throw new Error(`Failed to create item: ${message}`, { cause: error });
+    }
+  }
+
+  async function updateItem(
+    id: ItemId,
+    data: ItemFormValues,
+    addTagIds: TagId[],
+    removeTagIds: TagId[],
+    addTrickIds: TrickId[],
+    removeTrickIds: TrickId[]
+  ): Promise<void> {
+    if (addTagIds.length > MAX_TAGS_PER_ITEM) {
+      throw new MaxTagsError();
+    }
+    if (addTrickIds.length > MAX_TRICKS_PER_ITEM) {
+      throw new MaxTricksError();
+    }
+
+    const userId = getUserId();
+    const now = new Date().toISOString();
+
+    try {
+      await db.writeTransaction(async (tx) => {
+        const updateParams = [
+          userId,
+          data.name,
+          data.type,
+          emptyToNull(data.description),
+          emptyToNull(data.brand),
+          data.condition ?? null,
+          emptyToNull(data.location),
+          emptyToNull(data.notes),
+          emptyToNull(data.purchaseDate),
+          emptyToNull(data.purchasePrice),
+          data.quantity ?? 1,
+          emptyToNull(data.creator),
+          emptyToNull(data.url),
+          now,
+          id,
+          userId,
+        ];
+
+        const result = await tx.execute(ITEM_UPDATE_SQL, updateParams);
+        if (!result.rowsAffected) {
+          throw new ItemNotFoundError();
+        }
+
+        await applyJunctionDiff(
+          tx,
+          {
+            table: "item_tags",
+            fkColumn: "tag_id",
+            addIds: addTagIds,
+            removeIds: removeTagIds,
+          },
+          id,
+          userId,
+          now
+        );
+        await applyJunctionDiff(
+          tx,
+          {
+            table: "item_tricks",
+            fkColumn: "trick_id",
+            addIds: addTrickIds,
+            removeIds: removeTrickIds,
+          },
+          id,
+          userId,
+          now
+        );
+      });
+
+      trackEvent("item_updated");
+    } catch (error: unknown) {
+      if (isTypedMutationError(error)) {
+        throw error;
+      }
+      const message =
+        error instanceof Error ? error.message : "Unknown error updating item";
+      throw new Error(`Failed to update item: ${message}`, { cause: error });
+    }
+  }
+
+  async function deleteItem(id: ItemId): Promise<void> {
+    const userId = getUserId();
+    const now = new Date().toISOString();
+
+    try {
+      await db.writeTransaction(async (tx) => {
+        const result = await tx.execute(
+          "UPDATE items SET deleted_at = ?, updated_at = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
+          [now, now, id, userId]
+        );
+        if (!result.rowsAffected) {
+          throw new ItemNotFoundError();
+        }
+        await tx.execute(
+          "UPDATE item_tags SET deleted_at = ?, updated_at = ? WHERE item_id = ? AND user_id = ? AND deleted_at IS NULL",
+          [now, now, id, userId]
+        );
+        await tx.execute(
+          "UPDATE item_tricks SET deleted_at = ?, updated_at = ? WHERE item_id = ? AND user_id = ? AND deleted_at IS NULL",
+          [now, now, id, userId]
+        );
+      });
+
+      trackEvent("item_deleted");
+    } catch (error: unknown) {
+      if (isTypedMutationError(error)) {
+        throw error;
+      }
+      const message =
+        error instanceof Error ? error.message : "Unknown error deleting item";
+      throw new Error(`Failed to delete item: ${message}`, { cause: error });
+    }
+  }
+
+  return { createItem, deleteItem, updateItem };
+}

--- a/src/features/collect/hooks/use-item.test.ts
+++ b/src/features/collect/hooks/use-item.test.ts
@@ -1,0 +1,130 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ItemId } from "@/db/types";
+
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}));
+
+vi.mock("@powersync/react", () => ({
+  useQuery: mockUseQuery,
+  usePowerSync: vi.fn(),
+}));
+
+import { useItem } from "./use-item";
+
+const itemId = (id: string) => id as ItemId;
+
+describe("useItem", () => {
+  afterEach(() => {
+    mockUseQuery.mockClear();
+  });
+
+  it("returns null item when id is null", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    const { result } = renderHook(() => useItem(null));
+
+    expect(result.current.item).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("uses a no-op SQL query when id is null", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    renderHook(() => useItem(null));
+
+    const calledSql: string = mockUseQuery.mock.calls[0]?.[0];
+    expect(calledSql).toBe("SELECT 1 WHERE 0");
+    expect(mockUseQuery.mock.calls[0]?.[1]).toEqual([]);
+  });
+
+  it("queries by id when id is provided", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    renderHook(() => useItem(itemId("00000000-0000-4000-8000-000000000100")));
+
+    const calledSql: string = mockUseQuery.mock.calls[0]?.[0];
+    expect(calledSql).toContain("WHERE id = ?");
+    expect(calledSql).toContain("deleted_at IS NULL");
+    expect(mockUseQuery.mock.calls[0]?.[1]).toEqual([
+      "00000000-0000-4000-8000-000000000100",
+    ]);
+  });
+
+  it("parses the row when data is returned", () => {
+    mockUseQuery.mockReturnValue({
+      data: [
+        {
+          id: "00000000-0000-4000-8000-000000000100",
+          name: "Test Item",
+          type: "prop",
+          brand: null,
+          condition: null,
+          created_at: "2025-01-15T12:00:00.000Z",
+          creator: null,
+          description: null,
+          location: null,
+          notes: null,
+          purchase_date: null,
+          purchase_price: null,
+          quantity: 1,
+          updated_at: "2025-01-15T12:00:00.000Z",
+          url: null,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() =>
+      useItem(itemId("00000000-0000-4000-8000-000000000100"))
+    );
+
+    expect(result.current.item).not.toBeNull();
+    expect(result.current.item?.id).toBe(
+      "00000000-0000-4000-8000-000000000100"
+    );
+    expect(result.current.item?.name).toBe("Test Item");
+    expect(result.current.item?.type).toBe("prop");
+  });
+
+  it("returns null item when data is empty", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    const { result } = renderHook(() =>
+      useItem(itemId("00000000-0000-4000-8000-000000000100"))
+    );
+
+    expect(result.current.item).toBeNull();
+  });
+
+  it("passes through isLoading state", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: true, error: null });
+    const { result } = renderHook(() =>
+      useItem(itemId("00000000-0000-4000-8000-000000000100"))
+    );
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns error when useQuery fails", () => {
+    const err = new Error("db error");
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: err });
+    const { result } = renderHook(() =>
+      useItem(itemId("00000000-0000-4000-8000-000000000100"))
+    );
+
+    expect(result.current.error).toBe(err);
+  });
+
+  it("returns null error when useQuery error is undefined", () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const { result } = renderHook(() =>
+      useItem(itemId("00000000-0000-4000-8000-000000000100"))
+    );
+
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/features/collect/hooks/use-item.ts
+++ b/src/features/collect/hooks/use-item.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useQuery } from "@powersync/react";
+import type { ItemId } from "@/db/types";
+import type { ParsedItem } from "../types";
+import { type ItemRow, parseItemRow } from "./parse-item";
+
+interface UseItemResult {
+  error: Error | null;
+  isLoading: boolean;
+  item: ParsedItem | null;
+}
+
+/**
+ * Returns a single item by ID from local SQLite.
+ * Returns null when id is null (creating new item).
+ */
+export function useItem(id: ItemId | null): UseItemResult {
+  const sql = id
+    ? "SELECT * FROM items WHERE id = ? AND deleted_at IS NULL"
+    : "SELECT 1 WHERE 0";
+  const params = id ? [id] : [];
+
+  const { data, isLoading, error } = useQuery<ItemRow>(sql, params);
+
+  const row = data[0];
+  const item = row ? parseItemRow(row) : null;
+
+  return { item, isLoading, error: error ?? null };
+}

--- a/src/features/collect/hooks/use-items.test.ts
+++ b/src/features/collect/hooks/use-items.test.ts
@@ -1,0 +1,296 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}));
+
+vi.mock("@powersync/react", () => ({
+  useQuery: mockUseQuery,
+  usePowerSync: vi.fn(),
+}));
+
+import { buildItemsQuery, useItems } from "./use-items";
+
+describe("useItems hook", () => {
+  it("returns empty items when data is empty", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    const { result } = renderHook(() => useItems());
+    expect(result.current.items).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns isLoading true while loading", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: true, error: null });
+    const { result } = renderHook(() => useItems());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns error when useQuery returns an error", () => {
+    const err = new Error("db error");
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: err,
+    });
+    const { result } = renderHook(() => useItems());
+    expect(result.current.error).toBe(err);
+  });
+
+  it("returns null error when useQuery error is undefined", () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const { result } = renderHook(() => useItems());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("parses raw SQL rows into typed ParsedItem objects", () => {
+    mockUseQuery.mockReturnValue({
+      data: [
+        {
+          id: "00000000-0000-4000-8000-0000000000ab",
+          name: "Invisible Deck",
+          type: "deck",
+          description: "A classic effect",
+          brand: "Bicycle",
+          condition: "new",
+          location: "Close-up case",
+          notes: "Keep dry",
+          purchase_date: "2025-01-10",
+          purchase_price: "29.99",
+          quantity: "2",
+          creator: "Bob Ostin",
+          url: "https://example.com",
+          created_at: "2025-01-15T12:00:00.000Z",
+          updated_at: "2025-01-15T12:00:00.000Z",
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    const { result } = renderHook(() => useItems());
+
+    expect(result.current.items).toHaveLength(1);
+    const item = result.current.items[0];
+    expect(item).toBeDefined();
+    expect(item?.id).toBe("00000000-0000-4000-8000-0000000000ab");
+    expect(item?.name).toBe("Invisible Deck");
+    expect(item?.type).toBe("deck");
+    expect(item?.description).toBe("A classic effect");
+    expect(item?.brand).toBe("Bicycle");
+    expect(item?.condition).toBe("new");
+    expect(item?.location).toBe("Close-up case");
+    expect(item?.notes).toBe("Keep dry");
+    expect(item?.purchaseDate).toBe("2025-01-10");
+    expect(item?.purchasePrice).toBe(29.99);
+    expect(item?.quantity).toBe(2);
+    expect(item?.creator).toBe("Bob Ostin");
+    expect(item?.url).toBe("https://example.com");
+    expect(item?.createdAt).toBe("2025-01-15T12:00:00.000Z");
+    expect(item?.updatedAt).toBe("2025-01-15T12:00:00.000Z");
+  });
+
+  it("passes search option through to buildItemsQuery", () => {
+    mockUseQuery.mockClear();
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    renderHook(() => useItems({ search: "bicycle" }));
+    const calledSql: string = mockUseQuery.mock.calls[0]?.[0];
+    expect(calledSql).toContain("LIKE ?");
+  });
+
+  it("passes type filter option through to buildItemsQuery", () => {
+    mockUseQuery.mockClear();
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    renderHook(() => useItems({ type: "book" }));
+    const calledSql: string = mockUseQuery.mock.calls[0]?.[0];
+    expect(calledSql).toContain("type = ?");
+  });
+
+  it("passes condition filter option through to buildItemsQuery", () => {
+    mockUseQuery.mockClear();
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    renderHook(() => useItems({ condition: "new" }));
+    const calledSql: string = mockUseQuery.mock.calls[0]?.[0];
+    expect(calledSql).toContain("condition = ?");
+  });
+});
+
+describe("buildItemsQuery", () => {
+  it("returns default query with no filters", () => {
+    const { sql, params } = buildItemsQuery();
+
+    expect(sql).toBe(
+      "SELECT * FROM items WHERE deleted_at IS NULL ORDER BY created_at DESC"
+    );
+    expect(params).toEqual([]);
+  });
+
+  it("returns default query when options are empty", () => {
+    const { sql, params } = buildItemsQuery({});
+
+    expect(sql).toBe(
+      "SELECT * FROM items WHERE deleted_at IS NULL ORDER BY created_at DESC"
+    );
+    expect(params).toEqual([]);
+  });
+
+  it("adds search filter for name, description, and brand", () => {
+    const { sql, params } = buildItemsQuery({ search: "bicycle" });
+
+    expect(sql).toContain(
+      "(name LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\' OR brand LIKE ? ESCAPE '\\')"
+    );
+    expect(params).toEqual(["%bicycle%", "%bicycle%", "%bicycle%"]);
+  });
+
+  it("escapes % in search term", () => {
+    const { params } = buildItemsQuery({ search: "100%" });
+    expect(params).toEqual(["%100\\%%", "%100\\%%", "%100\\%%"]);
+  });
+
+  it("escapes _ in search term", () => {
+    const { params } = buildItemsQuery({ search: "a_b" });
+    expect(params).toEqual(["%a\\_b%", "%a\\_b%", "%a\\_b%"]);
+  });
+
+  it("escapes backslash in search term", () => {
+    const { params } = buildItemsQuery({ search: "a\\b" });
+    expect(params).toEqual(["%a\\\\b%", "%a\\\\b%", "%a\\\\b%"]);
+  });
+
+  it("escapes multiple special characters in search term", () => {
+    const { params } = buildItemsQuery({ search: "%_\\" });
+    expect(params).toEqual(["%\\%\\_\\\\%", "%\\%\\_\\\\%", "%\\%\\_\\\\%"]);
+  });
+
+  it("ignores empty search string", () => {
+    const { sql, params } = buildItemsQuery({ search: "" });
+
+    expect(sql).toBe(
+      "SELECT * FROM items WHERE deleted_at IS NULL ORDER BY created_at DESC"
+    );
+    expect(params).toEqual([]);
+  });
+
+  it("does not trim whitespace-only search string", () => {
+    const { sql, params } = buildItemsQuery({ search: "   " });
+
+    expect(sql).toContain(
+      "(name LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\' OR brand LIKE ? ESCAPE '\\')"
+    );
+    expect(params).toEqual(["%   %", "%   %", "%   %"]);
+  });
+
+  it("adds type filter", () => {
+    const { sql, params } = buildItemsQuery({ type: "book" });
+
+    expect(sql).toContain("type = ?");
+    expect(params).toContain("book");
+  });
+
+  it("ignores null type filter", () => {
+    const { sql, params } = buildItemsQuery({ type: null });
+
+    expect(sql).toBe(
+      "SELECT * FROM items WHERE deleted_at IS NULL ORDER BY created_at DESC"
+    );
+    expect(params).toEqual([]);
+  });
+
+  it("adds condition filter", () => {
+    const { sql, params } = buildItemsQuery({ condition: "new" });
+
+    expect(sql).toContain("condition = ?");
+    expect(params).toContain("new");
+  });
+
+  it("ignores null condition filter", () => {
+    const { sql, params } = buildItemsQuery({ condition: null });
+
+    expect(sql).toBe(
+      "SELECT * FROM items WHERE deleted_at IS NULL ORDER BY created_at DESC"
+    );
+    expect(params).toEqual([]);
+  });
+
+  it("combines search, type, and condition filters with AND", () => {
+    const { sql, params } = buildItemsQuery({
+      search: "trick",
+      type: "book",
+      condition: "good",
+    });
+
+    expect(sql).toContain("deleted_at IS NULL");
+    expect(sql).toContain(
+      "(name LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\' OR brand LIKE ? ESCAPE '\\')"
+    );
+    expect(sql).toContain("type = ?");
+    expect(sql).toContain("condition = ?");
+    expect(params).toEqual(["%trick%", "%trick%", "%trick%", "book", "good"]);
+  });
+
+  it("all conditions join with AND", () => {
+    const { sql } = buildItemsQuery({
+      search: "test",
+      type: "prop",
+      condition: "new",
+    });
+    const whereClause = sql.split("WHERE ")[1]?.split(" ORDER BY")[0];
+    expect(whereClause).toContain("AND");
+  });
+
+  describe("sort options", () => {
+    it("sorts by newest by default", () => {
+      const { sql } = buildItemsQuery();
+      expect(sql.endsWith("ORDER BY created_at DESC")).toBe(true);
+    });
+
+    it("sorts by name ascending", () => {
+      const { sql } = buildItemsQuery({ sort: "name-asc" });
+      expect(sql.endsWith("ORDER BY name ASC")).toBe(true);
+    });
+
+    it("sorts by name descending", () => {
+      const { sql } = buildItemsQuery({ sort: "name-desc" });
+      expect(sql.endsWith("ORDER BY name DESC")).toBe(true);
+    });
+
+    it("sorts by newest", () => {
+      const { sql } = buildItemsQuery({ sort: "newest" });
+      expect(sql.endsWith("ORDER BY created_at DESC")).toBe(true);
+    });
+
+    it("sorts by oldest", () => {
+      const { sql } = buildItemsQuery({ sort: "oldest" });
+      expect(sql.endsWith("ORDER BY created_at ASC")).toBe(true);
+    });
+
+    it("sorts by type", () => {
+      const { sql } = buildItemsQuery({ sort: "type-asc" });
+      expect(sql.endsWith("ORDER BY type ASC, name ASC")).toBe(true);
+    });
+
+    it("sorts by price ascending (NULLS LAST)", () => {
+      const { sql } = buildItemsQuery({ sort: "price-asc" });
+      expect(
+        sql.endsWith("ORDER BY CAST(purchase_price AS REAL) ASC NULLS LAST")
+      ).toBe(true);
+    });
+
+    it("sorts by price descending (NULLS LAST)", () => {
+      const { sql } = buildItemsQuery({ sort: "price-desc" });
+      expect(
+        sql.endsWith("ORDER BY CAST(purchase_price AS REAL) DESC NULLS LAST")
+      ).toBe(true);
+    });
+
+    it("defaults to newest when sort is not specified", () => {
+      const { sql } = buildItemsQuery({});
+      expect(sql.endsWith("ORDER BY created_at DESC")).toBe(true);
+    });
+  });
+});

--- a/src/features/collect/hooks/use-items.ts
+++ b/src/features/collect/hooks/use-items.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useQuery } from "@powersync/react";
+import type { SqlParam } from "@/sync/queries";
+import type { FilterSortValue, ItemCondition, ItemType } from "../constants";
+import type { ParsedItem } from "../types";
+import { type ItemRow, parseItemRow } from "./parse-item";
+
+interface UseItemsOptions {
+  condition?: ItemCondition | null;
+  search?: string;
+  sort?: FilterSortValue;
+  type?: ItemType | null;
+}
+
+interface UseItemsResult {
+  error: Error | null;
+  isLoading: boolean;
+  items: ParsedItem[];
+}
+
+const SORT_CLAUSES = {
+  newest: "created_at DESC",
+  oldest: "created_at ASC",
+  "name-asc": "name ASC",
+  "name-desc": "name DESC",
+  "price-asc": "CAST(purchase_price AS REAL) ASC NULLS LAST",
+  "price-desc": "CAST(purchase_price AS REAL) DESC NULLS LAST",
+  "type-asc": "type ASC, name ASC",
+} as const satisfies Record<FilterSortValue, string>;
+
+/**
+ * Builds the SQL query and parameters for fetching items with optional
+ * filtering by search term, type, and condition, plus configurable sort order.
+ */
+export function buildItemsQuery(options: UseItemsOptions = {}): {
+  sql: string;
+  params: SqlParam[];
+} {
+  const { search, type, condition, sort = "newest" } = options;
+
+  const conditions: string[] = ["deleted_at IS NULL"];
+  const params: SqlParam[] = [];
+
+  if (search) {
+    conditions.push(
+      "(name LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\' OR brand LIKE ? ESCAPE '\\')"
+    );
+    const escaped = search.replace(/[%_\\]/g, "\\$&");
+    const pattern = `%${escaped}%`;
+    params.push(pattern, pattern, pattern);
+  }
+
+  if (type) {
+    conditions.push("type = ?");
+    params.push(type);
+  }
+
+  if (condition) {
+    conditions.push("condition = ?");
+    params.push(condition);
+  }
+
+  const whereClause = conditions.join(" AND ");
+  // Defense-in-depth: even though `sort` is typed as FilterSortValue, fall
+  // back to "newest" for unknown keys (e.g. stale URL params or bad state)
+  // so the query never reaches `ORDER BY undefined`.
+  const orderClause = SORT_CLAUSES[sort] ?? SORT_CLAUSES.newest;
+  const sql = `SELECT * FROM items WHERE ${whereClause} ORDER BY ${orderClause}`;
+
+  return { sql, params };
+}
+
+/**
+ * Returns a reactive list of items from local SQLite, with optional
+ * filtering by search term, type, and condition, plus configurable sort order.
+ *
+ * Data is re-fetched automatically by PowerSync whenever the underlying
+ * `items` table changes (inserts, updates, deletes).
+ */
+export function useItems(options: UseItemsOptions = {}): UseItemsResult {
+  const { sql, params } = buildItemsQuery(options);
+
+  const { data, isLoading, error } = useQuery<ItemRow>(sql, params);
+
+  // parseItemRow returns null for rows with invalid UUIDs (defense-in-depth at
+  // the sync boundary). Filter them out so consumers see a clean ParsedItem[].
+  const items = data
+    .map(parseItemRow)
+    .filter((item): item is ParsedItem => item !== null);
+
+  return { items, isLoading, error: error ?? null };
+}
+
+export type { UseItemsOptions, UseItemsResult };

--- a/src/features/collect/schema.test.ts
+++ b/src/features/collect/schema.test.ts
@@ -1,0 +1,641 @@
+import { describe, expect, it } from "vitest";
+import { ITEM_CONDITIONS, ITEM_TYPES } from "./constants";
+import { itemFormSchema } from "./schema";
+
+describe("itemFormSchema", () => {
+  describe("name field", () => {
+    it("is valid with only name and type provided", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Svengali Deck",
+        type: "deck",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("is valid with all fields provided", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Invisible Deck",
+        type: "deck",
+        description: "A classic effect",
+        brand: "Bicycle",
+        creator: "Bob Ostin",
+        condition: "new",
+        location: "Close-up case",
+        quantity: 2,
+        purchaseDate: "2025-01-15",
+        purchasePrice: "29.99",
+        url: "https://vanishinginc.com/invisible-deck",
+        notes: "Great for walk-around",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects empty name", () => {
+      const result = itemFormSchema.safeParse({ name: "", type: "prop" });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.nameRequired");
+      }
+    });
+
+    it("rejects whitespace-only name after trim", () => {
+      const result = itemFormSchema.safeParse({ name: "   ", type: "prop" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects name exceeding 200 characters", () => {
+      const result = itemFormSchema.safeParse({
+        name: "a".repeat(201),
+        type: "prop",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.nameTooLong");
+      }
+    });
+
+    it("accepts name of exactly 200 characters", () => {
+      const result = itemFormSchema.safeParse({
+        name: "a".repeat(200),
+        type: "prop",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("trims whitespace from name", () => {
+      const result = itemFormSchema.safeParse({
+        name: "  Svengali Deck  ",
+        type: "deck",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.name).toBe("Svengali Deck");
+      }
+    });
+  });
+
+  describe("type field", () => {
+    it("accepts all valid ITEM_TYPES", () => {
+      for (const type of ITEM_TYPES) {
+        const result = itemFormSchema.safeParse({ name: "Item", type });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("rejects invalid type", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "furniture",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("requires type to be provided", () => {
+      const result = itemFormSchema.safeParse({ name: "Item" });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("condition field", () => {
+    it("accepts all valid ITEM_CONDITIONS", () => {
+      for (const condition of ITEM_CONDITIONS) {
+        const result = itemFormSchema.safeParse({
+          name: "Item",
+          type: "prop",
+          condition,
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("accepts null condition", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        condition: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.condition).toBeNull();
+      }
+    });
+
+    it("defaults to null when not provided", () => {
+      const result = itemFormSchema.safeParse({ name: "Item", type: "prop" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.condition).toBeNull();
+      }
+    });
+
+    it("rejects invalid condition value", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        condition: "perfect",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("quantity field", () => {
+    it("accepts valid integer quantity", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        quantity: 5,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.quantity).toBe(5);
+      }
+    });
+
+    it("accepts quantity of 0", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        quantity: 0,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.quantity).toBe(0);
+      }
+    });
+
+    it("accepts quantity of 9999", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        quantity: 9999,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects quantity of 10000", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        quantity: 10_000,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.quantityMax");
+      }
+    });
+
+    it("rejects negative quantity", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        quantity: -1,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.quantityMin");
+      }
+    });
+
+    it("rejects non-integer quantity", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        quantity: 1.5,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("coerces string quantity to number", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        quantity: "3",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.quantity).toBe(3);
+      }
+    });
+
+    it("defaults to 1 when not provided", () => {
+      const result = itemFormSchema.safeParse({ name: "Item", type: "prop" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.quantity).toBe(1);
+      }
+    });
+  });
+
+  describe("purchasePrice field", () => {
+    it("accepts valid decimal price", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchasePrice: "29.99",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts integer price without decimals", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchasePrice: "30",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts price with one decimal place", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchasePrice: "9.5",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts price of 0", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchasePrice: "0",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts empty string", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchasePrice: "",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.purchasePrice).toBe("");
+      }
+    });
+
+    it("defaults to empty string when not provided", () => {
+      const result = itemFormSchema.safeParse({ name: "Item", type: "prop" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.purchasePrice).toBe("");
+      }
+    });
+
+    it("rejects non-numeric string", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchasePrice: "abc",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.invalidPrice");
+      }
+    });
+
+    it("rejects price with more than 2 decimal places", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchasePrice: "9.999",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.invalidPrice");
+      }
+    });
+
+    it("rejects price with leading non-digit before decimal", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchasePrice: ".99",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects negative price values", () => {
+      for (const price of ["-10.00", "-0.01", "-1"]) {
+        const result = itemFormSchema.safeParse({
+          name: "Item",
+          type: "prop",
+          purchasePrice: price,
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0]?.message).toBe(
+            "validation.invalidPrice"
+          );
+        }
+      }
+    });
+  });
+
+  describe("purchaseDate field", () => {
+    it("accepts a valid ISO date string", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchaseDate: "2025-01-15",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts empty string", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchaseDate: "",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("defaults to empty string when not provided", () => {
+      const result = itemFormSchema.safeParse({ name: "Item", type: "prop" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.purchaseDate).toBe("");
+      }
+    });
+
+    it("rejects invalid date string", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        purchaseDate: "not-a-date",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.invalidDate");
+      }
+    });
+  });
+
+  describe("url field", () => {
+    it("accepts a valid HTTPS URL", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "https://vanishinginc.com/product",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts empty string", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("defaults to empty string when not provided", () => {
+      const result = itemFormSchema.safeParse({ name: "Item", type: "prop" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.url).toBe("");
+      }
+    });
+
+    it("rejects HTTP URL (non-HTTPS)", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "http://example.com/product",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.invalidUrl");
+      }
+    });
+
+    it("rejects plain text that is not a URL", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "not-a-url",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.invalidUrl");
+      }
+    });
+
+    it("rejects url exceeding 2000 characters", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: `https://example.com/${"a".repeat(2000)}`,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.urlTooLong");
+      }
+    });
+
+    it("normalizes uppercase HTTPS:// scheme to lowercase", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "HTTPS://example.com/Path?q=Value",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.url).toBe("https://example.com/Path?q=Value");
+      }
+    });
+
+    it("normalizes mixed-case Https:// scheme to lowercase", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "Https://example.com",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.url).toBe("https://example.com");
+      }
+    });
+
+    it("rejects javascript: scheme", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "javascript:alert(1)",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.invalidUrl");
+      }
+    });
+
+    it("rejects data: scheme", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "data:text/html,<h1>x</h1>",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.invalidUrl");
+      }
+    });
+
+    it("rejects bare https:// with no host", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "https://",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe("validation.invalidUrl");
+      }
+    });
+
+    it("trims surrounding whitespace before validation", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        url: "  https://example.com  ",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.url).toBe("https://example.com");
+      }
+    });
+  });
+
+  describe("string trim behavior", () => {
+    it("trims description, brand, creator, location, notes", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        description: "  desc text  ",
+        brand: "  Bicycle  ",
+        creator: "  Creator  ",
+        location: "  Storage  ",
+        notes: "  notes  ",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.description).toBe("desc text");
+        expect(result.data.brand).toBe("Bicycle");
+        expect(result.data.creator).toBe("Creator");
+        expect(result.data.location).toBe("Storage");
+        expect(result.data.notes).toBe("notes");
+      }
+    });
+  });
+
+  describe("description field", () => {
+    it("accepts description at exactly 2000 characters", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        description: "a".repeat(2000),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects description at 2001 characters", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        description: "a".repeat(2001),
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          "validation.descriptionTooLong"
+        );
+      }
+    });
+
+    it("defaults to empty string when not provided", () => {
+      const result = itemFormSchema.safeParse({ name: "Item", type: "prop" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.description).toBe("");
+      }
+    });
+  });
+
+  describe("notes field", () => {
+    it("accepts notes at exactly 5000 characters", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        notes: "a".repeat(5000),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects notes at 5001 characters", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        notes: "a".repeat(5001),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("defaults to empty string when not provided", () => {
+      const result = itemFormSchema.safeParse({ name: "Item", type: "prop" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.notes).toBe("");
+      }
+    });
+  });
+
+  describe("brand field", () => {
+    it("accepts brand at exactly 200 characters", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        brand: "a".repeat(200),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects brand at 201 characters", () => {
+      const result = itemFormSchema.safeParse({
+        name: "Item",
+        type: "prop",
+        brand: "a".repeat(201),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("defaults to empty string when not provided", () => {
+      const result = itemFormSchema.safeParse({ name: "Item", type: "prop" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.brand).toBe("");
+      }
+    });
+  });
+
+  describe("coerced defaults for all optional fields", () => {
+    it("applies all default values when only name and type are given", () => {
+      const result = itemFormSchema.safeParse({ name: "Item", type: "prop" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.description).toBe("");
+        expect(result.data.brand).toBe("");
+        expect(result.data.creator).toBe("");
+        expect(result.data.condition).toBeNull();
+        expect(result.data.location).toBe("");
+        expect(result.data.quantity).toBe(1);
+        expect(result.data.purchaseDate).toBe("");
+        expect(result.data.purchasePrice).toBe("");
+        expect(result.data.url).toBe("");
+        expect(result.data.notes).toBe("");
+      }
+    });
+  });
+});

--- a/src/features/collect/schema.ts
+++ b/src/features/collect/schema.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+import { ITEM_CONDITIONS, ITEM_TYPES } from "./constants";
+
+const HTTPS_URL_RE = /^https:\/\//i;
+const PRICE_RE = /^\d{1,7}(\.\d{0,2})?$/;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const itemFormSchema = z.object({
+  // Essentials
+  name: z
+    .string()
+    .trim()
+    .min(1, "validation.nameRequired")
+    .max(200, "validation.nameTooLong"),
+  type: z.enum(ITEM_TYPES),
+  description: z
+    .string()
+    .trim()
+    .max(2000, "validation.descriptionTooLong")
+    .optional()
+    .default(""),
+
+  // Details
+  brand: z.string().trim().max(200).optional().default(""),
+  creator: z.string().trim().max(200).optional().default(""),
+  condition: z.enum(ITEM_CONDITIONS).nullable().optional().default(null),
+  location: z.string().trim().max(200).optional().default(""),
+  quantity: z.coerce
+    .number()
+    .int()
+    .min(0, "validation.quantityMin")
+    .max(9999, "validation.quantityMax")
+    .optional()
+    .default(1),
+
+  // Purchase
+  purchaseDate: z
+    .string()
+    .trim()
+    .refine((val) => val === "" || ISO_DATE_RE.test(val), {
+      message: "validation.invalidDate",
+    })
+    .optional()
+    .default(""),
+  purchasePrice: z
+    .string()
+    .trim()
+    .refine((val) => val === "" || (PRICE_RE.test(val) && Number(val) >= 0), {
+      message: "validation.invalidPrice",
+    })
+    .optional()
+    .default(""),
+
+  // Reference
+  url: z
+    .string()
+    .trim()
+    .max(2000, "validation.urlTooLong")
+    // Lowercase only the scheme so the DB CHECK (LIKE 'https://%') accepts
+    // values where the user typed "HTTPS://" — the path/query is preserved
+    // as-is to avoid changing case-sensitive query strings or fragments.
+    .transform((val) =>
+      HTTPS_URL_RE.test(val)
+        ? `${val.slice(0, 8).toLowerCase()}${val.slice(8)}`
+        : val
+    )
+    .refine(
+      (val) => {
+        if (val === "") {
+          return true;
+        }
+        if (!(HTTPS_URL_RE.test(val) && URL.canParse(val))) {
+          return false;
+        }
+        const parsed = new URL(val);
+        // Reject URLs with no host (e.g. bare "https://").
+        if (parsed.hostname.length === 0) {
+          return false;
+        }
+        // Reject userinfo (e.g. https://user:pass@evil.com) — a common
+        // phishing trick that obscures the real host from casual inspection.
+        if (parsed.username !== "" || parsed.password !== "") {
+          return false;
+        }
+        // Reject IDN/punycode hosts (e.g. https://xn--pple-43d.com mimicking
+        // apple.com) to block homograph phishing. Trade-off: legitimate IDN
+        // URLs are rejected too — for a personal-inventory feature the set
+        // of valid punycode references is essentially zero.
+        if (parsed.hostname.toLowerCase().includes("xn--")) {
+          return false;
+        }
+        return true;
+      },
+      { message: "validation.invalidUrl" }
+    )
+    .optional()
+    .default(""),
+
+  // Organization (tags and tricks handled via junction tables, not in this schema)
+  notes: z.string().trim().max(5000).optional().default(""),
+});
+
+type ItemFormValues = z.infer<typeof itemFormSchema>;
+
+export type { ItemFormValues };
+export { itemFormSchema };

--- a/src/features/collect/types.ts
+++ b/src/features/collect/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Parsed types for collection data read from local SQLite via PowerSync.
+ *
+ * These mirror the server-side Drizzle schema but use camelCase field names
+ * and native JS types (numbers instead of text for price, etc.).
+ */
+
+import type { ItemId, TrickId } from "@/db/types";
+import type { ParsedTag } from "@/features/repertoire/types";
+import type { ItemCondition, ItemType } from "./constants";
+
+export interface LinkedItem {
+  id: ItemId;
+  name: string;
+  type: ItemType;
+}
+
+export interface ParsedItem {
+  brand: string | null;
+  condition: ItemCondition | null;
+  createdAt: string;
+  creator: string | null;
+  description: string | null;
+  id: ItemId;
+  location: string | null;
+  name: string;
+  notes: string | null;
+  purchaseDate: string | null;
+  purchasePrice: number | null;
+  quantity: number;
+  type: ItemType;
+  updatedAt: string;
+  url: string | null;
+}
+
+export interface LinkedTrick {
+  id: TrickId;
+  name: string;
+}
+
+export interface ItemWithRelations extends ParsedItem {
+  tags: ParsedTag[];
+  tricks: LinkedTrick[];
+}

--- a/src/features/repertoire/components/category-combobox.tsx
+++ b/src/features/repertoire/components/category-combobox.tsx
@@ -25,6 +25,8 @@ interface CategoryComboboxProps {
   onChange: (value: string) => void;
   placeholder?: string;
   suggestions: readonly string[];
+  /** i18n namespace containing combobox.* keys. Defaults to "repertoire". */
+  translationNamespace?: string;
   userValues: string[];
   value: string;
 }
@@ -50,8 +52,9 @@ function CategoryCombobox({
   userValues,
   placeholder,
   label,
+  translationNamespace = "repertoire",
 }: CategoryComboboxProps): React.ReactElement {
-  const t = useTranslations("repertoire");
+  const t = useTranslations(translationNamespace);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const displayPlaceholder = placeholder ?? t("combobox.select");

--- a/src/features/repertoire/components/repertoire-view.tsx
+++ b/src/features/repertoire/components/repertoire-view.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import type { TagId, TrickId } from "@/db/types";
+import type { ItemId, TagId, TrickId } from "@/db/types";
 import { useTagMutations } from "../hooks/use-tag-mutations";
 import { useTags } from "../hooks/use-tags";
 import { useTrick } from "../hooks/use-trick";
@@ -54,6 +54,13 @@ interface TrickTagRow {
   tag_id: string;
   tag_name: string;
   trick_id: string;
+}
+
+/** Row shape returned by the item_tricks + items join query. */
+interface TrickItemRow {
+  item_id: ItemId;
+  item_name: string;
+  trick_id: TrickId;
 }
 
 /** Debounce delay for the search input (milliseconds). */
@@ -125,7 +132,7 @@ export function RepertoireView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   // Trick-tags join query (build a Map<trickId, ParsedTag[]>)
   // ---------------------------------------------------------------------------
-  const { data: trickTagRows } = useQuery<TrickTagRow>(
+  const { data: trickTagRows, error: trickTagError } = useQuery<TrickTagRow>(
     `SELECT tt.trick_id, t.id AS tag_id, t.name AS tag_name, t.color
      FROM trick_tags tt
      JOIN tags t ON tt.tag_id = t.id
@@ -133,6 +140,26 @@ export function RepertoireView(): React.ReactElement {
   );
 
   const trickTagMap = buildTrickTagMap(trickTagRows);
+
+  // ---------------------------------------------------------------------------
+  // Trick-items join query (build a Map<trickId, LinkedItem[]>)
+  // ---------------------------------------------------------------------------
+  const { data: trickItemRows, error: trickItemError } = useQuery<TrickItemRow>(
+    `SELECT itr.trick_id, i.id AS item_id, i.name AS item_name
+     FROM item_tricks itr
+     JOIN items i ON itr.item_id = i.id
+     WHERE itr.deleted_at IS NULL AND i.deleted_at IS NULL`
+  );
+
+  useEffect(() => {
+    const error = trickTagError ?? trickItemError;
+    if (error) {
+      console.error("Failed to load trick relations:", error);
+      toast.error(t("loadError"));
+    }
+  }, [trickTagError, trickItemError, t]);
+
+  const trickItemMap = buildTrickItemMap(trickItemRows);
 
   const tricksWithTags: TrickWithTags[] = tricks.map((trick) => ({
     ...trick,
@@ -205,7 +232,8 @@ export function RepertoireView(): React.ReactElement {
       setSheetOpen(false);
       setEditingTrickId(null);
       setSelectedTagIds([]);
-    } catch {
+    } catch (error) {
+      console.error("Failed to save trick:", error);
       toast.error(t("saveFailed"));
     }
   }
@@ -223,7 +251,8 @@ export function RepertoireView(): React.ReactElement {
     try {
       await deleteTrick(deletingTrickId);
       toast.success(t("trickDeleted"));
-    } catch {
+    } catch (error) {
+      console.error("Failed to delete trick:", error);
       toast.error(t("deleteFailed"));
     } finally {
       setDeleteDialogOpen(false);
@@ -261,6 +290,7 @@ export function RepertoireView(): React.ReactElement {
     if (tricksWithTags.length > 0) {
       return (
         <TrickList
+          itemMap={trickItemMap}
           onDelete={handleDeleteTrick}
           onEdit={handleEditTrick}
           tricks={tricksWithTags}
@@ -356,6 +386,28 @@ export function RepertoireView(): React.ReactElement {
 
 function isFilterSortValue(value: string): value is FilterSortValue {
   return value in SORT_MAP;
+}
+
+/**
+ * Builds a Map from trick ID to its linked items, given the raw join rows.
+ */
+function buildTrickItemMap(
+  rows: TrickItemRow[]
+): Map<TrickId, { id: ItemId; name: string }[]> {
+  const map = new Map<TrickId, { id: ItemId; name: string }[]>();
+
+  for (const row of rows) {
+    const item = { id: row.item_id, name: row.item_name };
+
+    const existing = map.get(row.trick_id);
+    if (existing) {
+      existing.push(item);
+    } else {
+      map.set(row.trick_id, [item]);
+    }
+  }
+
+  return map;
 }
 
 /**

--- a/src/features/repertoire/components/tag-picker.tsx
+++ b/src/features/repertoire/components/tag-picker.tsx
@@ -31,6 +31,8 @@ interface TagPickerProps {
   onCreateTag: (name: string) => Promise<TagId>;
   onToggleTag: (tagId: TagId) => void;
   selectedTagIds: TagId[];
+  /** i18n namespace containing tagPicker.* keys. Defaults to "repertoire". */
+  translationNamespace?: string;
 }
 
 function TagPicker({
@@ -39,8 +41,9 @@ function TagPicker({
   onToggleTag,
   onCreateTag,
   maxTags,
+  translationNamespace = "repertoire",
 }: TagPickerProps): React.ReactElement {
-  const t = useTranslations("repertoire");
+  const t = useTranslations(translationNamespace);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [creating, setCreating] = useState(false);
@@ -225,7 +228,7 @@ function TagPicker({
                 <span>{tag.name}</span>
                 <button
                   aria-label={t("tagPicker.remove", { name: tag.name })}
-                  className="relative flex items-center justify-center rounded-sm p-1.5 before:absolute before:inset-[-8px] before:content-[''] hover:bg-accent"
+                  className="relative flex min-h-11 min-w-11 items-center justify-center rounded-sm p-1.5 hover:bg-accent"
                   onClick={() => handleRemove(tag)}
                   type="button"
                 >

--- a/src/features/repertoire/components/trick-card.tsx
+++ b/src/features/repertoire/components/trick-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Clock, Edit, MoreHorizontal, Trash2 } from "lucide-react";
+import { Clock, Edit, MoreHorizontal, Package, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -10,13 +10,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { TrickId } from "@/db/types";
+import type { ItemId, TrickId } from "@/db/types";
 import { cn } from "@/lib/utils";
 import type { ParsedTag, TrickWithTags } from "../types";
 import { TrickDifficulty } from "./trick-difficulty";
 import { TrickStatusBadge } from "./trick-status-badge";
 
 interface TrickCardProps {
+  linkedItems?: { id: ItemId; name: string }[];
   onDelete: (id: TrickId) => void;
   onEdit: (id: TrickId) => void;
   trick: TrickWithTags;
@@ -38,10 +39,13 @@ export function formatDuration(seconds: number): string {
 
 const MAX_VISIBLE_TAGS = 3;
 
+const MAX_VISIBLE_ITEMS = 2;
+
 export function TrickCard({
   trick,
   onEdit,
   onDelete,
+  linkedItems,
 }: TrickCardProps): React.ReactElement {
   const t = useTranslations("repertoire");
 
@@ -177,6 +181,21 @@ export function TrickCard({
               </li>
             )}
           </ul>
+        )}
+
+        {/* Linked items */}
+        {linkedItems && linkedItems.length > 0 && (
+          <div className="flex items-center gap-1.5 text-muted-foreground text-sm">
+            <Package aria-hidden="true" className="size-3.5 shrink-0" />
+            <span>
+              {linkedItems
+                .slice(0, MAX_VISIBLE_ITEMS)
+                .map((item) => item.name)
+                .join(", ")}
+              {linkedItems.length > MAX_VISIBLE_ITEMS &&
+                `, +${linkedItems.length - MAX_VISIBLE_ITEMS}`}
+            </span>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/features/repertoire/components/trick-list.tsx
+++ b/src/features/repertoire/components/trick-list.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import type { TrickId } from "@/db/types";
+import type { ItemId, TrickId } from "@/db/types";
 import type { TrickWithTags } from "../types";
 import { TrickCard } from "./trick-card";
 
 interface TrickListProps {
+  itemMap?: Map<TrickId, { id: ItemId; name: string }[]>;
   onDelete: (id: TrickId) => void;
   onEdit: (id: TrickId) => void;
   tricks: TrickWithTags[];
@@ -21,6 +22,7 @@ export function TrickList({
   tricks,
   onEdit,
   onDelete,
+  itemMap,
 }: TrickListProps): React.ReactElement {
   const t = useTranslations("repertoire");
 
@@ -31,7 +33,12 @@ export function TrickList({
     >
       {tricks.map((trick) => (
         <li key={trick.id}>
-          <TrickCard onDelete={onDelete} onEdit={onEdit} trick={trick} />
+          <TrickCard
+            linkedItems={itemMap?.get(trick.id)}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            trick={trick}
+          />
         </li>
       ))}
     </ul>

--- a/src/features/repertoire/hooks/use-trick-mutations.test.ts
+++ b/src/features/repertoire/hooks/use-trick-mutations.test.ts
@@ -821,14 +821,18 @@ describe("use-trick-mutations", () => {
   });
 
   describe("deleteTrick", () => {
+    beforeEach(() => {
+      mockExecute.mockResolvedValue({ rowsAffected: 1 });
+    });
+
     it("executes soft-delete SQL", async () => {
       const { useTrickMutations } = await getHookExports();
       const { deleteTrick } = useTrickMutations();
 
       await deleteTrick(trickId("trick-1"));
 
-      // 1 trick soft-delete + 1 trick_tags cascade soft-delete
-      expect(mockExecute).toHaveBeenCalledTimes(2);
+      // 1 trick soft-delete + 1 trick_tags cascade + 1 item_tricks cascade
+      expect(mockExecute).toHaveBeenCalledTimes(3);
 
       const trickSql = mockExecute.mock.calls[0]?.[0] as string;
       expect(trickSql).toContain("UPDATE tricks SET deleted_at = ?");
@@ -849,6 +853,11 @@ describe("use-trick-mutations", () => {
       const tagsParams = mockExecute.mock.calls[1]?.[1] as unknown[];
       expect(tagsParams).toContain("trick-1"); // trick_id
       expect(tagsParams).toContain("user-123"); // user_id
+
+      const itemsSql = mockExecute.mock.calls[2]?.[0] as string;
+      expect(itemsSql).toContain("UPDATE item_tricks SET deleted_at = ?");
+      expect(itemsSql).toContain("WHERE trick_id = ?");
+      expect(itemsSql).toContain("user_id = ?");
     });
 
     it("tracks trick_deleted event on success", async () => {

--- a/src/features/repertoire/hooks/use-trick-mutations.ts
+++ b/src/features/repertoire/hooks/use-trick-mutations.ts
@@ -197,7 +197,7 @@ export function useTrickMutations(): UseTrickMutationsReturn {
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : "Unknown error creating trick";
-      throw new Error(`Failed to create trick: ${message}`);
+      throw new Error(`Failed to create trick: ${message}`, { cause: error });
     }
   }
 
@@ -270,7 +270,7 @@ export function useTrickMutations(): UseTrickMutationsReturn {
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : "Unknown error updating trick";
-      throw new Error(`Failed to update trick: ${message}`);
+      throw new Error(`Failed to update trick: ${message}`, { cause: error });
     }
   }
 
@@ -280,12 +280,19 @@ export function useTrickMutations(): UseTrickMutationsReturn {
 
     try {
       await db.writeTransaction(async (tx) => {
-        await tx.execute(
+        const result = await tx.execute(
           "UPDATE tricks SET deleted_at = ?, updated_at = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
           [now, now, id, userId]
         );
+        if (!result.rowsAffected) {
+          throw new Error("Trick not found or already deleted");
+        }
         await tx.execute(
           "UPDATE trick_tags SET deleted_at = ?, updated_at = ? WHERE trick_id = ? AND user_id = ? AND deleted_at IS NULL",
+          [now, now, id, userId]
+        );
+        await tx.execute(
+          "UPDATE item_tricks SET deleted_at = ?, updated_at = ? WHERE trick_id = ? AND user_id = ? AND deleted_at IS NULL",
           [now, now, id, userId]
         );
       });
@@ -294,7 +301,7 @@ export function useTrickMutations(): UseTrickMutationsReturn {
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : "Unknown error deleting trick";
-      throw new Error(`Failed to delete trick: ${message}`);
+      throw new Error(`Failed to delete trick: ${message}`, { cause: error });
     }
   }
 

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -54,6 +54,7 @@
     "trickDeleted": "Trick gelöscht",
     "saveFailed": "Trick konnte nicht gespeichert werden",
     "deleteFailed": "Trick konnte nicht gelöscht werden",
+    "loadError": "Daten konnten nicht geladen werden",
     "emptyTitle": "Dein Repertoire ist leer",
     "emptyDescription": "Füge deinen ersten Trick hinzu, um dein Repertoire aufzubauen.",
     "searchPlaceholder": "Tricks suchen...",
@@ -178,7 +179,9 @@
       "tooManyTags": "Maximal 20 Tags erlaubt",
       "tagNameRequired": "Der Tag-Name ist erforderlich",
       "tagNameTooLong": "Der Tag-Name darf maximal 50 Zeichen lang sein"
-    }
+    },
+    "linkedItems": "Verknüpfte Objekte",
+    "noLinkedItems": "Nicht mit Objekten verknüpft."
   },
   "landing": {
     "tagline": "Trainieren. Planen. Auftreten. Hebe deine Magie auf ein neues Level.",
@@ -208,7 +211,10 @@
     "fallbackName": "Magier",
     "repertoireTitle": "Mein Repertoire",
     "repertoireDescription": "{count, plural, one {# Trick} other {# Tricks}} in deiner Sammlung",
-    "repertoireLink": "Repertoire öffnen"
+    "repertoireLink": "Repertoire öffnen",
+    "collectionTitle": "Meine Sammlung",
+    "collectionDescription": "{count, plural, one {# Objekt} other {# Objekte}} in deinem Inventar",
+    "collectionLink": "Sammlung öffnen"
   },
   "improve": {
     "title": "Verbessern",
@@ -233,7 +239,143 @@
   },
   "collect": {
     "title": "Sammlung",
-    "description": "Verwalte dein Inventar an Requisiten, Büchern, Gimmicks und mehr."
+    "description": "Verwalte dein Inventar an Requisiten, Büchern, Gimmicks und mehr.",
+    "addItem": "Objekt hinzufügen",
+    "editItem": "Objekt bearbeiten",
+    "deleteItem": "Objekt löschen",
+    "deleteConfirmTitle": "\"{name}\" löschen?",
+    "deleteConfirmDescription": "Dieses Objekt wird aus deiner Sammlung entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "itemCreated": "Objekt hinzugefügt",
+    "itemUpdated": "Objekt aktualisiert",
+    "itemDeleted": "Objekt gelöscht",
+    "saveFailed": "Objekt konnte nicht gespeichert werden",
+    "deleteFailed": "Objekt konnte nicht gelöscht werden",
+    "loadError": "Daten konnten nicht geladen werden",
+    "emptyTitle": "Deine Sammlung ist leer",
+    "emptyDescription": "Füge dein erstes Objekt hinzu, um deine Sammlung aufzubauen.",
+    "searchPlaceholder": "Objekte suchen...",
+    "sortBy": "Sortieren nach",
+    "filterByType": "Nach Typ filtern",
+    "filterByCondition": "Nach Zustand filtern",
+    "allTypes": "Alle Typen",
+    "allConditions": "Alle Zustände",
+    "noResults": "Keine Objekte entsprechen deinen Filtern.",
+    "unsavedChanges": "Du hast ungespeicherte Änderungen. Verwerfen?",
+    "discardChangesTitle": "Änderungen verwerfen?",
+    "discardAction": "Verwerfen",
+    "noneSelected": "Keine",
+    "itemCount": "{count, plural, one {# Objekt} other {# Objekte}}",
+    "quantityLabel": "Anz.: {count}",
+    "linkedTricksCount": "{count, plural, one {Verwendet in # Trick} other {Verwendet in # Tricks}}",
+    "type": {
+      "prop": "Requisite",
+      "book": "Buch",
+      "gimmick": "Gimmick",
+      "dvd": "DVD",
+      "download": "Download",
+      "deck": "Kartenspiel",
+      "clothing": "Kleidung",
+      "consumable": "Verbrauchsmaterial",
+      "accessory": "Zubehör",
+      "other": "Sonstiges"
+    },
+    "condition": {
+      "new": "Neu",
+      "good": "Guter Zustand",
+      "worn": "Abgenutzt",
+      "needs_repair": "Reparaturbedürftig"
+    },
+    "sort": {
+      "nameAsc": "Name A-Z",
+      "nameDesc": "Name Z-A",
+      "newest": "Neueste",
+      "oldest": "Älteste",
+      "type": "Typ",
+      "priceAsc": "Preis: aufsteigend",
+      "priceDesc": "Preis: absteigend"
+    },
+    "field": {
+      "name": "Name",
+      "namePlaceholder": "Invisible Deck, Card College...",
+      "type": "Typ",
+      "description": "Beschreibung",
+      "descriptionPlaceholder": "Was ist dieser Gegenstand?",
+      "brand": "Marke",
+      "brandPlaceholder": "Bicycle, Murphy's Magic...",
+      "creator": "Ersteller",
+      "creatorPlaceholder": "Autor, Erfinder, Designer...",
+      "creatorLabelBook": "Autor",
+      "creatorLabelDefault": "Ersteller",
+      "condition": "Zustand",
+      "location": "Standort",
+      "locationPlaceholder": "Close-up-Koffer, Bühnenkoffer...",
+      "quantity": "Menge",
+      "purchaseDate": "Kaufdatum",
+      "purchasePrice": "Kaufpreis",
+      "pricePlaceholder": "0,00",
+      "url": "Produkt-URL",
+      "urlPlaceholder": "https://...",
+      "tags": "Tags",
+      "linkedTricks": "Verwendet in Tricks",
+      "notes": "Notizen",
+      "notesPlaceholder": "Persönliche Notizen, Aufbewahrungstipps..."
+    },
+    "section": {
+      "essentials": "Grundlagen",
+      "details": "Details",
+      "purchase": "Kaufinformationen",
+      "reference": "Referenz",
+      "organization": "Organisation"
+    },
+    "tagPicker": {
+      "search": "Tags suchen...",
+      "noResults": "Keine Tags gefunden.",
+      "create": "\"{name}\" erstellen",
+      "selectedTags": "Ausgewählte Tags",
+      "remove": "{name} entfernen",
+      "addedTag": "Tag {name} hinzugefügt",
+      "removedTag": "Tag {name} entfernt",
+      "createdTag": "Tag {name} erstellt und hinzugefügt",
+      "createFailed": "Tag konnte nicht erstellt werden"
+    },
+    "trickPicker": {
+      "search": "Tricks suchen...",
+      "noResults": "Keine Tricks gefunden.",
+      "selectedTricks": "Verknüpfte Tricks",
+      "remove": "{name} trennen",
+      "addedTrick": "{name} verknüpft",
+      "removedTrick": "{name} getrennt"
+    },
+    "validation": {
+      "nameRequired": "Name ist erforderlich",
+      "nameTooLong": "Der Name darf maximal 200 Zeichen lang sein",
+      "descriptionTooLong": "Die Beschreibung darf maximal 2.000 Zeichen lang sein",
+      "invalidUrl": "Bitte gib eine gültige HTTPS-URL ein",
+      "urlTooLong": "Die URL darf maximal 2.000 Zeichen lang sein",
+      "invalidPrice": "Bitte gib einen gültigen Preis ein (z. B. 29,99)",
+      "invalidDate": "Bitte gib ein gültiges Datum ein",
+      "quantityMin": "Die Menge muss mindestens 0 sein",
+      "quantityMax": "Die Menge darf maximal 9.999 betragen",
+      "tooManyTags": "Es können nicht mehr als 20 Tags zu einem Objekt hinzugefügt werden.",
+      "tooManyTricks": "Es können nicht mehr als {count} Tricks mit einem Objekt verknüpft werden."
+    },
+    "errors": {
+      "itemMissing": "Dieses Objekt wurde bereits gelöscht oder nicht gefunden."
+    },
+    "addItemDescription": "Ein neues Objekt zu deiner Sammlung hinzufügen.",
+    "editItemDescription": "Die Details dieses Objekts bearbeiten.",
+    "cardActions": "Aktionen",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "deleteConfirm": "Löschen",
+    "combobox": {
+      "select": "Auswählen...",
+      "clearSelection": "Auswahl löschen",
+      "noResults": "Keine Ergebnisse gefunden.",
+      "useCustom": "\"{value}\" verwenden"
+    }
   },
   "admin": {
     "title": "Admin",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -54,6 +54,7 @@
     "trickDeleted": "Trick deleted",
     "saveFailed": "Failed to save trick",
     "deleteFailed": "Failed to delete trick",
+    "loadError": "Failed to load data",
     "emptyTitle": "Your repertoire is empty",
     "emptyDescription": "Add your first trick to start building your repertoire.",
     "searchPlaceholder": "Search tricks...",
@@ -178,7 +179,9 @@
       "tooManyTags": "Maximum 20 tags allowed",
       "tagNameRequired": "Tag name is required",
       "tagNameTooLong": "Tag name must be 50 characters or less"
-    }
+    },
+    "linkedItems": "Linked items",
+    "noLinkedItems": "Not linked to any items."
   },
   "landing": {
     "tagline": "Train. Plan. Perform. Elevate your magic.",
@@ -208,7 +211,10 @@
     "fallbackName": "magician",
     "repertoireTitle": "My Repertoire",
     "repertoireDescription": "{count, plural, one {# trick} other {# tricks}} in your collection",
-    "repertoireLink": "Open repertoire"
+    "repertoireLink": "Open repertoire",
+    "collectionTitle": "My Collection",
+    "collectionDescription": "{count, plural, one {# item} other {# items}} in your inventory",
+    "collectionLink": "Open collection"
   },
   "improve": {
     "title": "Improve",
@@ -233,7 +239,143 @@
   },
   "collect": {
     "title": "Collection",
-    "description": "Manage your inventory of props, books, gimmicks, and more."
+    "description": "Manage your inventory of props, books, gimmicks, and more.",
+    "addItem": "Add item",
+    "editItem": "Edit item",
+    "deleteItem": "Delete item",
+    "deleteConfirmTitle": "Delete \"{name}\"?",
+    "deleteConfirmDescription": "This item will be removed from your collection. This action cannot be undone.",
+    "itemCreated": "Item added",
+    "itemUpdated": "Item updated",
+    "itemDeleted": "Item deleted",
+    "saveFailed": "Failed to save item",
+    "deleteFailed": "Failed to delete item",
+    "loadError": "Failed to load data",
+    "emptyTitle": "Your collection is empty",
+    "emptyDescription": "Add your first item to start building your collection.",
+    "searchPlaceholder": "Search items...",
+    "sortBy": "Sort by",
+    "filterByType": "Filter by type",
+    "filterByCondition": "Filter by condition",
+    "allTypes": "All types",
+    "allConditions": "All conditions",
+    "noResults": "No items match your filters.",
+    "unsavedChanges": "You have unsaved changes. Discard them?",
+    "discardChangesTitle": "Discard changes?",
+    "discardAction": "Discard",
+    "noneSelected": "None",
+    "itemCount": "{count, plural, one {# item} other {# items}}",
+    "quantityLabel": "Qty: {count}",
+    "linkedTricksCount": "{count, plural, one {Used in # trick} other {Used in # tricks}}",
+    "type": {
+      "prop": "Prop",
+      "book": "Book",
+      "gimmick": "Gimmick",
+      "dvd": "DVD",
+      "download": "Download",
+      "deck": "Deck",
+      "clothing": "Clothing",
+      "consumable": "Consumable",
+      "accessory": "Accessory",
+      "other": "Other"
+    },
+    "condition": {
+      "new": "New",
+      "good": "Good",
+      "worn": "Worn",
+      "needs_repair": "Needs Repair"
+    },
+    "sort": {
+      "nameAsc": "Name A-Z",
+      "nameDesc": "Name Z-A",
+      "newest": "Newest",
+      "oldest": "Oldest",
+      "type": "Type",
+      "priceAsc": "Price: low to high",
+      "priceDesc": "Price: high to low"
+    },
+    "field": {
+      "name": "Name",
+      "namePlaceholder": "Invisible Deck, Card College...",
+      "type": "Type",
+      "description": "Description",
+      "descriptionPlaceholder": "What is this item?",
+      "brand": "Brand",
+      "brandPlaceholder": "Bicycle, Murphy's Magic...",
+      "creator": "Creator",
+      "creatorPlaceholder": "Author, inventor, designer...",
+      "creatorLabelBook": "Author",
+      "creatorLabelDefault": "Creator",
+      "condition": "Condition",
+      "location": "Location",
+      "locationPlaceholder": "Close-up case, stage case...",
+      "quantity": "Quantity",
+      "purchaseDate": "Purchase date",
+      "purchasePrice": "Purchase price",
+      "pricePlaceholder": "0.00",
+      "url": "Product URL",
+      "urlPlaceholder": "https://...",
+      "tags": "Tags",
+      "linkedTricks": "Used in tricks",
+      "notes": "Notes",
+      "notesPlaceholder": "Personal notes, storage tips..."
+    },
+    "section": {
+      "essentials": "Essentials",
+      "details": "Details",
+      "purchase": "Purchase Info",
+      "reference": "Reference",
+      "organization": "Organization"
+    },
+    "tagPicker": {
+      "search": "Search tags...",
+      "noResults": "No tags found.",
+      "create": "Create \"{name}\"",
+      "selectedTags": "Selected tags",
+      "remove": "Remove {name}",
+      "addedTag": "Added tag {name}",
+      "removedTag": "Removed tag {name}",
+      "createdTag": "Created and added tag {name}",
+      "createFailed": "Failed to create tag"
+    },
+    "trickPicker": {
+      "search": "Search tricks...",
+      "noResults": "No tricks found.",
+      "selectedTricks": "Linked tricks",
+      "remove": "Unlink {name}",
+      "addedTrick": "Linked {name}",
+      "removedTrick": "Unlinked {name}"
+    },
+    "validation": {
+      "nameRequired": "Name is required",
+      "nameTooLong": "Name must be 200 characters or less",
+      "descriptionTooLong": "Description must be 2,000 characters or less",
+      "invalidUrl": "Please enter a valid HTTPS URL",
+      "urlTooLong": "URL must be 2,000 characters or less",
+      "invalidPrice": "Please enter a valid price (e.g. 29.99)",
+      "invalidDate": "Please enter a valid date",
+      "quantityMin": "Quantity must be at least 0",
+      "quantityMax": "Quantity must be 9,999 or less",
+      "tooManyTags": "Cannot add more than 20 tags to an item.",
+      "tooManyTricks": "Cannot link more than {count} tricks to an item."
+    },
+    "errors": {
+      "itemMissing": "This item was already deleted or not found."
+    },
+    "addItemDescription": "Add a new item to your collection.",
+    "editItemDescription": "Edit the details of this item.",
+    "cardActions": "Actions",
+    "edit": "Edit",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "save": "Save",
+    "deleteConfirm": "Delete",
+    "combobox": {
+      "select": "Select...",
+      "clearSelection": "Clear selection",
+      "noResults": "No results found.",
+      "useCustom": "Use \"{value}\""
+    }
   },
   "admin": {
     "title": "Admin",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -54,6 +54,7 @@
     "trickDeleted": "Truco eliminado",
     "saveFailed": "Error al guardar el truco",
     "deleteFailed": "Error al eliminar el truco",
+    "loadError": "Error al cargar los datos",
     "emptyTitle": "Tu repertorio está vacío",
     "emptyDescription": "Añade tu primer truco para empezar a construir tu repertorio.",
     "searchPlaceholder": "Buscar trucos...",
@@ -178,7 +179,9 @@
       "tooManyTags": "Máximo 20 etiquetas permitidas",
       "tagNameRequired": "El nombre de la etiqueta es obligatorio",
       "tagNameTooLong": "El nombre de la etiqueta debe tener 50 caracteres o menos"
-    }
+    },
+    "linkedItems": "Objetos vinculados",
+    "noLinkedItems": "No está vinculado a ningún objeto."
   },
   "landing": {
     "tagline": "Entrena. Planifica. Actúa. Eleva tu magia.",
@@ -208,7 +211,10 @@
     "fallbackName": "mago",
     "repertoireTitle": "Mi repertorio",
     "repertoireDescription": "{count, plural, one {# truco} other {# trucos}} en tu colección",
-    "repertoireLink": "Abrir repertorio"
+    "repertoireLink": "Abrir repertorio",
+    "collectionTitle": "Mi colección",
+    "collectionDescription": "{count, plural, one {# objeto} other {# objetos}} en tu inventario",
+    "collectionLink": "Abrir colección"
   },
   "improve": {
     "title": "Mejorar",
@@ -233,7 +239,143 @@
   },
   "collect": {
     "title": "Colección",
-    "description": "Gestiona tu inventario de accesorios, libros, gimmicks y más."
+    "description": "Gestiona tu inventario de accesorios, libros, gimmicks y más.",
+    "addItem": "Agregar objeto",
+    "editItem": "Editar objeto",
+    "deleteItem": "Eliminar objeto",
+    "deleteConfirmTitle": "¿Eliminar \"{name}\"?",
+    "deleteConfirmDescription": "Este objeto se eliminará de tu colección. Esta acción no se puede deshacer.",
+    "itemCreated": "Objeto agregado",
+    "itemUpdated": "Objeto actualizado",
+    "itemDeleted": "Objeto eliminado",
+    "saveFailed": "Error al guardar el objeto",
+    "deleteFailed": "Error al eliminar el objeto",
+    "loadError": "Error al cargar los datos",
+    "emptyTitle": "Tu colección está vacía",
+    "emptyDescription": "Agrega tu primer objeto para empezar a construir tu colección.",
+    "searchPlaceholder": "Buscar objetos...",
+    "sortBy": "Ordenar por",
+    "filterByType": "Filtrar por tipo",
+    "filterByCondition": "Filtrar por estado",
+    "allTypes": "Todos los tipos",
+    "allConditions": "Todos los estados",
+    "noResults": "Ningún objeto coincide con tus filtros.",
+    "unsavedChanges": "Tienes cambios sin guardar. ¿Descartarlos?",
+    "discardChangesTitle": "¿Descartar cambios?",
+    "discardAction": "Descartar",
+    "noneSelected": "Ninguno",
+    "itemCount": "{count, plural, one {# objeto} other {# objetos}}",
+    "quantityLabel": "Cant.: {count}",
+    "linkedTricksCount": "{count, plural, one {Usado en # truco} other {Usado en # trucos}}",
+    "type": {
+      "prop": "Accesorio",
+      "book": "Libro",
+      "gimmick": "Gimmick",
+      "dvd": "DVD",
+      "download": "Descarga",
+      "deck": "Baraja",
+      "clothing": "Ropa",
+      "consumable": "Consumible",
+      "accessory": "Accesorio",
+      "other": "Otro"
+    },
+    "condition": {
+      "new": "Nuevo",
+      "good": "Buen estado",
+      "worn": "Desgastado",
+      "needs_repair": "Necesita reparación"
+    },
+    "sort": {
+      "nameAsc": "Nombre A-Z",
+      "nameDesc": "Nombre Z-A",
+      "newest": "Más reciente",
+      "oldest": "Más antiguo",
+      "type": "Tipo",
+      "priceAsc": "Precio: menor a mayor",
+      "priceDesc": "Precio: mayor a menor"
+    },
+    "field": {
+      "name": "Nombre",
+      "namePlaceholder": "Invisible Deck, Card College...",
+      "type": "Tipo",
+      "description": "Descripción",
+      "descriptionPlaceholder": "¿Qué es este objeto?",
+      "brand": "Marca",
+      "brandPlaceholder": "Bicycle, Murphy's Magic...",
+      "creator": "Creador",
+      "creatorPlaceholder": "Autor, inventor, diseñador...",
+      "creatorLabelBook": "Autor",
+      "creatorLabelDefault": "Creador",
+      "condition": "Estado",
+      "location": "Ubicación",
+      "locationPlaceholder": "Maletín de close-up, maletín de escenario...",
+      "quantity": "Cantidad",
+      "purchaseDate": "Fecha de compra",
+      "purchasePrice": "Precio de compra",
+      "pricePlaceholder": "0,00",
+      "url": "URL del producto",
+      "urlPlaceholder": "https://...",
+      "tags": "Etiquetas",
+      "linkedTricks": "Usado en trucos",
+      "notes": "Notas",
+      "notesPlaceholder": "Notas personales, consejos de almacenamiento..."
+    },
+    "section": {
+      "essentials": "Esenciales",
+      "details": "Detalles",
+      "purchase": "Datos de compra",
+      "reference": "Referencia",
+      "organization": "Organización"
+    },
+    "tagPicker": {
+      "search": "Buscar etiquetas...",
+      "noResults": "No se encontraron etiquetas.",
+      "create": "Crear \"{name}\"",
+      "selectedTags": "Etiquetas seleccionadas",
+      "remove": "Eliminar {name}",
+      "addedTag": "Etiqueta {name} añadida",
+      "removedTag": "Etiqueta {name} eliminada",
+      "createdTag": "Etiqueta {name} creada y añadida",
+      "createFailed": "Error al crear la etiqueta"
+    },
+    "trickPicker": {
+      "search": "Buscar trucos...",
+      "noResults": "No se encontraron trucos.",
+      "selectedTricks": "Trucos vinculados",
+      "remove": "Desvincular {name}",
+      "addedTrick": "{name} vinculado",
+      "removedTrick": "{name} desvinculado"
+    },
+    "validation": {
+      "nameRequired": "El nombre es obligatorio",
+      "nameTooLong": "El nombre debe tener 200 caracteres o menos",
+      "descriptionTooLong": "La descripción debe tener 2000 caracteres o menos",
+      "invalidUrl": "Introduce una URL HTTPS válida",
+      "urlTooLong": "La URL debe tener 2000 caracteres o menos",
+      "invalidPrice": "Introduce un precio válido (ej.: 29,99)",
+      "invalidDate": "Introduce una fecha válida",
+      "quantityMin": "La cantidad debe ser al menos 0",
+      "quantityMax": "La cantidad debe ser 9999 o menos",
+      "tooManyTags": "No se pueden añadir más de 20 etiquetas a un objeto.",
+      "tooManyTricks": "No se pueden vincular más de {count} trucos a un objeto."
+    },
+    "errors": {
+      "itemMissing": "Este objeto ya se ha eliminado o no se ha encontrado."
+    },
+    "addItemDescription": "Agregar un nuevo objeto a tu colección.",
+    "editItemDescription": "Editar los detalles de este objeto.",
+    "cardActions": "Acciones",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "deleteConfirm": "Eliminar",
+    "combobox": {
+      "select": "Seleccionar...",
+      "clearSelection": "Borrar selección",
+      "noResults": "No se encontraron resultados.",
+      "useCustom": "Usar \"{value}\""
+    }
   },
   "admin": {
     "title": "Administración",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -54,6 +54,7 @@
     "trickDeleted": "Tour supprimé",
     "saveFailed": "Échec de l'enregistrement du tour",
     "deleteFailed": "Échec de la suppression du tour",
+    "loadError": "Échec du chargement des données",
     "emptyTitle": "Votre répertoire est vide",
     "emptyDescription": "Ajoutez votre premier tour pour commencer à construire votre répertoire.",
     "searchPlaceholder": "Rechercher des tours...",
@@ -178,7 +179,9 @@
       "tooManyTags": "20 tags maximum autorisés",
       "tagNameRequired": "Le nom du tag est requis",
       "tagNameTooLong": "Le nom du tag doit contenir 50 caractères ou moins"
-    }
+    },
+    "linkedItems": "Objets associés",
+    "noLinkedItems": "Non associé à aucun objet."
   },
   "landing": {
     "tagline": "S'entraîner. Planifier. Performer. Sublimer sa magie.",
@@ -208,7 +211,10 @@
     "fallbackName": "magicien",
     "repertoireTitle": "Mon répertoire",
     "repertoireDescription": "{count, plural, one {# tour} other {# tours}} dans votre collection",
-    "repertoireLink": "Ouvrir le répertoire"
+    "repertoireLink": "Ouvrir le répertoire",
+    "collectionTitle": "Ma collection",
+    "collectionDescription": "{count, plural, one {# objet} other {# objets}} dans votre inventaire",
+    "collectionLink": "Ouvrir la collection"
   },
   "improve": {
     "title": "Améliorer",
@@ -233,7 +239,143 @@
   },
   "collect": {
     "title": "Collection",
-    "description": "Gérez votre inventaire d'accessoires, de livres, de gimmicks et plus encore."
+    "description": "Gérez votre inventaire d'accessoires, de livres, de gimmicks et plus encore.",
+    "addItem": "Ajouter un objet",
+    "editItem": "Modifier l'objet",
+    "deleteItem": "Supprimer l'objet",
+    "deleteConfirmTitle": "Supprimer \"{name}\" ?",
+    "deleteConfirmDescription": "Cet objet sera retiré de votre collection. Cette action est irréversible.",
+    "itemCreated": "Objet ajouté",
+    "itemUpdated": "Objet mis à jour",
+    "itemDeleted": "Objet supprimé",
+    "saveFailed": "Échec de l'enregistrement de l'objet",
+    "deleteFailed": "Échec de la suppression de l'objet",
+    "loadError": "Échec du chargement des données",
+    "emptyTitle": "Votre collection est vide",
+    "emptyDescription": "Ajoutez votre premier objet pour commencer à construire votre collection.",
+    "searchPlaceholder": "Rechercher des objets...",
+    "sortBy": "Trier par",
+    "filterByType": "Filtrer par type",
+    "filterByCondition": "Filtrer par état",
+    "allTypes": "Tous les types",
+    "allConditions": "Tous les états",
+    "noResults": "Aucun objet ne correspond à vos filtres.",
+    "unsavedChanges": "Vous avez des modifications non enregistrées. Les abandonner ?",
+    "discardChangesTitle": "Abandonner les modifications ?",
+    "discardAction": "Abandonner",
+    "noneSelected": "Aucun",
+    "itemCount": "{count, plural, one {# objet} other {# objets}}",
+    "quantityLabel": "Qté : {count}",
+    "linkedTricksCount": "{count, plural, one {Utilisé dans # tour} other {Utilisé dans # tours}}",
+    "type": {
+      "prop": "Accessoire",
+      "book": "Livre",
+      "gimmick": "Gimmick",
+      "dvd": "DVD",
+      "download": "Téléchargement",
+      "deck": "Jeu de cartes",
+      "clothing": "Vêtement",
+      "consumable": "Consommable",
+      "accessory": "Accessoire",
+      "other": "Autre"
+    },
+    "condition": {
+      "new": "Neuf",
+      "good": "Bon état",
+      "worn": "Usé",
+      "needs_repair": "À réparer"
+    },
+    "sort": {
+      "nameAsc": "Nom A-Z",
+      "nameDesc": "Nom Z-A",
+      "newest": "Plus récent",
+      "oldest": "Plus ancien",
+      "type": "Type",
+      "priceAsc": "Prix : croissant",
+      "priceDesc": "Prix : décroissant"
+    },
+    "field": {
+      "name": "Nom",
+      "namePlaceholder": "Invisible Deck, Card College...",
+      "type": "Type",
+      "description": "Description",
+      "descriptionPlaceholder": "De quoi s'agit-il ?",
+      "brand": "Marque",
+      "brandPlaceholder": "Bicycle, Murphy's Magic...",
+      "creator": "Créateur",
+      "creatorPlaceholder": "Auteur, inventeur, concepteur...",
+      "creatorLabelBook": "Auteur",
+      "creatorLabelDefault": "Créateur",
+      "condition": "État",
+      "location": "Emplacement",
+      "locationPlaceholder": "Valise close-up, valise de scène...",
+      "quantity": "Quantité",
+      "purchaseDate": "Date d'achat",
+      "purchasePrice": "Prix d'achat",
+      "pricePlaceholder": "0,00",
+      "url": "URL du produit",
+      "urlPlaceholder": "https://...",
+      "tags": "Tags",
+      "linkedTricks": "Utilisé dans les tours",
+      "notes": "Notes",
+      "notesPlaceholder": "Notes personnelles, conseils de rangement..."
+    },
+    "section": {
+      "essentials": "Essentiel",
+      "details": "Détails",
+      "purchase": "Informations d'achat",
+      "reference": "Référence",
+      "organization": "Organisation"
+    },
+    "tagPicker": {
+      "search": "Rechercher des tags...",
+      "noResults": "Aucun tag trouvé.",
+      "create": "Créer \"{name}\"",
+      "selectedTags": "Tags sélectionnés",
+      "remove": "Retirer {name}",
+      "addedTag": "Tag {name} ajouté",
+      "removedTag": "Tag {name} retiré",
+      "createdTag": "Tag {name} créé et ajouté",
+      "createFailed": "Échec de la création du tag"
+    },
+    "trickPicker": {
+      "search": "Rechercher des tours...",
+      "noResults": "Aucun tour trouvé.",
+      "selectedTricks": "Tours associés",
+      "remove": "Dissocier {name}",
+      "addedTrick": "{name} associé",
+      "removedTrick": "{name} dissocié"
+    },
+    "validation": {
+      "nameRequired": "Le nom est requis",
+      "nameTooLong": "Le nom doit contenir 200 caractères ou moins",
+      "descriptionTooLong": "La description doit contenir 2 000 caractères ou moins",
+      "invalidUrl": "Veuillez entrer une URL HTTPS valide",
+      "urlTooLong": "L'URL doit contenir 2 000 caractères ou moins",
+      "invalidPrice": "Veuillez entrer un prix valide (ex. : 29,99)",
+      "invalidDate": "Veuillez entrer une date valide",
+      "quantityMin": "La quantité doit être au moins 0",
+      "quantityMax": "La quantité doit être de 9 999 ou moins",
+      "tooManyTags": "Impossible d'ajouter plus de 20 tags à un objet.",
+      "tooManyTricks": "Impossible d'associer plus de {count} tours à un objet."
+    },
+    "errors": {
+      "itemMissing": "Cet objet a déjà été supprimé ou est introuvable."
+    },
+    "addItemDescription": "Ajouter un nouvel objet à votre collection.",
+    "editItemDescription": "Modifier les détails de cet objet.",
+    "cardActions": "Actions",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "deleteConfirm": "Supprimer",
+    "combobox": {
+      "select": "Sélectionner...",
+      "clearSelection": "Effacer la sélection",
+      "noResults": "Aucun résultat trouvé.",
+      "useCustom": "Utiliser \"{value}\""
+    }
   },
   "admin": {
     "title": "Administration",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -54,6 +54,7 @@
     "trickDeleted": "Trucco eliminato",
     "saveFailed": "Impossibile salvare il trucco",
     "deleteFailed": "Impossibile eliminare il trucco",
+    "loadError": "Impossibile caricare i dati",
     "emptyTitle": "Il tuo repertorio è vuoto",
     "emptyDescription": "Aggiungi il tuo primo trucco per iniziare a costruire il tuo repertorio.",
     "searchPlaceholder": "Cerca trucchi...",
@@ -178,7 +179,9 @@
       "tooManyTags": "Massimo 20 tag consentiti",
       "tagNameRequired": "Il nome del tag è obbligatorio",
       "tagNameTooLong": "Il nome del tag deve contenere al massimo 50 caratteri"
-    }
+    },
+    "linkedItems": "Oggetti collegati",
+    "noLinkedItems": "Non collegato a nessun oggetto."
   },
   "landing": {
     "tagline": "Allenati. Pianifica. Esibisciti. Eleva la tua magia.",
@@ -208,7 +211,10 @@
     "fallbackName": "mago",
     "repertoireTitle": "Il mio repertorio",
     "repertoireDescription": "{count, plural, one {# trucco} other {# trucchi}} nella tua collezione",
-    "repertoireLink": "Apri repertorio"
+    "repertoireLink": "Apri repertorio",
+    "collectionTitle": "La mia collezione",
+    "collectionDescription": "{count, plural, one {# oggetto} other {# oggetti}} nel tuo inventario",
+    "collectionLink": "Apri collezione"
   },
   "improve": {
     "title": "Migliora",
@@ -233,7 +239,143 @@
   },
   "collect": {
     "title": "Collezione",
-    "description": "Gestisci il tuo inventario di attrezzi, libri, gimmick e altro."
+    "description": "Gestisci il tuo inventario di attrezzi, libri, gimmick e altro.",
+    "addItem": "Aggiungi oggetto",
+    "editItem": "Modifica oggetto",
+    "deleteItem": "Elimina oggetto",
+    "deleteConfirmTitle": "Eliminare \"{name}\"?",
+    "deleteConfirmDescription": "Questo oggetto verrà rimosso dalla tua collezione. Questa azione non può essere annullata.",
+    "itemCreated": "Oggetto aggiunto",
+    "itemUpdated": "Oggetto aggiornato",
+    "itemDeleted": "Oggetto eliminato",
+    "saveFailed": "Impossibile salvare l'oggetto",
+    "deleteFailed": "Impossibile eliminare l'oggetto",
+    "loadError": "Impossibile caricare i dati",
+    "emptyTitle": "La tua collezione è vuota",
+    "emptyDescription": "Aggiungi il tuo primo oggetto per iniziare a costruire la tua collezione.",
+    "searchPlaceholder": "Cerca oggetti...",
+    "sortBy": "Ordina per",
+    "filterByType": "Filtra per tipo",
+    "filterByCondition": "Filtra per condizione",
+    "allTypes": "Tutti i tipi",
+    "allConditions": "Tutte le condizioni",
+    "noResults": "Nessun oggetto corrisponde ai tuoi filtri.",
+    "unsavedChanges": "Hai modifiche non salvate. Scartarle?",
+    "discardChangesTitle": "Scartare le modifiche?",
+    "discardAction": "Scartare",
+    "noneSelected": "Nessuno",
+    "itemCount": "{count, plural, one {# oggetto} other {# oggetti}}",
+    "quantityLabel": "Qtà: {count}",
+    "linkedTricksCount": "{count, plural, one {Usato in # trucco} other {Usato in # trucchi}}",
+    "type": {
+      "prop": "Attrezzo",
+      "book": "Libro",
+      "gimmick": "Gimmick",
+      "dvd": "DVD",
+      "download": "Download",
+      "deck": "Mazzo",
+      "clothing": "Abbigliamento",
+      "consumable": "Consumabile",
+      "accessory": "Accessorio",
+      "other": "Altro"
+    },
+    "condition": {
+      "new": "Nuovo",
+      "good": "Buono stato",
+      "worn": "Usurato",
+      "needs_repair": "Da riparare"
+    },
+    "sort": {
+      "nameAsc": "Nome A-Z",
+      "nameDesc": "Nome Z-A",
+      "newest": "Più recente",
+      "oldest": "Meno recente",
+      "type": "Tipo",
+      "priceAsc": "Prezzo: crescente",
+      "priceDesc": "Prezzo: decrescente"
+    },
+    "field": {
+      "name": "Nome",
+      "namePlaceholder": "Invisible Deck, Card College...",
+      "type": "Tipo",
+      "description": "Descrizione",
+      "descriptionPlaceholder": "Cos'è questo oggetto?",
+      "brand": "Marca",
+      "brandPlaceholder": "Bicycle, Murphy's Magic...",
+      "creator": "Creatore",
+      "creatorPlaceholder": "Autore, inventore, designer...",
+      "creatorLabelBook": "Autore",
+      "creatorLabelDefault": "Creatore",
+      "condition": "Condizione",
+      "location": "Posizione",
+      "locationPlaceholder": "Valigetta close-up, valigetta da palco...",
+      "quantity": "Quantità",
+      "purchaseDate": "Data di acquisto",
+      "purchasePrice": "Prezzo di acquisto",
+      "pricePlaceholder": "0,00",
+      "url": "URL del prodotto",
+      "urlPlaceholder": "https://...",
+      "tags": "Tag",
+      "linkedTricks": "Usato nei trucchi",
+      "notes": "Note",
+      "notesPlaceholder": "Note personali, consigli per la conservazione..."
+    },
+    "section": {
+      "essentials": "Essenziali",
+      "details": "Dettagli",
+      "purchase": "Dati di acquisto",
+      "reference": "Riferimento",
+      "organization": "Organizzazione"
+    },
+    "tagPicker": {
+      "search": "Cerca tag...",
+      "noResults": "Nessun tag trovato.",
+      "create": "Crea \"{name}\"",
+      "selectedTags": "Tag selezionati",
+      "remove": "Rimuovi {name}",
+      "addedTag": "Tag {name} aggiunto",
+      "removedTag": "Tag {name} rimosso",
+      "createdTag": "Tag {name} creato e aggiunto",
+      "createFailed": "Creazione del tag non riuscita"
+    },
+    "trickPicker": {
+      "search": "Cerca trucchi...",
+      "noResults": "Nessun trucco trovato.",
+      "selectedTricks": "Trucchi collegati",
+      "remove": "Scollega {name}",
+      "addedTrick": "{name} collegato",
+      "removedTrick": "{name} scollegato"
+    },
+    "validation": {
+      "nameRequired": "Il nome è obbligatorio",
+      "nameTooLong": "Il nome deve contenere al massimo 200 caratteri",
+      "descriptionTooLong": "La descrizione deve contenere al massimo 2000 caratteri",
+      "invalidUrl": "Inserisci un URL HTTPS valido",
+      "urlTooLong": "L'URL deve contenere al massimo 2000 caratteri",
+      "invalidPrice": "Inserisci un prezzo valido (es. 29,99)",
+      "invalidDate": "Inserisci una data valida",
+      "quantityMin": "La quantità deve essere almeno 0",
+      "quantityMax": "La quantità deve essere 9999 o meno",
+      "tooManyTags": "Impossibile aggiungere più di 20 tag a un oggetto.",
+      "tooManyTricks": "Impossibile collegare più di {count} trucchi a un oggetto."
+    },
+    "errors": {
+      "itemMissing": "Questo oggetto è già stato eliminato o non è stato trovato."
+    },
+    "addItemDescription": "Aggiungi un nuovo oggetto alla tua collezione.",
+    "editItemDescription": "Modifica i dettagli di questo oggetto.",
+    "cardActions": "Azioni",
+    "edit": "Modifica",
+    "delete": "Elimina",
+    "cancel": "Annulla",
+    "save": "Salva",
+    "deleteConfirm": "Elimina",
+    "combobox": {
+      "select": "Seleziona...",
+      "clearSelection": "Cancella selezione",
+      "noResults": "Nessun risultato trovato.",
+      "useCustom": "Usa \"{value}\""
+    }
   },
   "admin": {
     "title": "Admin",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -54,6 +54,7 @@
     "trickDeleted": "Truc verwijderd",
     "saveFailed": "Truc opslaan mislukt",
     "deleteFailed": "Truc verwijderen mislukt",
+    "loadError": "Gegevens laden mislukt",
     "emptyTitle": "Je repertoire is leeg",
     "emptyDescription": "Voeg je eerste truc toe om je repertoire op te bouwen.",
     "searchPlaceholder": "Trucs zoeken...",
@@ -178,7 +179,9 @@
       "tooManyTags": "Maximaal 20 tags toegestaan",
       "tagNameRequired": "Tagnaam is verplicht",
       "tagNameTooLong": "Tagnaam mag maximaal 50 tekens bevatten"
-    }
+    },
+    "linkedItems": "Gekoppelde items",
+    "noLinkedItems": "Niet gekoppeld aan items."
   },
   "landing": {
     "tagline": "Trainen. Plannen. Optreden. Til je magie naar een hoger niveau.",
@@ -208,7 +211,10 @@
     "fallbackName": "goochelaar",
     "repertoireTitle": "Mijn Repertoire",
     "repertoireDescription": "{count, plural, one {# truc} other {# trucs}} in je collectie",
-    "repertoireLink": "Repertoire openen"
+    "repertoireLink": "Repertoire openen",
+    "collectionTitle": "Mijn Collectie",
+    "collectionDescription": "{count, plural, one {# item} other {# items}} in je inventaris",
+    "collectionLink": "Collectie openen"
   },
   "improve": {
     "title": "Verbeteren",
@@ -233,7 +239,143 @@
   },
   "collect": {
     "title": "Collectie",
-    "description": "Beheer je inventaris van rekwisieten, boeken, gimmicks en meer."
+    "description": "Beheer je inventaris van rekwisieten, boeken, gimmicks en meer.",
+    "addItem": "Item toevoegen",
+    "editItem": "Item bewerken",
+    "deleteItem": "Item verwijderen",
+    "deleteConfirmTitle": "\"{name}\" verwijderen?",
+    "deleteConfirmDescription": "Dit item wordt uit je collectie verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
+    "itemCreated": "Item toegevoegd",
+    "itemUpdated": "Item bijgewerkt",
+    "itemDeleted": "Item verwijderd",
+    "saveFailed": "Item opslaan mislukt",
+    "deleteFailed": "Item verwijderen mislukt",
+    "loadError": "Gegevens laden mislukt",
+    "emptyTitle": "Je collectie is leeg",
+    "emptyDescription": "Voeg je eerste item toe om je collectie op te bouwen.",
+    "searchPlaceholder": "Items zoeken...",
+    "sortBy": "Sorteren op",
+    "filterByType": "Filteren op type",
+    "filterByCondition": "Filteren op staat",
+    "allTypes": "Alle typen",
+    "allConditions": "Alle staten",
+    "noResults": "Geen items komen overeen met je filters.",
+    "unsavedChanges": "Je hebt niet-opgeslagen wijzigingen. Wil je ze verwerpen?",
+    "discardChangesTitle": "Wijzigingen verwerpen?",
+    "discardAction": "Verwerpen",
+    "noneSelected": "Geen",
+    "itemCount": "{count, plural, one {# item} other {# items}}",
+    "quantityLabel": "Aantal: {count}",
+    "linkedTricksCount": "{count, plural, one {Gebruikt in # truc} other {Gebruikt in # trucs}}",
+    "type": {
+      "prop": "Rekwisiet",
+      "book": "Boek",
+      "gimmick": "Gimmick",
+      "dvd": "DVD",
+      "download": "Download",
+      "deck": "Kaartspel",
+      "clothing": "Kleding",
+      "consumable": "Verbruiksartikel",
+      "accessory": "Accessoire",
+      "other": "Overig"
+    },
+    "condition": {
+      "new": "Nieuw",
+      "good": "Goede staat",
+      "worn": "Versleten",
+      "needs_repair": "Reparatie nodig"
+    },
+    "sort": {
+      "nameAsc": "Naam A-Z",
+      "nameDesc": "Naam Z-A",
+      "newest": "Nieuwste",
+      "oldest": "Oudste",
+      "type": "Type",
+      "priceAsc": "Prijs: laag naar hoog",
+      "priceDesc": "Prijs: hoog naar laag"
+    },
+    "field": {
+      "name": "Naam",
+      "namePlaceholder": "Invisible Deck, Card College...",
+      "type": "Type",
+      "description": "Beschrijving",
+      "descriptionPlaceholder": "Wat is dit item?",
+      "brand": "Merk",
+      "brandPlaceholder": "Bicycle, Murphy's Magic...",
+      "creator": "Maker",
+      "creatorPlaceholder": "Auteur, uitvinder, ontwerper...",
+      "creatorLabelBook": "Auteur",
+      "creatorLabelDefault": "Maker",
+      "condition": "Staat",
+      "location": "Locatie",
+      "locationPlaceholder": "Close-up koffer, podiumkoffer...",
+      "quantity": "Aantal",
+      "purchaseDate": "Aankoopdatum",
+      "purchasePrice": "Aankoopprijs",
+      "pricePlaceholder": "0,00",
+      "url": "Product-URL",
+      "urlPlaceholder": "https://...",
+      "tags": "Tags",
+      "linkedTricks": "Gebruikt in trucs",
+      "notes": "Notities",
+      "notesPlaceholder": "Persoonlijke notities, opslagtips..."
+    },
+    "section": {
+      "essentials": "Essentieel",
+      "details": "Details",
+      "purchase": "Aankoopgegevens",
+      "reference": "Referentie",
+      "organization": "Organisatie"
+    },
+    "tagPicker": {
+      "search": "Tags zoeken...",
+      "noResults": "Geen tags gevonden.",
+      "create": "\"{name}\" aanmaken",
+      "selectedTags": "Geselecteerde tags",
+      "remove": "{name} verwijderen",
+      "addedTag": "Tag {name} toegevoegd",
+      "removedTag": "Tag {name} verwijderd",
+      "createdTag": "Tag {name} aangemaakt en toegevoegd",
+      "createFailed": "Kan tag niet aanmaken"
+    },
+    "trickPicker": {
+      "search": "Trucs zoeken...",
+      "noResults": "Geen trucs gevonden.",
+      "selectedTricks": "Gekoppelde trucs",
+      "remove": "{name} ontkoppelen",
+      "addedTrick": "{name} gekoppeld",
+      "removedTrick": "{name} ontkoppeld"
+    },
+    "validation": {
+      "nameRequired": "Naam is verplicht",
+      "nameTooLong": "Naam mag maximaal 200 tekens bevatten",
+      "descriptionTooLong": "Beschrijving mag maximaal 2.000 tekens bevatten",
+      "invalidUrl": "Voer een geldige HTTPS-URL in",
+      "urlTooLong": "URL mag maximaal 2.000 tekens bevatten",
+      "invalidPrice": "Voer een geldige prijs in (bijv. 29,99)",
+      "invalidDate": "Voer een geldige datum in",
+      "quantityMin": "Aantal moet minimaal 0 zijn",
+      "quantityMax": "Aantal mag maximaal 9.999 zijn",
+      "tooManyTags": "Je kunt niet meer dan 20 tags aan een item toevoegen.",
+      "tooManyTricks": "Je kunt niet meer dan {count} trucs aan een item koppelen."
+    },
+    "errors": {
+      "itemMissing": "Dit item is al verwijderd of niet gevonden."
+    },
+    "addItemDescription": "Voeg een nieuw item toe aan je collectie.",
+    "editItemDescription": "Bewerk de details van dit item.",
+    "cardActions": "Acties",
+    "edit": "Bewerken",
+    "delete": "Verwijderen",
+    "cancel": "Annuleren",
+    "save": "Opslaan",
+    "deleteConfirm": "Verwijderen",
+    "combobox": {
+      "select": "Selecteer...",
+      "clearSelection": "Selectie wissen",
+      "noResults": "Geen resultaten gevonden.",
+      "useCustom": "\"{value}\" gebruiken"
+    }
   },
   "admin": {
     "title": "Admin",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -54,6 +54,7 @@
     "trickDeleted": "Truque eliminado",
     "saveFailed": "Falha ao guardar o truque",
     "deleteFailed": "Falha ao eliminar o truque",
+    "loadError": "Falha ao carregar os dados",
     "emptyTitle": "O seu repertório está vazio",
     "emptyDescription": "Adicione o seu primeiro truque para começar a construir o seu repertório.",
     "searchPlaceholder": "Pesquisar truques...",
@@ -178,7 +179,9 @@
       "tooManyTags": "Máximo de 20 etiquetas permitidas",
       "tagNameRequired": "O nome da etiqueta é obrigatório",
       "tagNameTooLong": "O nome da etiqueta deve ter 50 caracteres ou menos"
-    }
+    },
+    "linkedItems": "Objetos associados",
+    "noLinkedItems": "Não está associado a nenhum objeto."
   },
   "landing": {
     "tagline": "Treinar. Planear. Apresentar. Eleve a sua magia.",
@@ -208,7 +211,10 @@
     "fallbackName": "mágico",
     "repertoireTitle": "O Meu Repertório",
     "repertoireDescription": "{count, plural, one {# truque} other {# truques}} na sua coleção",
-    "repertoireLink": "Abrir repertório"
+    "repertoireLink": "Abrir repertório",
+    "collectionTitle": "A Minha Coleção",
+    "collectionDescription": "{count, plural, one {# objeto} other {# objetos}} no seu inventário",
+    "collectionLink": "Abrir coleção"
   },
   "improve": {
     "title": "Melhorar",
@@ -233,7 +239,143 @@
   },
   "collect": {
     "title": "Coleção",
-    "description": "Faça a gestão do seu inventário de adereços, livros, gimmicks e outros itens."
+    "description": "Faça a gestão do seu inventário de adereços, livros, gimmicks e outros itens.",
+    "addItem": "Adicionar objeto",
+    "editItem": "Editar objeto",
+    "deleteItem": "Eliminar objeto",
+    "deleteConfirmTitle": "Eliminar \"{name}\"?",
+    "deleteConfirmDescription": "Este objeto será removido da sua coleção. Esta ação não pode ser desfeita.",
+    "itemCreated": "Objeto adicionado",
+    "itemUpdated": "Objeto atualizado",
+    "itemDeleted": "Objeto eliminado",
+    "saveFailed": "Falha ao guardar o objeto",
+    "deleteFailed": "Falha ao eliminar o objeto",
+    "loadError": "Falha ao carregar os dados",
+    "emptyTitle": "A sua coleção está vazia",
+    "emptyDescription": "Adicione o seu primeiro objeto para começar a construir a sua coleção.",
+    "searchPlaceholder": "Pesquisar objetos...",
+    "sortBy": "Ordenar por",
+    "filterByType": "Filtrar por tipo",
+    "filterByCondition": "Filtrar por estado",
+    "allTypes": "Todos os tipos",
+    "allConditions": "Todos os estados",
+    "noResults": "Nenhum objeto corresponde aos seus filtros.",
+    "unsavedChanges": "Tem alterações por guardar. Descartá-las?",
+    "discardChangesTitle": "Descartar alterações?",
+    "discardAction": "Descartar",
+    "noneSelected": "Nenhum",
+    "itemCount": "{count, plural, one {# objeto} other {# objetos}}",
+    "quantityLabel": "Qtd.: {count}",
+    "linkedTricksCount": "{count, plural, one {Usado em # truque} other {Usado em # truques}}",
+    "type": {
+      "prop": "Adereço",
+      "book": "Livro",
+      "gimmick": "Gimmick",
+      "dvd": "DVD",
+      "download": "Download",
+      "deck": "Baralho",
+      "clothing": "Vestuário",
+      "consumable": "Consumível",
+      "accessory": "Acessório",
+      "other": "Outro"
+    },
+    "condition": {
+      "new": "Novo",
+      "good": "Bom estado",
+      "worn": "Desgastado",
+      "needs_repair": "Necessita reparação"
+    },
+    "sort": {
+      "nameAsc": "Nome A-Z",
+      "nameDesc": "Nome Z-A",
+      "newest": "Mais recente",
+      "oldest": "Mais antigo",
+      "type": "Tipo",
+      "priceAsc": "Preço: menor para maior",
+      "priceDesc": "Preço: maior para menor"
+    },
+    "field": {
+      "name": "Nome",
+      "namePlaceholder": "Invisible Deck, Card College...",
+      "type": "Tipo",
+      "description": "Descrição",
+      "descriptionPlaceholder": "O que é este objeto?",
+      "brand": "Marca",
+      "brandPlaceholder": "Bicycle, Murphy's Magic...",
+      "creator": "Criador",
+      "creatorPlaceholder": "Autor, inventor, designer...",
+      "creatorLabelBook": "Autor",
+      "creatorLabelDefault": "Criador",
+      "condition": "Estado",
+      "location": "Localização",
+      "locationPlaceholder": "Mala de close-up, mala de palco...",
+      "quantity": "Quantidade",
+      "purchaseDate": "Data de compra",
+      "purchasePrice": "Preço de compra",
+      "pricePlaceholder": "0,00",
+      "url": "URL do produto",
+      "urlPlaceholder": "https://...",
+      "tags": "Etiquetas",
+      "linkedTricks": "Usado em truques",
+      "notes": "Notas",
+      "notesPlaceholder": "Notas pessoais, dicas de arrumação..."
+    },
+    "section": {
+      "essentials": "Essencial",
+      "details": "Detalhes",
+      "purchase": "Dados de compra",
+      "reference": "Referência",
+      "organization": "Organização"
+    },
+    "tagPicker": {
+      "search": "Pesquisar etiquetas...",
+      "noResults": "Nenhuma etiqueta encontrada.",
+      "create": "Criar \"{name}\"",
+      "selectedTags": "Etiquetas selecionadas",
+      "remove": "Remover {name}",
+      "addedTag": "Etiqueta {name} adicionada",
+      "removedTag": "Etiqueta {name} removida",
+      "createdTag": "Etiqueta {name} criada e adicionada",
+      "createFailed": "Falha ao criar etiqueta"
+    },
+    "trickPicker": {
+      "search": "Pesquisar truques...",
+      "noResults": "Nenhum truque encontrado.",
+      "selectedTricks": "Truques associados",
+      "remove": "Desassociar {name}",
+      "addedTrick": "{name} associado",
+      "removedTrick": "{name} desassociado"
+    },
+    "validation": {
+      "nameRequired": "O nome é obrigatório",
+      "nameTooLong": "O nome deve ter 200 caracteres ou menos",
+      "descriptionTooLong": "A descrição deve ter 2000 caracteres ou menos",
+      "invalidUrl": "Introduza um URL HTTPS válido",
+      "urlTooLong": "O URL deve ter 2000 caracteres ou menos",
+      "invalidPrice": "Introduza um preço válido (ex.: 29,99)",
+      "invalidDate": "Introduza uma data válida",
+      "quantityMin": "A quantidade deve ser pelo menos 0",
+      "quantityMax": "A quantidade deve ser 9999 ou menos",
+      "tooManyTags": "Não é possível adicionar mais de 20 etiquetas a um objeto.",
+      "tooManyTricks": "Não é possível associar mais de {count} truques a um objeto."
+    },
+    "errors": {
+      "itemMissing": "Este objeto já foi eliminado ou não foi encontrado."
+    },
+    "addItemDescription": "Adicionar um novo objeto à sua coleção.",
+    "editItemDescription": "Editar os detalhes deste objeto.",
+    "cardActions": "Ações",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "deleteConfirm": "Eliminar",
+    "combobox": {
+      "select": "Selecionar...",
+      "clearSelection": "Limpar seleção",
+      "noResults": "Nenhum resultado encontrado.",
+      "useCustom": "Usar \"{value}\""
+    }
   },
   "admin": {
     "title": "Administração",

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,5 @@
 import { track } from "@vercel/analytics";
+import type { ItemType } from "@/features/collect/constants";
 import type { Locale } from "@/i18n/config";
 
 /**
@@ -6,6 +7,9 @@ import type { Locale } from "@/i18n/config";
  * Centralised here so every call site is type-checked.
  */
 interface AnalyticsEventMap {
+  item_created: { type: ItemType };
+  item_deleted: Record<string, never>;
+  item_updated: Record<string, never>;
   locale_changed: { locale: Locale };
   push_notifications_disabled: Record<string, never>;
   push_notifications_enabled: Record<string, never>;

--- a/src/lib/modules.ts
+++ b/src/lib/modules.ts
@@ -38,7 +38,7 @@ const APP_MODULES = [
   {
     slug: "collect",
     icon: Package,
-    enabled: false,
+    enabled: true,
     group: "library",
   },
   {

--- a/src/sync/queries.ts
+++ b/src/sync/queries.ts
@@ -10,6 +10,7 @@
 // synced table having a deleted_at column for soft-delete.
 const SYNCED_TABLE_NAMES = [
   "goals",
+  "item_tags",
   "item_tricks",
   "items",
   "performances",
@@ -42,6 +43,15 @@ const SYNCED_COLUMNS = {
     "updated_at",
     "deleted_at",
   ]),
+  item_tags: new Set([
+    "id",
+    "user_id",
+    "item_id",
+    "tag_id",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+  ]),
   item_tricks: new Set([
     "id",
     "user_id",
@@ -63,6 +73,9 @@ const SYNCED_COLUMNS = {
     "notes",
     "purchase_date",
     "purchase_price",
+    "quantity",
+    "creator",
+    "url",
     "created_at",
     "updated_at",
     "deleted_at",

--- a/src/sync/schema.ts
+++ b/src/sync/schema.ts
@@ -128,6 +128,18 @@ const items = new Table({
   // Stored as text to preserve exact decimal precision (server uses numeric(10,2)).
   // Client code must parse this value as a number when displaying.
   purchase_price: column.text,
+  quantity: column.integer,
+  creator: column.text,
+  url: column.text,
+  created_at: column.text,
+  updated_at: column.text,
+  deleted_at: column.text,
+});
+
+const item_tags = new Table({
+  user_id: column.text,
+  item_id: column.text,
+  tag_id: column.text,
   created_at: column.text,
   updated_at: column.text,
   deleted_at: column.text,
@@ -171,6 +183,7 @@ export const appSchema = new Schema({
   practice_session_tricks,
   performances,
   items,
+  item_tags,
   item_tricks,
   goals,
 });

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,6 +1,7 @@
 import type {
   Goal,
   Item,
+  ItemTag,
   NewGoal,
   NewItem,
   NewPerformance,
@@ -166,6 +167,22 @@ function createTestItem(overrides?: Partial<NewItem>): Item {
     notes: null,
     purchaseDate: null,
     purchasePrice: null,
+    quantity: 1,
+    creator: null,
+    url: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function createTestItemTag(overrides?: Partial<ItemTag>): ItemTag {
+  return {
+    id: nextId(),
+    userId: nextId(),
+    itemId: nextId(),
+    tagId: nextId(),
     createdAt: new Date(),
     updatedAt: new Date(),
     deletedAt: null,
@@ -195,6 +212,7 @@ function createTestGoal(overrides?: Partial<NewGoal>): Goal {
 export {
   createTestGoal,
   createTestItem,
+  createTestItemTag,
   createTestPerformance,
   createTestPracticeSession,
   createTestSetlist,


### PR DESCRIPTION
## Summary

Adds the **Collect** module — a personal inventory for magic-related items (props, books, gimmicks, decks, etc.) with tag organization and bidirectional linking to tricks. Enables the second module in the Library group alongside Repertoire.

### Database (migration `0017`)
- New `item_tags` junction table (mirrors `trick_tags`) with FKs, partial indexes, RLS policy, and `updated_at` trigger.
- New columns on `items`: `quantity` (int NOT NULL DEFAULT 1), `creator` (text), `url` (text).
- New CHECK constraints: `quantity_non_negative`, `type_valid` (10 enum values: `prop, book, gimmick, dvd, download, deck, clothing, consumable, accessory, other`), `url_https_only`, `condition_check` (`new, good, worn, needs_repair`).
- Type enum expanded with `deck`, `clothing`, `consumable`, `accessory`.

### Sync layer
- PowerSync client schema (`src/sync/schema.ts`) gains `quantity`/`creator`/`url` on items and the `item_tags` table.
- Server-side allowlists in `src/sync/queries.ts` updated for new columns and `item_tags`.
- Cron cleanup job extended to handle `item_tags` soft-deletes and 30-day hard-deletes.

### UI
- `/collect` route with full CRUD: form sheet, item list with filters, empty/loading/error states, type and condition badges.
- Item form covers essentials (name, type), details (brand, creator, condition, location, quantity), purchase tracking (date, price), reference (URL with HTTPS validation, anti-phishing checks), and notes.
- Trick picker for cross-linking items to tricks via the new `item_tricks` junction (existing table).
- Tag picker reused from repertoire — refactored to accept a `translationNamespace` prop so each module can use its own i18n keys.

### Module registry
- `collect` flipped to `enabled: true` in `src/lib/modules.ts`.
- Collection card added to dashboard.

### i18n
- New `collect.*` namespace across all 7 locales (en, fr, es, pt, it, de, nl).

### Analytics
- New typed events: `item_created` (with type), `item_updated`, `item_deleted`.

### Docs
- `docs/architecture.md`, `docs/data-model.md`, schema/route/module diagrams regenerated.
- `public/llms-full.txt` regenerated.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes (new tests cover schema validation, parse-item, brands/locations hooks, mutations, form, list, filters, trick-picker, item-card, helpers, view)
- [ ] `pnpm i18n:check` passes
- [ ] Apply migration to dev: `pnpm db:migrate`
- [ ] Manually create an item at `/collect`, verify it persists across reload
- [ ] Add tags to an item, verify they sync via PowerSync
- [ ] Link a trick to an item, verify the cross-reference appears on both sides
- [ ] Edit, delete, filter, search items
- [ ] Confirm dashboard shows collection card
- [ ] Confirm no `Batch upload failed: 500` errors in browser console or server console

## Follow-ups (separate PRs)

- #220 — schema drift on `item_tricks` and `practice_session_tricks` (missing `user_id`) needs a remediation migration before trick-linking will work in production.
- PowerSync Cloud sync rules need `item_tags` added to sync down to clients (configured outside the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)