### PR TITLE
fix: backfill user_id on item_tricks/practice_session_tricks junctions (#220)

### DIFF
--- a/docs/diagrams/route-map.md
+++ b/docs/diagrams/route-map.md
@@ -1,6 +1,6 @@
 # Route Map
 
-<!-- Last verified: 2026-04-29 -->
+<!-- Last verified: 2026-04-30 -->
 
 ## Route Structure
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1034,7 +1034,7 @@ Source: docs/diagrams/route-map.md
 
 # Route Map
 
-<!-- Last verified: 2026-04-29 -->
+<!-- Last verified: 2026-04-30 -->
 
 ## Route Structure
 

--- a/src/app/api/powersync/batch/route.test.ts
+++ b/src/app/api/powersync/batch/route.test.ts
@@ -819,5 +819,223 @@ describe("POST /api/powersync/batch", () => {
 
       expect(response.status).toBe(500);
     });
+
+    describe("SQLSTATE exposure (per-op failure path)", () => {
+      it("includes the Postgres SQLSTATE in the 500 response body for transient DB errors", async () => {
+        // Regression guard for issue #220: 42703 undefined_column was returned as
+        // a generic 500 with no code, hiding schema drift behind PowerSync's retry
+        // loop. The SQLSTATE must round-trip to the client log.
+        authenticatedSession();
+        vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+        // Pin VERCEL_ENV explicitly so the assertion below isn't satisfied
+        // vacuously by a CI runner that happens to set VERCEL_ENV=production.
+        vi.stubEnv("VERCEL_ENV", "development");
+        const undefinedColumnError = new Error(
+          'column "user_id" of relation "item_tricks" does not exist'
+        ) as Error & { code: string };
+        undefinedColumnError.code = "42703";
+        mockClientQuery
+          .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+          .mockResolvedValueOnce({ rowCount: 0 }) // SAVEPOINT sp_0
+          .mockRejectedValueOnce(undefinedColumnError)
+          .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+        const { POST } = await import("./route");
+
+        const response = await POST(
+          createRequest({
+            operations: [
+              putOp("item_tricks", "it-1", {
+                item_id: "i-1",
+                trick_id: "t-1",
+              }),
+            ],
+          })
+        );
+
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).toMatchObject({
+          error: "Batch execution failed",
+          failedIndex: 0,
+          code: "42703",
+        });
+      });
+
+      it("includes the SQLSTATE when VERCEL_ENV is unset (local pnpm dev without Vercel CLI)", async () => {
+        // The env gate is a negative check (!== "production" && !== "preview"),
+        // so an unset VERCEL_ENV — the most common path for `pnpm dev` —
+        // currently exposes `code`. Pin this behavior so a future refactor to a
+        // positive check (=== "development") doesn't silently break the local
+        // debugging UX that issue #220's diagnostic logging was designed to fix.
+        authenticatedSession();
+        vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+        vi.stubEnv("VERCEL_ENV", "");
+        const undefinedColumnError = new Error(
+          'column "user_id" of relation "item_tricks" does not exist'
+        ) as Error & { code: string };
+        undefinedColumnError.code = "42703";
+        mockClientQuery
+          .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+          .mockResolvedValueOnce({ rowCount: 0 }) // SAVEPOINT sp_0
+          .mockRejectedValueOnce(undefinedColumnError)
+          .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+        const { POST } = await import("./route");
+
+        const response = await POST(
+          createRequest({
+            operations: [
+              putOp("item_tricks", "it-1", {
+                item_id: "i-1",
+                trick_id: "t-1",
+              }),
+            ],
+          })
+        );
+
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).toMatchObject({
+          error: "Batch execution failed",
+          failedIndex: 0,
+          code: "42703",
+        });
+      });
+
+      it.each([
+        ["production"],
+        ["preview"],
+      ])("omits the SQLSTATE from the response body when VERCEL_ENV=%s (server log retains it)", async (env) => {
+        // Both production AND preview must omit `code` to limit information
+        // disclosure to authenticated users — preview URLs are routinely
+        // shared (PR comments, link previews) and any authenticated user
+        // reaching them could enumerate schema state via SQLSTATE classes.
+        // The SQLSTATE remains in the server log for operators with Vercel
+        // log access. Non-production environments still expose `code` for
+        // fast browser-side debugging during the issue #220 soak.
+        authenticatedSession();
+        vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+        vi.stubEnv("VERCEL_ENV", env);
+        const undefinedColumnError = new Error(
+          'column "user_id" of relation "item_tricks" does not exist'
+        ) as Error & { code: string };
+        undefinedColumnError.code = "42703";
+        mockClientQuery
+          .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+          .mockResolvedValueOnce({ rowCount: 0 }) // SAVEPOINT sp_0
+          .mockRejectedValueOnce(undefinedColumnError)
+          .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+        const { POST } = await import("./route");
+
+        const response = await POST(
+          createRequest({
+            operations: [
+              putOp("item_tricks", "it-1", {
+                item_id: "i-1",
+                trick_id: "t-1",
+              }),
+            ],
+          })
+        );
+
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).not.toHaveProperty("code");
+        expect(body).toMatchObject({
+          error: "Batch execution failed",
+          failedIndex: 0,
+        });
+      });
+
+      it("omits the code field when the transient error has no SQLSTATE", async () => {
+        authenticatedSession();
+        vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+        // Pin VERCEL_ENV to a non-production value so this assertion isolates
+        // the "no SQLSTATE on the error" code path. Without the stub, a CI
+        // runner setting VERCEL_ENV=production would satisfy the assertion
+        // vacuously via the env gate instead of the no-code branch.
+        vi.stubEnv("VERCEL_ENV", "development");
+        mockClientQuery
+          .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+          .mockResolvedValueOnce({ rowCount: 0 }) // SAVEPOINT sp_0
+          .mockRejectedValueOnce(new Error("connection timeout"))
+          .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+        const { POST } = await import("./route");
+
+        const response = await POST(
+          createRequest({
+            operations: [putOp("tricks", "t-1", { name: "A" })],
+          })
+        );
+
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).not.toHaveProperty("code");
+      });
+    });
+
+    describe("SQLSTATE exposure (outer catch path)", () => {
+      it("includes the SQLSTATE in the 500 body in non-production", async () => {
+        // Coverage for the outer-catch path (route.ts ~452): when BEGIN itself
+        // throws a DB error, executeBatch re-throws into the POST handler's
+        // outer catch. Verify the env gate behaves the same way as the inner
+        // per-op-failure branch.
+        authenticatedSession();
+        vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+        vi.stubEnv("VERCEL_ENV", "development");
+        const beginError = new Error(
+          "connection terminated unexpectedly"
+        ) as Error & { code: string };
+        // 08006 (connection_failure) is the SQLSTATE Postgres realistically
+        // raises on a failed BEGIN — 25P02 (in_failed_sql_transaction) cannot
+        // be raised by BEGIN itself, only by subsequent statements on an
+        // already-failed connection.
+        beginError.code = "08006";
+        mockClientQuery
+          .mockRejectedValueOnce(beginError) // BEGIN
+          .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK in catch
+        const { POST } = await import("./route");
+
+        const response = await POST(
+          createRequest({
+            operations: [putOp("tricks", "t-1", { name: "A" })],
+          })
+        );
+
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).toMatchObject({
+          error: "Internal server error",
+          code: "08006",
+        });
+      });
+
+      it.each([
+        ["production"],
+        ["preview"],
+      ])("omits the SQLSTATE from the 500 body when VERCEL_ENV=%s", async (env) => {
+        authenticatedSession();
+        vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+        vi.stubEnv("VERCEL_ENV", env);
+        const beginError = new Error(
+          "connection terminated unexpectedly"
+        ) as Error & { code: string };
+        beginError.code = "08006";
+        mockClientQuery
+          .mockRejectedValueOnce(beginError) // BEGIN
+          .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK in catch
+        const { POST } = await import("./route");
+
+        const response = await POST(
+          createRequest({
+            operations: [putOp("tricks", "t-1", { name: "A" })],
+          })
+        );
+
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).not.toHaveProperty("code");
+        expect(body).toMatchObject({ error: "Internal server error" });
+      });
+    });
   });
 });

