### PR TITLE
fix: lock down authenticated role's CRUD grants (#245)

### DIFF
--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -9,7 +9,23 @@ paths:
 
 **Invoke the `/migrations` skill** — it enforces the full workflow (generate → review SQL → migrate → regenerate sync artifacts → reset dev branch → regenerate docs). Hand-rolling is error-prone.
 
-**Two safety rules the skill guards — also flag them in any review**:
+**Three safety rules the skill guards — also flag them in any review**:
 
 1. **Single migration file for dependent SQL.** `@neondatabase/serverless` runs each migration file as an independent HTTP call, so DDL from one file is **not visible** to the next within the same `drizzle-kit migrate` run. Never split dependent statements across files. Hand-written additions (e.g., RLS policies) that depend on a generated migration must be appended to that same file.
 2. **Journal timestamps must be monotonically increasing.** Drizzle-orm only applies migrations whose `when` in `meta/_journal.json` is greater than the last applied. Out-of-order entries are **silently skipped**. After generating or editing a migration, verify the new `when` is strictly greater than every previous entry.
+3. **Every `CREATE TABLE` for a synced table needs an explicit `GRANT … TO authenticated;` line in the same migration.** As of `0020_lockdown_authenticated_grants.sql` (issue #245), schema `public` has no default privileges for `authenticated` — tables created without an explicit GRANT are inaccessible to clients (PowerSync queries return empty silently). Reference matrix from 0020:
+   - Standard user-data tables: `GRANT SELECT, INSERT, UPDATE, DELETE`.
+   - `push_subscriptions`: `GRANT SELECT, INSERT, UPDATE` (no DELETE — cleanup is server-side).
+   - `event_log`: `GRANT SELECT, INSERT` + `GRANT UPDATE (deleted_at, updated_at)` (audit-trail invariant — no DELETE, no payload mutation from clients).
+   - Server-only tables (`users`, `user_preferences`): `GRANT SELECT` only.
+   - RLS policies stay defense-in-depth on top of GRANTs — the GRANT layer is the new enforcement floor; RLS narrows by `user_id`.
+
+## Rollback / recovery
+
+Drizzle migrations are **forward-only**. There is no down-migration tooling.
+
+- **Mistake in a migration that has not yet shipped to prod**: edit the file before merge. If it has been applied to `dev/julien` already, the cheapest fix is `mcp__neon__reset_from_parent` followed by `pnpm db:migrate` to replay from the corrected file. Do this before any other `dev/julien` work piles up — reset wipes the branch.
+- **Hash drift on edited-after-apply migrations**. Drizzle records each applied migration's SHA in `__drizzle_migrations`. Editing a file after it has been applied does NOT re-run it on the same branch — the journal entry exists, the recorded hash no longer matches the file, and on a fresh replay (new branch / `reset_from_parent`) Drizzle will refuse the run. **On dev branches**: always pair an edit with `mcp__neon__reset_from_parent` + fresh `pnpm db:migrate`. **On prod**: never edit an applied migration — ship a hotfix migration with the next `idx`.
+- **Mistake discovered post-deploy** (e.g., a synced table is inaccessible to `authenticated` because the GRANT line was omitted): ship a hotfix migration. Use the next `idx`, a strictly-greater `when`, and a descriptive tag (`NNNN_hotfix_<thing>.sql`). Triage steps: `SELECT relname, relacl FROM pg_class WHERE relnamespace = 'public'::regnamespace AND relname = '<table>';` — if `authenticated` is missing from `relacl`, add the GRANT in the hotfix.
+- **Never re-grant via ad-hoc `psql`**. It bypasses the journal and silently regresses on the next `reset_from_parent` or fresh-project replay.
+- **Migrations must run as `neondb_owner`** (the role behind `DATABASE_URL`). 0020's `ALTER DEFAULT PRIVILEGES` is keyed on that grantor; any other table-creating role would silently re-introduce the over-grant. 0020 added a `current_user` assertion (lines 32-36) as the canonical pattern — replicate it in any future migration that touches default privileges or grants.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,21 @@ User-facing activity history + canonical product analytics. Table `event_log`, s
 
 Client mutations always wrap the event-log write in `safeLogEvent()` (`src/lib/events/log.ts`), which calls `logEvent` inside the surrounding PowerSync `db.writeTransaction(...)` and routes any failure through `reportEventLogFailure`. The event row is **co-located** with the action — a successful event rides the same sync queue and replays offline — but the dual sink is **best-effort on the event side**: an event-log CHECK violation, schema mismatch, or downstream outage must never roll back the primary mutation. The primary table is the source of truth; the event log is the canonical activity history but not load-bearing for correctness. `logEventServer` writes directly to Neon from server actions, route handlers, and `auth/ensure-user.ts` (typically via `after()` so it doesn't block the response). Event taxonomy lives in `src/lib/events/types.ts`. See `docs/features/activity.md` for the full reference.
 
+### DB grants & roles
+
+Two Postgres roles exist on Neon. Today, **all server-side code paths use `neondb_owner`** — Drizzle (`src/db/index.ts`), server actions, route handlers including the PowerSync upload route (`Pool({ databaseUrl })` at `src/app/api/powersync/batch/route.ts:180`), `logEventServer()`, and `auth/ensure-user.ts`. `neondb_owner` has full DB access and bypasses RLS, so **anything sensitive must be guarded at the application layer**.
+
+The `authenticated` role is currently exercised only by the JWT-aware client paths the codebase does not yet use directly (Neon Data API, JWT-forwarded PowerSync sync — both anticipated, not active). Migration `0020_lockdown_authenticated_grants.sql` (issue #245) hardens what `authenticated` CAN see/do **before** any code path actually authenticates as that role:
+
+- Schema `public` has **no default privileges** for `authenticated`. Every `CREATE TABLE` synced via PowerSync MUST include an explicit `GRANT <subset> ON <table> TO authenticated;` line in the **same migration file**. Future synced tables added without a GRANT will be invisible to any future `authenticated`-role client (PowerSync queries return empty).
+- The canonical per-table grant matrix lives in `0020`. Reference shape:
+  - Standard user-data tables (12): `SELECT, INSERT, UPDATE, DELETE`.
+  - `push_subscriptions`: `SELECT, INSERT, UPDATE` — no `DELETE` for clients (cleanup of expired subs is server-side).
+  - `event_log`: `SELECT, INSERT` + column-level `UPDATE (deleted_at, updated_at)` only — no `DELETE`, no payload mutation. Audit-trail invariant.
+  - Server-only tables (`users`, `user_preferences`): `SELECT` only.
+
+**The 422 gate in `src/app/api/powersync/batch/route.ts:122-144` IS still the only enforcement of the `event_log` audit-trail invariant on the live write path** — because that path runs as `neondb_owner` and bypasses both the new `authenticated` GRANTs and RLS. Do not weaken or remove the 422 gate without first migrating the upload route to a JWT-forwarding `authenticated`-role connection. The DB GRANT lockdown is forward-positioning + hardening against an accidental `DATABASE_URL` swap to a less-privileged role; it is not a replacement for the application-layer check today.
+
 ### Key Directories
 
 - **`scripts/`** — codegen and ops CLIs: `generate-sync.ts`, `check-sync.ts`, `check-i18n.ts`, `generate-docs.ts`, `generate-screenshots.ts`, `powersync.ts`, `setup.ts`. Entry points behind the `pnpm sync:*`, `pnpm i18n:check`, `pnpm docs:generate`, `pnpm screenshots` scripts.

--- a/src/app/api/powersync/batch/route.test.ts
+++ b/src/app/api/powersync/batch/route.test.ts
@@ -308,6 +308,198 @@ describe("POST /api/powersync/batch", () => {
     });
   });
 
+  describe("event_log invariants", () => {
+    // Pin the application-layer audit-trail guard at route.ts:122-144 so a future
+    // refactor of buildOperationQuery cannot silently delete it. The DB-layer GRANT
+    // (migration 0020) is the load-bearing enforcement; this 422 is the friendly UX.
+    it("rejects DELETE on event_log with status 422 (append-only)", async () => {
+      authenticatedSession();
+      vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+      mockClientQuery.mockResolvedValue({ rowCount: 0 });
+      const { POST } = await import("./route");
+
+      const response = await POST(
+        createRequest({
+          operations: [deleteOp("event_log", "evt-1")],
+        })
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.results[0]).toMatchObject({
+        index: 0,
+        status: 422,
+        error: "Validation error",
+      });
+
+      // Validation throws before SAVEPOINT/SQL runs — no DELETE statement hits the wire.
+      const calls = mockClientQuery.mock.calls.map(
+        (call: unknown[]) => call[0]
+      );
+      expect(
+        calls.some((q) => typeof q === "string" && q.includes("DELETE FROM"))
+      ).toBe(false);
+    });
+
+    it.each([
+      // `source` is the trust label distinguishing client-emitted from server-emitted
+      // events — route.ts:131-135 explicitly omits it from the allowlist; this test
+      // pins that decision against future refactors.
+      ["source", { source: "server" }],
+      ["payload", { payload: { x: 1 } }],
+      ["event_type", { event_type: "trick.created" }],
+      ["entity_type", { entity_type: "trick" }],
+    ])("rejects PATCH on event_log mutating disallowed column %s", async (_label, opData) => {
+      authenticatedSession();
+      vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+      mockClientQuery.mockResolvedValue({ rowCount: 0 });
+      const { POST } = await import("./route");
+
+      const response = await POST(
+        createRequest({
+          operations: [patchOp("event_log", "evt-1", opData)],
+        })
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.results[0]).toMatchObject({
+        index: 0,
+        status: 422,
+        error: "Validation error",
+      });
+
+      // Belt-and-braces: validation throws before any SQL is built, so no UPDATE
+      // against event_log should hit the wire. Without this, a refactor that
+      // issues the UPDATE *then* returns 422 would silently violate the invariant.
+      const calls = mockClientQuery.mock.calls.map(
+        (call: unknown[]) => call[0]
+      );
+      expect(
+        calls.some(
+          (q) =>
+            typeof q === "string" &&
+            q.includes("UPDATE") &&
+            q.includes('"event_log"')
+        )
+      ).toBe(false);
+    });
+
+    it("rejects PATCH on event_log mixing allowed + disallowed columns (no partial apply)", async () => {
+      // Guards against a "be liberal in what you accept" refactor that would
+      // silently drop the disallowed columns and proceed with the allowed ones —
+      // every existing test would still pass while the audit-trail invariant is
+      // violated. The whole PATCH must reject; no partial UPDATE may reach the wire.
+      authenticatedSession();
+      vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+      mockClientQuery.mockResolvedValue({ rowCount: 0 });
+      const { POST } = await import("./route");
+
+      const response = await POST(
+        createRequest({
+          operations: [
+            patchOp("event_log", "evt-1", {
+              deleted_at: "2026-04-30T10:00:00Z",
+              payload: "{}",
+            }),
+          ],
+        })
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.results[0]).toMatchObject({
+        index: 0,
+        status: 422,
+        error: "Validation error",
+      });
+
+      const calls = mockClientQuery.mock.calls.map(
+        (call: unknown[]) => call[0]
+      );
+      expect(
+        calls.some(
+          (q) =>
+            typeof q === "string" &&
+            q.includes("UPDATE") &&
+            q.includes('"event_log"')
+        )
+      ).toBe(false);
+    });
+
+    it("permits PATCH on event_log mutating only deleted_at + updated_at (soft-delete path)", async () => {
+      // Positive coverage for the allowlist: a PATCH limited to (deleted_at,
+      // updated_at) is the soft-delete path described at route.ts:117-121 and
+      // must succeed. Without this test, a future over-restriction (e.g.,
+      // "if (op === OpType.PATCH) throw") would pass every negative test while
+      // breaking offline soft-delete sync.
+      authenticatedSession();
+      vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+      mockClientQuery.mockResolvedValue({ rowCount: 1 });
+      const { POST } = await import("./route");
+
+      const response = await POST(
+        createRequest({
+          operations: [
+            patchOp("event_log", "evt-1", {
+              deleted_at: "2026-04-30T10:00:00Z",
+            }),
+          ],
+        })
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.results[0]).toEqual({ index: 0, status: 200 });
+
+      // Confirm the UPDATE actually went to the wire against event_log.
+      const updateCall = mockClientQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("UPDATE") &&
+          sql.includes('"event_log"')
+      );
+      expect(updateCall).toBeDefined();
+    });
+
+    it("forces source = 'client' on event_log INSERT even when client sends 'server'", async () => {
+      authenticatedSession();
+      vi.stubEnv("DATABASE_URL", "postgres://localhost/test");
+      mockClientQuery.mockResolvedValue({ rowCount: 1 });
+      const { POST } = await import("./route");
+
+      await POST(
+        createRequest({
+          operations: [
+            putOp("event_log", "evt-1", {
+              event_type: "trick.created",
+              entity_type: "trick",
+              entity_id: "t-1",
+              // Real clients pre-stringify via JSON.stringify(payload) — see
+              // src/lib/events/log.ts:49. The route validator rejects raw objects.
+              payload: "{}",
+              source: "server",
+            }),
+          ],
+        })
+      );
+
+      // Locate the INSERT by SQL prefix, not by call index — resilient against
+      // pre-INSERT statements like SET LOCAL or SET ROLE that future refactors
+      // could add.
+      const insertCall = mockClientQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.startsWith("INSERT INTO") &&
+          sql.includes('"event_log"')
+      );
+      expect(insertCall).toBeDefined();
+      const [, params] = insertCall!;
+      expect(params).toContain("client");
+      expect(params).not.toContain("server");
+    });
+  });
+
   describe("database configuration", () => {
     it("returns 500 when DATABASE_URL is not set", async () => {
       authenticatedSession();

--- a/src/db/migrations/0018_woozy_beyonder.sql
+++ b/src/db/migrations/0018_woozy_beyonder.sql
@@ -1,3 +1,14 @@
+-- HISTORICAL NOTE (added with #245 / migration 0020):
+-- The GRANT statements at the bottom of this file (SELECT, INSERT + UPDATE on
+-- deleted_at/updated_at only) were silently no-op'd by Neon's pg_default_acl on
+-- schema "public", which auto-granted full CRUD to authenticated on every
+-- CREATE TABLE. Migration 0020 REVOKEs the over-grant and ALTER DEFAULT PRIVILEGES
+-- prevents recurrence — but only for the `authenticated` role. The live PowerSync
+-- upload path uses `neondb_owner` via DATABASE_URL Pool (route.ts:180), bypasses
+-- these GRANTs and RLS, so the audit-trail invariant on the live write path is
+-- enforced SOLELY by the 422 gate at src/app/api/powersync/batch/route.ts:122-144.
+-- Do NOT weaken or remove that gate without first migrating the upload route to a
+-- JWT-forwarding `authenticated` connection.
 CREATE TABLE "event_log" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"user_id" uuid NOT NULL,

--- a/src/db/migrations/0020_lockdown_authenticated_grants.sql
+++ b/src/db/migrations/0020_lockdown_authenticated_grants.sql
@@ -1,0 +1,87 @@
+-- 0020: lock down the `authenticated` role's CRUD privileges (issue #245).
+--
+-- Phase 0 investigation (run against dev/julien on 2026-04-30) confirmed pg_default_acl
+-- on schema "public" auto-grants {authenticated=arwd/neondb_owner} on every CREATE TABLE,
+-- silently overriding migration-level scoped GRANTs (notably 0018 on event_log, which
+-- intended SELECT/INSERT + column-UPDATE only). This migration:
+--
+--   1. Asserts current_user = neondb_owner — ALTER DEFAULT PRIVILEGES is keyed on the
+--      grantor; running as any other role would silently fail to neutralize the auto-grant.
+--   2. GRANT USAGE ON SCHEMA public TO authenticated — defensive idempotent re-grant so a
+--      fresh-project replay (post mcp__neon__reset_from_parent on a project that lacks the
+--      Neon Auth bootstrap USAGE grant) cannot leave authenticated unable to access tables.
+--   3. REVOKEs all current grants per table (clears table-level + column-level).
+--   4. Re-GRANTs with the correct narrow scope per table (defense-in-depth — see route.ts
+--      gates and RLS policies, which remain in place).
+--   5. ALTER DEFAULT PRIVILEGES so future CREATE TABLE no longer auto-grants. From now on,
+--      every new synced table MUST include an explicit GRANT line in the same migration.
+--
+-- The entire migration runs inside ONE PL/pgSQL anonymous DO block — i.e., one HTTP call
+-- under @neondatabase/serverless = one implicit transaction. Either every step lands or
+-- none do, eliminating the silent-partial-apply failure mode that hit issue #220 (where a
+-- multi-chunk migration was recorded as applied with only the first chunk committed).
+--
+-- ROLLBACK / RECOVERY: forward-only. If a future synced table is found to be inaccessible
+-- to authenticated post-deploy, ship a hotfix migration adding the missing GRANT (see
+-- .claude/rules/migrations.md §3 for the per-table-class matrix). Do NOT re-grant via
+-- ad-hoc psql — it bypasses the journal and will silently regress on the next
+-- reset_from_parent.
+
+DO $$ BEGIN
+  -- Step 1: assert grantor consistency.
+  IF current_user <> 'neondb_owner' THEN
+    RAISE EXCEPTION
+      'Migration 0020 must run as neondb_owner to ensure ALTER DEFAULT PRIVILEGES grantor consistency; got: %',
+      current_user;
+  END IF;
+
+  -- Step 2: schema-level USAGE for authenticated (idempotent defensive).
+  GRANT USAGE ON SCHEMA public TO authenticated;
+
+  -- Step 3: scrub all prior table grants. REVOKE ALL clears table-level + column-level.
+  REVOKE ALL ON TABLE
+    "tricks", "setlists", "setlist_tricks",
+    "practice_sessions", "practice_session_tricks",
+    "performances", "goals",
+    "items", "item_tricks", "item_tags",
+    "tags", "trick_tags",
+    "push_subscriptions", "event_log",
+    "users", "user_preferences"
+  FROM authenticated;
+
+  -- Step 4: re-grant with narrow scope per table-class.
+
+  -- 4a. Standard user-data tables — full CRUD for authenticated clients.
+  GRANT SELECT, INSERT, UPDATE, DELETE ON
+    "tricks", "setlists", "setlist_tricks",
+    "practice_sessions", "practice_session_tricks",
+    "performances", "goals",
+    "items", "item_tricks", "item_tags",
+    "tags", "trick_tags"
+  TO authenticated;
+
+  -- 4b. push_subscriptions — clients can read/insert/update; cleanup of expired
+  --     subscriptions happens server-side via neondb_owner connection.
+  GRANT SELECT, INSERT, UPDATE ON "push_subscriptions" TO authenticated;
+
+  -- 4c. event_log — audit-trail invariant for the `authenticated` role only. No DELETE;
+  --     UPDATE only on lifecycle columns (deleted_at for soft-delete, updated_at
+  --     maintained by the trigger). NOTE: the live PowerSync upload path runs as
+  --     `neondb_owner` via DATABASE_URL Pool (route.ts:180) and bypasses these GRANTs
+  --     and RLS, so the audit-trail invariant on the live write path is still enforced
+  --     solely by the 422 gate at route.ts:122-144 — do NOT weaken or remove that gate
+  --     without first migrating the upload route to a JWT-forwarding `authenticated`
+  --     connection. This GRANT layer is forward-positioning + hardening against an
+  --     accidental DATABASE_URL swap to a less-privileged role.
+  GRANT SELECT, INSERT ON "event_log" TO authenticated;
+  GRANT UPDATE ("deleted_at", "updated_at") ON "event_log" TO authenticated;
+
+  -- 4d. Server-write-only tables (Neon Auth + user prefs) — read access only.
+  GRANT SELECT ON "users", "user_preferences" TO authenticated;
+
+  -- Step 5: stop pg_default_acl from re-granting full CRUD on the next CREATE TABLE.
+  --         Sequence and function defaults are intentionally left untouched (see #253
+  --         follow-up); current schema uses uuid().defaultRandom() PKs everywhere.
+  ALTER DEFAULT PRIVILEGES FOR ROLE neondb_owner IN SCHEMA public
+    REVOKE ALL ON TABLES FROM authenticated;
+END $$;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1777500736314,
       "tag": "0019_backfill_user_id_junctions",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1777558792560,
+      "tag": "0020_lockdown_authenticated_grants",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #245.

Neon's `pg_default_acl` auto-grants full CRUD to the `authenticated` role on every `CREATE TABLE` in schema `public`, silently no-op'ing migration-level scoped GRANTs (notably 0018's column-scoped `UPDATE (deleted_at, updated_at)` on `event_log`).

This PR adds migration `0020_lockdown_authenticated_grants.sql` which:

- Asserts `current_user = neondb_owner` so `ALTER DEFAULT PRIVILEGES` lands on the right grantor.
- Re-grants `USAGE ON SCHEMA public` (defensive idempotent — handles a fresh-project replay where Neon Auth bootstrap is missing).
- `REVOKE ALL` on the 16 user-data tables, then narrow per-table-class re-GRANT:
  - Standard tables (12): `SELECT, INSERT, UPDATE, DELETE`.
  - `push_subscriptions`: `SELECT, INSERT, UPDATE` — no `DELETE` (server-side cleanup).
  - `event_log`: `SELECT, INSERT` + column-level `UPDATE (deleted_at, updated_at)` only — audit-trail invariant.
  - `users`, `user_preferences`: `SELECT` only.
- `ALTER DEFAULT PRIVILEGES FOR ROLE neondb_owner ... REVOKE ALL ON TABLES FROM authenticated` — future `CREATE TABLE`s no longer auto-grant.

The entire migration runs as a **single PL/pgSQL DO block** — one HTTP call under `@neondatabase/serverless` = one implicit transaction = atomic apply or full rollback. Eliminates the silent-partial-apply failure mode that hit #220.

### Why the app-layer 422 gate is still load-bearing

The PowerSync upload route (`src/app/api/powersync/batch/route.ts:122-144`) runs as `neondb_owner` via `Pool({ databaseUrl: process.env.DATABASE_URL })` (line 180). `neondb_owner` bypasses both the new `authenticated` GRANTs and RLS — so the `event_log` audit-trail invariant on the live write path is enforced **solely** by the 422 gate. The DB GRANT lockdown is forward-positioning + hardening against an accidental `DATABASE_URL` swap to a less-privileged role; it is not a replacement for the application-layer check today.

CLAUDE.md, `0018.sql:1-11`, and `0020.sql:64-77` all explicitly call this out so a future reader cannot weaken the 422 gate believing the DB backstops it.

### Acceptance check on dev/julien

`pg_default_acl` post-apply on `dev/julien`:
- Tables (`r`): zero rows reference `authenticated` — migration successfully neutralized the over-grant.
- Sequences (`S`) / functions (`f`): `authenticated` retains `USAGE` / `EXECUTE` — intentional out-of-scope per `0020.sql:77-78` (tracked by #253; current schema uses `uuid().defaultRandom()` PKs).

## Changes

- **Migration**: `src/db/migrations/0020_lockdown_authenticated_grants.sql` (new), journal entry idx 20.
- **Migration comment**: `0018_woozy_beyonder.sql:1-11` — historical note explaining 0020's effect.
- **Tests**: `src/app/api/powersync/batch/route.test.ts` — new `event_log invariants` describe block with 4 tests pinning the 422 gate (DELETE rejected, PATCH allowlist with `it.each` over disallowed columns + SQL-not-issued assertion, mixed allowed+disallowed PATCH, positive soft-delete path, INSERT `source` forced to `"client"`).
- **Docs**: `CLAUDE.md` — new "DB grants & roles" section. `.claude/rules/migrations.md` — GRANT discipline rule (rule #3) + new "Rollback / recovery" subsection covering forward-only nature, hash-drift recovery, and the `neondb_owner` grantor requirement.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — 1713/1713 passing (+1 net new test)
- [x] `pnpm sync:check` — artifacts up to date
- [x] Migration applied to `dev/julien` via `pnpm db:migrate`
- [x] `pg_default_acl` post-apply verified clean for tables on dev/julien
- [x] Per-table grant matrix verified via `information_schema.role_table_grants` query

## Follow-ups

- [#255](https://github.com/julienroussel/tml/issues/255) — extend PATCH allowlist tests to cover `entity_id` / `created_at` / `user_id`; revisit `globalThis.__batchPool` cleanup brittleness.
- [#253](https://github.com/julienroussel/tml/issues/253) — sequences and functions default privileges (out-of-scope for this PR; current schema uses `uuid()` PKs everywhere).