### PR TITLE
ci: validate PowerSync sync config on pull requests

### DIFF
--- a/.github/workflows/validate-sync.yml
+++ b/.github/workflows/validate-sync.yml
@@ -1,0 +1,61 @@
+name: Validate PowerSync sync config
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "powersync/sync-config.yaml"
+      - "src/db/schema/**"
+      - "src/sync/schema.ts"
+      - "src/sync/synced-columns.ts"
+      - "scripts/generate-sync.ts"
+      - "scripts/powersync.ts"
+      - ".github/workflows/validate-sync.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate sync-config.yaml
+    # Skip fork PRs (no access to POWERSYNC_ADMIN_TOKEN — would fail opaquely)
+    # and Dependabot PRs (same secrets restriction). The post-merge deploy
+    # workflow still catches any real issue.
+    #
+    # Note: if this job is ever marked required in branch protection, these
+    # skip conditions produce "skipped" status, which GitHub treats as neither
+    # pass nor fail — blocking auto-merge for Dependabot and fork PRs.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check sync artifacts are up to date
+        run: pnpm sync:check
+
+      - name: Validate sync config
+        run: pnpm sync:validate
+        env:
+          POWERSYNC_ADMIN_TOKEN: ${{ secrets.POWERSYNC_ADMIN_TOKEN }}
+          POWERSYNC_INSTANCE_ID: ${{ vars.POWERSYNC_INSTANCE_ID }}
+          POWERSYNC_PROJECT_ID: ${{ vars.POWERSYNC_PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ next-env.d.ts
 # claude code generated artifacts
 .claude/audit-*
 .claude/review-*.json
+.claude/*.lock
 .claude/settings.local.json
 /CLAUDE.local.md
 .claude/worktrees

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "i18n:check": "tsx scripts/check-i18n.ts",
     "sync:generate": "tsx scripts/generate-sync.ts",
     "sync:check": "tsx scripts/check-sync.ts",
-    "sync:validate": "tsx scripts/powersync.ts validate",
+    "sync:validate": "tsx scripts/powersync.ts validate --validate-only=sync-config",
     "sync:deploy": "tsx scripts/powersync.ts deploy sync-config",
     "email:dev": "email dev --dir src/emails --port 3030",
     "screenshots": "tsx scripts/generate-screenshots.ts"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/validate-sync.yml` running `pnpm sync:check` and `pnpm sync:validate` on PRs that touch sync artifacts, Drizzle schema, or the sync generator
- Narrows `pnpm sync:validate` to `--validate-only=sync-config` so the new workflow only validates the sync config (not unrelated schema checks)
- Skips fork and Dependabot PRs since they can't access `POWERSYNC_ADMIN_TOKEN`; the post-merge deploy workflow still catches any real issue
- Ignores `.claude/*.lock` artifacts locally

## Test plan
- [ ] Workflow runs and passes on this PR (it touches `.github/workflows/validate-sync.yml`, which is in the path filter)
- [ ] `pnpm sync:validate` still succeeds locally