--- a/src/app/api/powersync/batch/route.ts
+++ b/src/app/api/powersync/batch/route.ts
@@ -78,12 +78,29 @@ function isPermanentDbError(
   return isDatabaseError(error) && PERMANENT_PG_ERROR_CODES.has(error.code);
 }
 
+// Production AND preview omit the SQLSTATE because preview URLs are routinely
+// shared (PR comments, link previews) and any authenticated user reaching them
+// could enumerate schema state via SQLSTATE classes (42703 = undefined column,
+// 42P01 = undefined table). The SQLSTATE stays in the server log for operators.
+// Negative check (rather than === "development") intentionally exposes `code`
+// when VERCEL_ENV is unset, which is the normal `pnpm dev` path.
+function shouldExposeSqlstate(): boolean {
+  return (
+    process.env.VERCEL_ENV !== "production" &&
+    process.env.VERCEL_ENV !== "preview"
+  );
+}
+
 type BatchResult =
   | { ok: true; results: OperationResult[] }
   | {
       ok: false;
       failedIndex: number;
       message: string;
+      // SQLSTATE for transient DB errors — surfaced in the response body and
+      // client-side logs so the next "PowerSync retries forever" symptom names
+      // its underlying Postgres error class instead of staying generic.
+      code?: string;
       results: OperationResult[];
     };
 
