### PR TITLE
fix(biome): include all files in lint scope

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,7 @@
   "files": {
     "ignoreUnknown": true,
     "includes": [
+      "**",
       "!node_modules",
       "!.next",
       "!dist",

--- a/e2e/pwa-offline.spec.ts
+++ b/e2e/pwa-offline.spec.ts
@@ -16,36 +16,37 @@ import { expect, type Page, test } from "@playwright/test";
  * Polls `getRegistration()` until an active SW appears (up to 15s).
  */
 async function waitForAutoRegistration(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    return new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("SW did not auto-register within 15s")),
-        15_000
-      );
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error("SW did not auto-register within 15s")),
+          15_000
+        );
 
-      async function check(): Promise<void> {
-        const reg = await navigator.serviceWorker.getRegistration("/");
-        const sw = reg?.active ?? reg?.waiting ?? reg?.installing;
-        if (sw?.state === "activated") {
-          clearTimeout(timeout);
-          resolve();
-          return;
+        async function check(): Promise<void> {
+          const reg = await navigator.serviceWorker.getRegistration("/");
+          const sw = reg?.active ?? reg?.waiting ?? reg?.installing;
+          if (sw?.state === "activated") {
+            clearTimeout(timeout);
+            resolve();
+            return;
+          }
+          if (sw) {
+            sw.addEventListener("statechange", () => {
+              if (sw.state === "activated") {
+                clearTimeout(timeout);
+                resolve();
+              }
+            });
+          } else {
+            setTimeout(check, 500);
+          }
         }
-        if (sw) {
-          sw.addEventListener("statechange", () => {
-            if (sw.state === "activated") {
-              clearTimeout(timeout);
-              resolve();
-            }
-          });
-        } else {
-          setTimeout(check, 500);
-        }
-      }
 
-      check();
-    });
-  });
+        check();
+      })
+  );
 }
 
 /**

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -33,13 +33,11 @@ const FormField = <
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
   ...props
-}: ControllerProps<TFieldValues, TName>) => {
-  return (
-    <FormFieldContext.Provider value={{ name: props.name }}>
-      <Controller {...props} />
-    </FormFieldContext.Provider>
-  );
-};
+}: ControllerProps<TFieldValues, TName>) => (
+  <FormFieldContext.Provider value={{ name: props.name }}>
+    <Controller {...props} />
+  </FormFieldContext.Provider>
+);
 
 const useFormField = () => {
   const fieldContext = useContext(FormFieldContext);

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -98,9 +98,11 @@ function SidebarProvider({
 
   // Helper to toggle the sidebar.
   // biome-ignore lint/correctness/useExhaustiveDependencies: shadcn vendor code
-  const toggleSidebar = useCallback(() => {
-    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
-  }, [isMobile, setOpen, setOpenMobile]);
+  const toggleSidebar = useCallback(
+    () =>
+      isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open),
+    [isMobile, setOpen, setOpenMobile]
+  );
 
   // Adds a keyboard shortcut to toggle the sidebar.
   useEffect(() => {
@@ -608,9 +610,7 @@ function SidebarMenuSkeleton({
   showIcon?: boolean;
 }) {
   // Random width between 50 to 90%.
-  const width = useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+  const width = useMemo(() => `${Math.floor(Math.random() * 40) + 50}%`, []);
 
   return (
     <div

--- a/src/i18n/negotiate.ts
+++ b/src/i18n/negotiate.ts
@@ -40,5 +40,5 @@ export function negotiateLocale(acceptLanguage: string): Locale | undefined {
     }
   }
 
-  return undefined;
+  return;
 }

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -37,6 +37,7 @@ type AssertAllDirectives =
   Exclude<CspDirectiveName, (typeof ALL_DIRECTIVE_NAMES)[number]> extends never
     ? true
     : never;
+// biome-ignore lint/suspicious/noUnusedExpressions: compile-time type assertion
 true satisfies AssertAllDirectives;
 
 function cspDirectiveNames(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -89,7 +89,7 @@ function redirectToLocalePath(
 ): NextResponse | undefined {
   const { pathname } = request.nextUrl;
   if (!MARKETING_PATHS.has(pathname)) {
-    return undefined;
+    return;
   }
 
   const locale = detectLocale(request);


### PR DESCRIPTION
## Summary

`pnpm lint` was silently checking only `biome.json` itself — every `.ts`/`.tsx`/`.json`/`.css` source file was skipped, so lint failures weren't caught locally or in CI.

**Root cause:** Biome v2's `files.includes` requires at least one positive glob pattern. With only negation patterns (`!node_modules`, `!.next`, etc.), nothing was matched.

**Fix:** Added `"**"` as the first entry of `files.includes`. Lint now scans 341 files (was: 1).

Also applies the 7 violations that surfaced:
- format-only auto-fixes in `form.tsx`, `sidebar.tsx`, `pwa-offline.spec.ts`
- redundant `return undefined` simplified in `negotiate.ts` and `proxy.ts`
- `biome-ignore` on the compile-time `satisfies` assertion in `csp.ts`

## Test plan

- [x] `pnpm lint` — passes, 341 files checked (was: 1)
- [x] `pnpm typecheck` — passes
- [x] Pre-commit hook still works (lefthook ran `ultracite fix` on commit)
- [ ] CI lint job catches a deliberate violation in a follow-up to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)