### PR TITLE
ci: allow manual re-runs of the PowerSync sync deploy

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -9,7 +9,9 @@ on:
       - "src/sync/schema.ts"
       - "src/sync/synced-columns.ts"
       - "scripts/generate-sync.ts"
+      - "scripts/powersync.ts"
       - ".github/workflows/deploy-sync.yml"
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -22,6 +24,7 @@ jobs:
   deploy:
     name: Deploy sync-config.yaml
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     timeout-minutes: 5
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch: {}` so the deploy can be re-run on demand from the GitHub UI / `gh workflow run`, no no-op commit required.
- Add `scripts/powersync.ts` to the `paths:` filter so future fixes to the deploy mechanism itself auto-trigger.
- Gate the `deploy` job with `if: github.ref == 'refs/heads/main'` so manual triggers from feature branches are skipped (no accidental cross-branch deploys to PowerSync Cloud).

## Why

Production PowerSync Cloud still shows the old edition-2 `bucket_definitions` config despite #224 introducing the edition-3 `streams:` format and the deploy workflow.

Root cause: the deploy ran exactly once on the #224 merge (`59920f8`), failed at `pnpm sync:validate` because the PowerSync CLI couldn't find a `service.yaml` (only relevant to self-hosted). #226 fixed validate by adding `--validate-only=sync-config` in `package.json`, but `package.json` is not in the workflow's `paths:` filter — so #226 never re-triggered the deploy and no subsequent commit has touched a path-filtered file.

Merging this PR self-triggers the deploy (the workflow file itself is in `paths:`), and at HEAD the `--validate-only=sync-config` flag is in place, so validate passes and the deploy step pushes the new sync rules to PowerSync Cloud.

## Test plan

- [ ] After merge, confirm the `Deploy PowerSync sync config` workflow run kicked off by this commit succeeds.
- [ ] Verify the PowerSync Cloud Sync Rules view shows `streams:` with the `user_data` stream (replacing the old `bucket_definitions`).
- [ ] Sanity-check on a client: open the app online, confirm data syncs; go offline and confirm reads still work (offline-first invariant).
- [ ] Follow-up: `gh workflow run deploy-sync.yml` should kick off an idempotent no-op deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)