@@ -234,8 +251,9 @@ async function executeOperation(
     return { continue: true, result: { index, status: 200 } };
   } catch (error: unknown) {
     if (!isPermanentDbError(error)) {
+      const code = isDatabaseError(error) ? error.code : undefined;
       console.error(
-        `Transient DB error on operation ${index} (table: ${operation.table}, op: ${operation.op}):`,
+        `Transient DB error on operation ${index} (table: ${operation.table}, op: ${operation.op}, code: ${code ?? "none"}):`,
         error instanceof Error ? error.message : String(error)
       );
       await client.query("ROLLBACK");
@@ -245,6 +263,7 @@ async function executeOperation(
           ok: false,
           failedIndex: index,
           message: "Internal error",
+          ...(code !== undefined && { code }),
           results: results.map((r) => ({ ...r, rolledBack: true })),
         },
       };
@@ -422,10 +441,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         `Batch execution failed at index ${result.failedIndex}:`,
         result.message
       );
+      const exposeCode = result.code !== undefined && shouldExposeSqlstate();
       return NextResponse.json(
         {
           error: "Batch execution failed",
           failedIndex: result.failedIndex,
+          ...(exposeCode && { code: result.code }),
           results: result.results,
         },
         { status: 500 }
@@ -434,8 +455,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ results: result.results });
   } catch (error: unknown) {
     console.error("Unhandled batch execution error:", error);
+    const code = isDatabaseError(error) ? error.code : undefined;
+    const exposeCode = code !== undefined && shouldExposeSqlstate();
     return NextResponse.json(
-      { error: "Internal server error" },
+      { error: "Internal server error", ...(exposeCode && { code }) },
       { status: 500 }
     );
   }

