### PR TITLE
chore(claude): scope PostToolUse ultracite hook to the edited file

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm dlx ultracite fix"
+            "command": "file=$(jq -r '.tool_input.file_path // empty' 2>/dev/null); [ -n \"$file\" ] && [ -f \"$file\" ] && pnpm exec ultracite fix -- \"$file\" >/dev/null 2>&1 || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Scopes the `PostToolUse` ultracite hook in `.claude/settings.json` to only the file that was just edited:

- Reads `tool_input.file_path` from the hook payload via `jq`.
- Falls back cleanly (no-op) if the payload has no file path.
- Switches from `pnpm dlx ultracite` (fetches over the network on every edit) to `pnpm exec ultracite` (uses the local devDependency).
- Silences stdout/stderr — the hook is a fire-and-forget formatter.

## Test plan

- [x] Edit any file via Claude Code and observe the hook runs sub-second against only that file.
- [x] Edit a non-existent path — hook exits cleanly without error (the `[ -f "$file" ]` guard handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)