### PR TITLE
ci: skip docs staleness check on main branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           DATABASE_URL: postgresql://unused:unused@localhost:5432/unused
 
       - name: Check generated docs staleness
-        if: github.event_name == 'push' || github.event.pull_request.user.login != 'dependabot[bot]'
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           pnpm docs:generate
           git diff --exit-code public/llms.txt public/llms-full.txt docs/diagrams/


### PR DESCRIPTION
## Summary
- Restrict `Check generated docs staleness` (`.github/workflows/ci.yml:77-81`) to `pull_request` events so it no longer runs on `push: main`.
- Keeps the existing Dependabot exclusion via `github.event.pull_request.user.login`, matching the pattern used by the sibling `Check migration drift` step.

## Why
Main is protected and CI is a required status check, so any commit reaching main has already passed this gate on its PR. The post-merge re-run only produces noise when main has drifted — e.g. https://github.com/julienroussel/tml/actions/runs/24388475024/job/71228032097. Migration drift stays guarded on both events (higher blast radius).

## Relationship to PR #211

PR #211 (commit 410d424, *\"fix(ci): skip Dependabot drift checks via PR author, not triggerer\"*) rewrote both drift guards:

```diff
- if: github.actor != 'dependabot[bot]'
+ if: github.event_name == 'push' || github.event.pull_request.user.login != 'dependabot[bot]'
```

Two intents were bundled there:
1. **Stability fix** — replace `github.actor` (who triggered the run, flips on re-run) with `github.event.pull_request.user.login` (PR author, fixed by GitHub).
2. **Push arm** — keep the step running on `push: main`.

This PR narrows only intent (2), and only for the docs step:
- Intent (1) is preserved — still `github.event.pull_request.user.login`, not `github.actor`. The re-run stability fix stays in place.
- `Check migration drift` is untouched — #211's full guard remains for the higher-blast-radius step.

So this is a scoped follow-up to #211, not a revert.

## Test plan
- [ ] This PR's CI run executes the `Check generated docs staleness` step and passes (green) — confirms PR-path drift protection still works.
- [ ] All other CI steps pass.
- [ ] After merge, the next `push: main` CI run shows `Check generated docs staleness` as **skipped** (grey, unmet `if:` condition).
- [ ] `Check migration drift` remains unchanged (runs on both events).

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)