--- a/src/db/migrations/0019_backfill_user_id_junctions.sql
+++ b/src/db/migrations/0019_backfill_user_id_junctions.sql
@@ -1,0 +1,71 @@
+-- 0019: forward-only idempotent fix for missing user_id on item_tricks & practice_session_tricks.
+-- Migration 0006 was recorded as applied but two of its three table-level chunks failed silently
+-- under @neondatabase/serverless's no-cross-statement-transaction semantics. This brings the
+-- schema in line with the Drizzle source of truth on every branch where it has drifted.
+-- See issue #220.
+
+-- 1. Add column if missing (no-op on branches where 0006 succeeded fully).
+ALTER TABLE "item_tricks"             ADD COLUMN IF NOT EXISTS "user_id" uuid;--> statement-breakpoint
+ALTER TABLE "practice_session_tricks" ADD COLUMN IF NOT EXISTS "user_id" uuid;--> statement-breakpoint
+
+-- 2. Backfill from parent (no-op on currently-empty tables; preserved for the canonical pattern
+--    and for any branch where rows were inserted with NULL user_id between failed states).
+--    Only copy when BOTH parents agree on owner — junction rows with cross-user FK references
+--    fall through to the orphan-DELETE in step 3, preventing a tenant boundary cross via the
+--    new RLS USING clause (which only checks user_id on the junction, not parent EXISTS).
+UPDATE "item_tricks" jt
+   SET "user_id" = i."user_id"
+  FROM "items" i, "tricks" t
+ WHERE i."id" = jt."item_id"
+   AND t."id" = jt."trick_id"
+   AND i."user_id" = t."user_id"
+   AND jt."user_id" IS NULL;--> statement-breakpoint
+UPDATE "practice_session_tricks" jt
+   SET "user_id" = ps."user_id"
+  FROM "practice_sessions" ps, "tricks" t
+ WHERE ps."id" = jt."practice_session_id"
+   AND t."id" = jt."trick_id"
+   AND ps."user_id" = t."user_id"
+   AND jt."user_id" IS NULL;--> statement-breakpoint
+
+-- 3. Drop orphans (rows whose parent disappeared) — should be 0 in practice.
+DELETE FROM "item_tricks"             WHERE "user_id" IS NULL;--> statement-breakpoint
+DELETE FROM "practice_session_tricks" WHERE "user_id" IS NULL;--> statement-breakpoint
+
+-- 4. NOT NULL — Postgres treats SET NOT NULL on an already-NOT-NULL column as a no-op.
+ALTER TABLE "item_tricks"             ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "practice_session_tricks" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+
+-- 5. FK + partial index (idempotent guards match the 0014 pattern).
+DO $$ BEGIN ALTER TABLE "item_tricks" ADD CONSTRAINT "item_tricks_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "practice_session_tricks" ADD CONSTRAINT "practice_session_tricks_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "item_tricks_user_id_idx"             ON "item_tricks"             USING btree ("user_id") WHERE deleted_at IS NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "practice_session_tricks_user_id_idx" ON "practice_session_tricks" USING btree ("user_id") WHERE deleted_at IS NULL;--> statement-breakpoint
+
+-- 6. Replace RLS policies with the simplified user_id form (matches 0006's intent for routine_tricks
+--    and 0014's setlist_tricks). USING does direct user_id match for read-path speed.
+--    WITH CHECK keeps the EXISTS subqueries on parent tables for defense-in-depth on writes.
+--    Each DROP+CREATE pair runs inside one DO $$ block so both DDLs land in the same HTTP statement
+--    (and one implicit transaction) — avoids the brief deny-all window on `authenticated` between
+--    the DROP and CREATE that the @neondatabase/serverless per-statement HTTP semantics would
+--    otherwise expose.
+DO $$ BEGIN
+  DROP POLICY IF EXISTS "item_tricks_rls_policy" ON "item_tricks";
+  CREATE POLICY "item_tricks_rls_policy" ON "item_tricks" FOR ALL TO authenticated
+    USING (user_id = auth.user_id()::uuid)
+    WITH CHECK (
+      user_id = auth.user_id()::uuid
+      AND EXISTS (SELECT 1 FROM "items"  WHERE "items".id  = "item_tricks".item_id  AND "items".user_id  = auth.user_id()::uuid)
+      AND EXISTS (SELECT 1 FROM "tricks" WHERE "tricks".id = "item_tricks".trick_id AND "tricks".user_id = auth.user_id()::uuid)
+    );
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  DROP POLICY IF EXISTS "practice_session_tricks_rls_policy" ON "practice_session_tricks";
+  CREATE POLICY "practice_session_tricks_rls_policy" ON "practice_session_tricks" FOR ALL TO authenticated
+    USING (user_id = auth.user_id()::uuid)
+    WITH CHECK (
+      user_id = auth.user_id()::uuid
+      AND EXISTS (SELECT 1 FROM "practice_sessions" WHERE "practice_sessions".id = "practice_session_tricks".practice_session_id AND "practice_sessions".user_id = auth.user_id()::uuid)
+      AND EXISTS (SELECT 1 FROM "tricks"            WHERE "tricks".id            = "practice_session_tricks".trick_id            AND "tricks".user_id            = auth.user_id()::uuid)
+    );
+END $$;

--- a/src/db/migrations/meta/0019_snapshot.json
+++ b/src/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,2334 @@
+{
+  "id": "80e70e9f-30c0-4711-a3ff-a596e43caa66",
+  "prevId": "cea481a7-48b8-426a-94d3-6a8ef776cc67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.event_log": {
+      "name": "event_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_log_user_id_created_at_idx": {
+          "name": "event_log_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "event_log_event_type_idx": {
+          "name": "event_log_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "event_log_user_id_users_id_fk": {
+          "name": "event_log_user_id_users_id_fk",
+          "tableFrom": "event_log",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "event_log_source_check": {
+          "name": "event_log_source_check",
+          "value": "\"event_log\".\"source\" IN ('client', 'server')"
+        },
+        "event_log_entity_pair_check": {
+          "name": "event_log_entity_pair_check",
+          "value": "(\"event_log\".\"entity_type\" IS NULL AND \"event_log\".\"entity_id\" IS NULL) OR (\"event_log\".\"entity_type\" IS NOT NULL AND \"event_log\".\"entity_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_value": {
+          "name": "target_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "goals_user_id_idx": {
+          "name": "goals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "goals_trick_id_idx": {
+          "name": "goals_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "goals_trick_id_tricks_id_fk": {
+          "name": "goals_trick_id_tricks_id_fk",
+          "tableFrom": "goals",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "tableTo": "tricks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_tags": {
+      "name": "item_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "item_tags_user_id_idx": {
+          "name": "item_tags_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "item_tags_item_id_idx": {
+          "name": "item_tags_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "item_tags_tag_id_idx": {
+          "name": "item_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "item_tags_item_tag_idx": {
+          "name": "item_tags_item_tag_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "item_tags_user_id_users_id_fk": {
+          "name": "item_tags_user_id_users_id_fk",
+          "tableFrom": "item_tags",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "item_tags_item_id_items_id_fk": {
+          "name": "item_tags_item_id_items_id_fk",
+          "tableFrom": "item_tags",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "item_tags_tag_id_tags_id_fk": {
+          "name": "item_tags_tag_id_tags_id_fk",
+          "tableFrom": "item_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_tricks": {
+      "name": "item_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "item_tricks_user_id_idx": {
+          "name": "item_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "item_tricks_item_id_idx": {
+          "name": "item_tricks_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "item_tricks_trick_id_idx": {
+          "name": "item_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "item_tricks_item_trick_idx": {
+          "name": "item_tricks_item_trick_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "item_tricks_user_id_users_id_fk": {
+          "name": "item_tricks_user_id_users_id_fk",
+          "tableFrom": "item_tricks",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "item_tricks_item_id_items_id_fk": {
+          "name": "item_tricks_item_id_items_id_fk",
+          "tableFrom": "item_tricks",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "item_tricks_trick_id_tricks_id_fk": {
+          "name": "item_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "item_tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "tableTo": "tricks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "items_user_id_idx": {
+          "name": "items_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "items_user_id_users_id_fk": {
+          "name": "items_user_id_users_id_fk",
+          "tableFrom": "items",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.performances": {
+      "name": "performances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setlist_id": {
+          "name": "setlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_size": {
+          "name": "audience_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_type": {
+          "name": "audience_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "performances_user_id_idx": {
+          "name": "performances_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "performances_setlist_id_idx": {
+          "name": "performances_setlist_id_idx",
+          "columns": [
+            {
+              "expression": "setlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "performances_user_id_date_idx": {
+          "name": "performances_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "performances_user_id_users_id_fk": {
+          "name": "performances_user_id_users_id_fk",
+          "tableFrom": "performances",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "performances_setlist_id_setlists_id_fk": {
+          "name": "performances_setlist_id_setlists_id_fk",
+          "tableFrom": "performances",
+          "columnsFrom": [
+            "setlist_id"
+          ],
+          "tableTo": "setlists",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_session_tricks": {
+      "name": "practice_session_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_session_id": {
+          "name": "practice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_session_tricks_user_id_idx": {
+          "name": "practice_session_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "practice_session_tricks_practice_session_id_idx": {
+          "name": "practice_session_tricks_practice_session_id_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "practice_session_tricks_trick_id_idx": {
+          "name": "practice_session_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "practice_session_tricks_session_trick_idx": {
+          "name": "practice_session_tricks_session_trick_idx",
+          "columns": [
+            {
+              "expression": "practice_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "practice_session_tricks_user_id_users_id_fk": {
+          "name": "practice_session_tricks_user_id_users_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "practice_session_tricks_practice_session_id_practice_sessions_id_fk": {
+          "name": "practice_session_tricks_practice_session_id_practice_sessions_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "columnsFrom": [
+            "practice_session_id"
+          ],
+          "tableTo": "practice_sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "practice_session_tricks_trick_id_tricks_id_fk": {
+          "name": "practice_session_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "practice_session_tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "tableTo": "tricks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_sessions": {
+      "name": "practice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_sessions_user_id_idx": {
+          "name": "practice_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "practice_sessions_user_id_date_idx": {
+          "name": "practice_sessions_user_id_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "practice_sessions_user_id_users_id_fk": {
+          "name": "practice_sessions_user_id_users_id_fk",
+          "tableFrom": "practice_sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "columns": [
+            "endpoint"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setlist_tricks": {
+      "name": "setlist_tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setlist_id": {
+          "name": "setlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_notes": {
+          "name": "transition_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "setlist_tricks_user_id_idx": {
+          "name": "setlist_tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "setlist_tricks_setlist_id_idx": {
+          "name": "setlist_tricks_setlist_id_idx",
+          "columns": [
+            {
+              "expression": "setlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "setlist_tricks_trick_id_idx": {
+          "name": "setlist_tricks_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "setlist_tricks_setlist_position_idx": {
+          "name": "setlist_tricks_setlist_position_idx",
+          "columns": [
+            {
+              "expression": "setlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "setlist_tricks_user_id_users_id_fk": {
+          "name": "setlist_tricks_user_id_users_id_fk",
+          "tableFrom": "setlist_tricks",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "setlist_tricks_setlist_id_setlists_id_fk": {
+          "name": "setlist_tricks_setlist_id_setlists_id_fk",
+          "tableFrom": "setlist_tricks",
+          "columnsFrom": [
+            "setlist_id"
+          ],
+          "tableTo": "setlists",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "setlist_tricks_trick_id_tricks_id_fk": {
+          "name": "setlist_tricks_trick_id_tricks_id_fk",
+          "tableFrom": "setlist_tricks",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "tableTo": "tricks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setlists": {
+      "name": "setlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_duration_minutes": {
+          "name": "estimated_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "setlists_user_id_idx": {
+          "name": "setlists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "setlists_user_id_users_id_fk": {
+          "name": "setlists_user_id_users_id_fk",
+          "tableFrom": "setlists",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tags_user_id_idx": {
+          "name": "tags_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "tags_user_name_idx": {
+          "name": "tags_user_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(name)",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trick_tags": {
+      "name": "trick_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trick_id": {
+          "name": "trick_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trick_tags_user_id_idx": {
+          "name": "trick_tags_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "trick_tags_trick_id_idx": {
+          "name": "trick_tags_trick_id_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "trick_tags_tag_id_idx": {
+          "name": "trick_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        },
+        "trick_tags_trick_tag_idx": {
+          "name": "trick_tags_trick_tag_idx",
+          "columns": [
+            {
+              "expression": "trick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "trick_tags_user_id_users_id_fk": {
+          "name": "trick_tags_user_id_users_id_fk",
+          "tableFrom": "trick_tags",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "trick_tags_trick_id_tricks_id_fk": {
+          "name": "trick_tags_trick_id_tricks_id_fk",
+          "tableFrom": "trick_tags",
+          "columnsFrom": [
+            "trick_id"
+          ],
+          "tableTo": "tricks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "trick_tags_tag_id_tags_id_fk": {
+          "name": "trick_tags_tag_id_tags_id_fk",
+          "tableFrom": "trick_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tricks": {
+      "name": "tricks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_type": {
+          "name": "effect_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performance_type": {
+          "name": "performance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle_sensitivity": {
+          "name": "angle_sensitivity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "props": {
+          "name": "props",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "music": {
+          "name": "music",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_camera_friendly": {
+          "name": "is_camera_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_silent": {
+          "name": "is_silent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tricks_user_id_idx": {
+          "name": "tricks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tricks_user_id_users_id_fk": {
+          "name": "tricks_user_id_users_id_fk",
+          "tableFrom": "tricks",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "push_enabled": {
+          "name": "push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "practice_reminder_time": {
+          "name": "practice_reminder_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_reminder_days": {
+          "name": "practice_reminder_days",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_summary_enabled": {
+          "name": "weekly_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1777305711736,
       "tag": "0018_woozy_beyonder",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1777500736314,
+      "tag": "0019_backfill_user_id_junctions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/sync/connector.test.ts
+++ b/src/sync/connector.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 vi.mock("./events", () => ({
   dispatchSyncError: vi.fn(),
@@ -552,6 +552,182 @@ describe("createNeonConnector", () => {
       const transaction =
         await db.getNextCrudTransaction.mock.results[0]!.value;
       expect(transaction.complete).not.toHaveBeenCalled();
+    });
+
+    describe("500 response — structured error log (issue #220)", () => {
+      // Regression guard: the structured `console.error` payload on the 500
+      // path is the diagnostic surface that lets operators see the Postgres
+      // SQLSTATE on the client side. A silent regression here would re-hide
+      // schema drift behind PowerSync's retry loop.
+      function find500LogCall(
+        spy: MockInstance<typeof console.error>
+      ): Record<string, unknown> | undefined {
+        const call = spy.mock.calls.find(
+          (args) => args[0] === "Batch upload failed:"
+        );
+        return call?.[1] as Record<string, unknown> | undefined;
+      }
+
+      it("logs pgCode and failedTable when the server returns a well-formed 500", async () => {
+        const errorSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => undefined);
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              error: "Batch execution failed",
+              failedIndex: 0,
+              code: "42703",
+              results: [],
+            }),
+            { status: 500 }
+          )
+        );
+        const mod = await importWithEnv(VALID_ENV);
+        const connector = mod.createNeonConnector(async () => "my-token");
+        const db = createMockDatabase([
+          {
+            id: "trick-1",
+            op: "PUT",
+            table: "tricks",
+            opData: { name: "Test" },
+          },
+        ]);
+
+        await expect(
+          connector.uploadData(
+            db as unknown as Parameters<typeof connector.uploadData>[0]
+          )
+        ).rejects.toThrow("Batch upload failed — will retry");
+
+        const logged = find500LogCall(errorSpy);
+        expect(logged).toMatchObject({
+          httpStatus: 500,
+          pgCode: "42703",
+          failedIndex: 0,
+          failedTable: "tricks",
+        });
+      });
+
+      it.each([
+        ["null (JSON drops NaN)", Number.NaN],
+        ["negative", -1],
+        ["non-integer", 0.5],
+        ["out of range (>= length)", 5],
+      ])("rejects %s failedIndex and logs failedIndex/failedTable as undefined", async (_label, badIndex) => {
+        const errorSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => undefined);
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              error: "Batch execution failed",
+              failedIndex: badIndex,
+              code: "42703",
+              results: [],
+            }),
+            { status: 500 }
+          )
+        );
+        const mod = await importWithEnv(VALID_ENV);
+        const connector = mod.createNeonConnector(async () => "my-token");
+        const db = createMockDatabase([
+          {
+            id: "trick-1",
+            op: "PUT",
+            table: "tricks",
+            opData: { name: "Test" },
+          },
+        ]);
+
+        await expect(
+          connector.uploadData(
+            db as unknown as Parameters<typeof connector.uploadData>[0]
+          )
+        ).rejects.toThrow("Batch upload failed — will retry");
+
+        const logged = find500LogCall(errorSpy);
+        expect(logged).toMatchObject({
+          httpStatus: 500,
+          pgCode: "42703",
+          failedIndex: undefined,
+          failedTable: undefined,
+        });
+      });
+
+      it("logs pgCode/failedIndex/failedTable as undefined when 500 body is not JSON", async () => {
+        const errorSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => undefined);
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response("<html>504 gateway timeout</html>", { status: 500 })
+        );
+        const mod = await importWithEnv(VALID_ENV);
+        const connector = mod.createNeonConnector(async () => "my-token");
+        const db = createMockDatabase([
+          {
+            id: "trick-1",
+            op: "PUT",
+            table: "tricks",
+            opData: { name: "Test" },
+          },
+        ]);
+
+        await expect(
+          connector.uploadData(
+            db as unknown as Parameters<typeof connector.uploadData>[0]
+          )
+        ).rejects.toThrow("Batch upload failed — will retry");
+
+        const logged = find500LogCall(errorSpy);
+        expect(logged).toMatchObject({
+          httpStatus: 500,
+          pgCode: undefined,
+          failedIndex: undefined,
+          failedTable: undefined,
+          body: "<html>504 gateway timeout</html>",
+        });
+      });
+
+      it("omits pgCode when the server response has no code field (production/preview path)", async () => {
+        const errorSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => undefined);
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              error: "Batch execution failed",
+              failedIndex: 0,
+              results: [],
+            }),
+            { status: 500 }
+          )
+        );
+        const mod = await importWithEnv(VALID_ENV);
+        const connector = mod.createNeonConnector(async () => "my-token");
+        const db = createMockDatabase([
+          {
+            id: "trick-1",
+            op: "PUT",
+            table: "tricks",
+            opData: { name: "Test" },
+          },
+        ]);
+
+        await expect(
+          connector.uploadData(
+            db as unknown as Parameters<typeof connector.uploadData>[0]
+          )
+        ).rejects.toThrow("Batch upload failed — will retry");
+
+        const logged = find500LogCall(errorSpy);
+        expect(logged).toMatchObject({
+          httpStatus: 500,
+          pgCode: undefined,
+          failedIndex: 0,
+          failedTable: "tricks",
+        });
+      });
     });
 
     it("throws on network error", async () => {

--- a/src/sync/connector.ts
+++ b/src/sync/connector.ts
@@ -190,13 +190,53 @@ async function sendAndProcessBatch(
 
   if (!response.ok) {
     const body = await response.text().catch(() => "");
-    console.error("Batch upload failed:", response.status, body);
+    let pgCode: string | undefined;
+    let failedIndex: number | undefined;
+    try {
+      const parsed: unknown = JSON.parse(body);
+      if (isRecord(parsed)) {
+        if (typeof parsed.code === "string") {
+          pgCode = parsed.code;
+        }
+        // Reject non-integer / negative / out-of-range failedIndex values so a
+        // malformed server response can't produce misleading log entries like
+        // `failedIndex: NaN, failedTable: undefined` when an operator is debugging.
+        if (
+          typeof parsed.failedIndex === "number" &&
+          Number.isInteger(parsed.failedIndex) &&
+          parsed.failedIndex >= 0 &&
+          parsed.failedIndex < originalOps.length
+        ) {
+          failedIndex = parsed.failedIndex;
+        }
+      }
+    } catch {
+      // body wasn't JSON — fall through and log the raw text
+    }
+    const failedTable =
+      failedIndex === undefined ? undefined : originalOps[failedIndex]?.table;
+    // pgCode is intentionally absent in production AND preview responses (see
+    // the exposeCode env gate in src/app/api/powersync/batch/route.ts). If you
+    // see `pgCode: undefined` here on a deployed environment, that is by design,
+    // not a regression — check the server log for the SQLSTATE.
+    console.error("Batch upload failed:", {
+      httpStatus: response.status,
+      pgCode,
+      failedIndex,
+      failedTable,
+      body,
+    });
     throw new Error("Batch upload failed — will retry");
   }
 
   const json: unknown = await response.json();
   const results = parseBatchResults(json);
   reportPermanentErrors(results, originalOps, onPermanentError);
+}
+
+/** Narrows an unknown JSON-parsed value to a plain record (excludes arrays and null). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /** Narrows an unknown JWT payload to an object with a numeric `exp` claim. */


### PR DESCRIPTION
## Summary

Restores the missing `user_id` column on `item_tricks` and `practice_session_tricks` (issue #220 — schema drift on `main` and `dev/julien` from a partial 0006 migration), and bundles a diagnostic-logging improvement so the next "PowerSync retries forever on a hidden Postgres error" incident gets diagnosed in seconds.

### Migration 0019 (forward-only, idempotent)

- `ADD COLUMN IF NOT EXISTS user_id uuid` on both junction tables
- Cross-tenant-safe backfill (only when both parent rows agree on owner)
- Drop orphan rows whose parents disappeared
- `SET NOT NULL`, FK to `users.id ON DELETE CASCADE`, partial index `WHERE deleted_at IS NULL`
- Replace RLS policies with the simplified `USING (user_id = auth.user_id())` form (faster reads), keeping `WITH CHECK` parent-EXISTS for defense-in-depth
- Each DROP+CREATE policy pair runs inside one `DO $$` block so both DDLs land in a single HTTP statement under `@neondatabase/serverless` — eliminates the brief deny-all window the per-statement transaction semantics would otherwise expose

### Diagnostic logging (bundled per the issue plan)

- `BatchResult` now carries an optional `code?: string` for the SQLSTATE on transient DB errors
- 500 response body exposes `code` only when `VERCEL_ENV` is neither `production` nor `preview` (preview URLs are routinely shared in PR comments / link previews; an authenticated user reaching one could enumerate schema state via SQLSTATE classes like `42703 = undefined column`). The SQLSTATE stays in the server log for operators with Vercel log access in all environments.
- Connector parses `pgCode` + `failedIndex` from the JSON body with strict bounds checking (rejects `NaN`, negative, non-integer, out-of-range values) and includes them in the structured `console.error` payload
- Two new tests in `route.test.ts` and `connector.test.ts` cover the env gate (production / preview / development / unset / no-SQLSTATE) and the failedIndex validation paths

## Verification

- [x] `pnpm verify` (lint + typecheck + tests + sync drift + i18n) — green, 1698/1698 tests
- [x] Migration applied cleanly to throwaway preview branch off `main`; pre-state showed drift, post-state showed `user_id NOT NULL`, FK + partial index present, RLS USING uses new simplified form
- [x] Migration applied to `dev/julien` (`br-delicate-forest-agyr6w0b`) with the same post-state confirmation
- [x] Drizzle journal monotonicity preserved (`when=1777500736314 > 1777305711736`)
- [x] PowerSync sync schema unchanged — already declared `user_id` on both tables, so the GitHub Actions sync deploy will not fire

## Test plan

- [x] Unit tests for the SQLSTATE env gate (per-op failure path + outer catch path, parameterized over production / preview)
- [x] Unit tests for the connector's response parsing (well-formed 500, malformed `failedIndex` values)
- [ ] Manual smoke: sign in to https://themagiclab.app/ after merge → `/collect` → create item with linked trick → expect `POST /api/powersync/batch` 200, no console errors

## Production rollout

After merge, run `pnpm db:migrate` against the production branch (`br-wandering-water-ag9ebs5x`) to apply the same migration to prod. The migration is idempotent — safe to run on any branch where 0006 partially applied.

Closes #220