### PR TITLE
fix: prevent silent tag/trick unlink on PowerSync hydration race (#216)

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -3,7 +3,10 @@ import { cn } from "@/lib/utils";
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-accent", className)}
+      className={cn(
+        "rounded-md bg-accent motion-safe:animate-pulse",
+        className
+      )}
       data-slot="skeleton"
       {...props}
     />

--- a/src/features/collect/components/collect-view.test.tsx
+++ b/src/features/collect/components/collect-view.test.tsx
@@ -741,6 +741,408 @@ describe("CollectView", () => {
     expect(toast.error).toHaveBeenCalledWith("collect.deleteFailed");
   });
 
+  // ---------------------------------------------------------------------------
+  // Issue #216 — hydration-race regression coverage
+  // ---------------------------------------------------------------------------
+
+  // (Test A) When Edit is clicked before the join queries hydrate, the form
+  // sheet is gated (relationsLoading=true) and the seeding effect waits.
+  // Once the join hydrates, selection is seeded from real data; saving
+  // without further interaction emits empty diffs (no silent unlink).
+  it("seeds selection from hydrated joins and never emits a stale diff (issue #216)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const { useQuery } = await import("@powersync/react");
+
+    const itemId = "00000000-0000-4000-8000-0000000ed172";
+    const item = makeItem(itemId, "Linking Rings");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+    // Joins not hydrated yet — empty data with isLoading: true.
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      isLoading: true,
+      isFetching: true,
+      error: undefined,
+    });
+
+    const { rerender } = render(<CollectView />);
+
+    // Click Edit while joins are still loading.
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+
+    // Sheet opened, but relations are gated.
+    expect(capturedFormSheetProps.open).toBe(true);
+    expect(capturedFormSheetProps.relationsLoading).toBe(true);
+    // Parent coerces null sentinel to [] for the sheet's prop type.
+    expect(capturedFormSheetProps.selectedTagIds).toEqual([]);
+    expect(capturedFormSheetProps.selectedTrickIds).toEqual([]);
+
+    // Defense-in-depth: a keyboard-driven submit while still seeding must
+    // not call updateItem at all (Save is also disabled in the sheet).
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "Linking Rings" })
+    );
+    expect(mockUpdateItem).not.toHaveBeenCalled();
+
+    // Joins hydrate with two existing tags for this item.
+    const t1 = "00000000-0000-4000-8000-0000000000a1" as TagId;
+    const t2 = "00000000-0000-4000-8000-0000000000a2" as TagId;
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM item_tags")) {
+        return {
+          data: [
+            {
+              item_id: itemId,
+              tag_id: t1,
+              tag_name: t1,
+              color: null,
+            },
+            {
+              item_id: itemId,
+              tag_id: t2,
+              tag_name: t2,
+              color: null,
+            },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<CollectView />);
+
+    // After hydration the seeding effect populates both selected/original
+    // from the join, and the gate lifts.
+    await waitFor(() => {
+      expect(capturedFormSheetProps.relationsLoading).toBe(false);
+      expect(capturedFormSheetProps.selectedTagIds).toEqual([t1, t2]);
+    });
+    // Snapshot semantics: post-seed, selected === original, so dirty flags
+    // remain false. If seeding ever drifted to non-equal arrays, the discard
+    // dialog would falsely trigger — this assertion locks the property.
+    expect(capturedFormSheetProps.tagsDirty).toBe(false);
+    expect(capturedFormSheetProps.tricksDirty).toBe(false);
+
+    // Submit without touching the picker — issue #216 used to emit
+    // removeTagIds=[t1,t2] silently. Now the diff is empty.
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "Linking Rings" })
+    );
+    expect(mockUpdateItem).toHaveBeenCalledWith(
+      itemId,
+      expect.any(Object),
+      [],
+      [],
+      [],
+      []
+    );
+  });
+
+  // (Test C) Closing the sheet mid-load and reopening after hydration must
+  // re-seed cleanly — no leaked sentinel from the previous session.
+  it("re-seeds cleanly when Edit is reopened after closing mid-load", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const { useQuery } = await import("@powersync/react");
+
+    const itemId = "00000000-0000-4000-8000-0000000ed173";
+    const item = makeItem(itemId, "Cups & Balls");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      isLoading: true,
+      isFetching: true,
+      error: undefined,
+    });
+
+    const { rerender } = render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+    expect(capturedFormSheetProps.relationsLoading).toBe(true);
+
+    // Close mid-load.
+    act(() => {
+      capturedFormSheetProps.onOpenChange?.(false);
+    });
+    expect(capturedFormSheetProps.open).toBe(false);
+
+    // Hydrate BOTH joins (tags + tricks) so that selected/original re-seed
+    // for each — a regression on either side must be detectable below.
+    const t1 = "00000000-0000-4000-8000-0000000000b1" as TagId;
+    const tr1 = "00000000-0000-4000-8000-00000000ee01" as TrickId;
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM item_tags")) {
+        return {
+          data: [
+            {
+              item_id: itemId,
+              tag_id: t1,
+              tag_name: t1,
+              color: null,
+            },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      if (typeof sql === "string" && sql.includes("FROM item_tricks")) {
+        return {
+          data: [
+            {
+              item_id: itemId,
+              trick_id: tr1,
+              trick_name: "Coin Vanish",
+            },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<CollectView />);
+
+    // Reopen Edit — seed fires fresh from the now-hydrated joins.
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+    await waitFor(() => {
+      expect(capturedFormSheetProps.relationsLoading).toBe(false);
+      expect(capturedFormSheetProps.selectedTagIds).toEqual([t1]);
+      expect(capturedFormSheetProps.selectedTrickIds).toEqual([tr1]);
+    });
+
+    // Submit with no further interaction → diff must be empty in BOTH tag
+    // and trick arrays. A regression where `selected` re-seeds but `original`
+    // stays stale at [] (or vice versa) would compute a phantom remove/add
+    // on either side and fail this assertion.
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "Cups & Balls" })
+    );
+    expect(mockUpdateItem).toHaveBeenCalledWith(
+      itemId,
+      expect.any(Object),
+      [],
+      [],
+      [],
+      []
+    );
+  });
+
+  // (Test D) Adjacent useItem race: keyboard-submitting before the trick row
+  // hydrates (item===null) must not invoke updateItem with RHF defaults.
+  it("gates Save and short-circuits submit while useItem is still loading (issue #216)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+
+    const itemId = "00000000-0000-4000-8000-0000000ed174";
+    const item = makeItem(itemId, "Sponge Balls");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    // useItem reports isLoading: true — the row hasn't materialised yet.
+    vi.mocked(useItem).mockReturnValue({
+      item: null,
+      error: null,
+      isLoading: true,
+    });
+
+    const { rerender } = render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+    expect(capturedFormSheetProps.relationsLoading).toBe(true);
+
+    // Keyboard submit while still loading — defense in depth.
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "Sponge Balls" })
+    );
+    expect(mockUpdateItem).not.toHaveBeenCalled();
+
+    // Hydrate the row.
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+    rerender(<CollectView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.relationsLoading).toBe(false);
+    });
+
+    // Now submit goes through.
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "Sponge Balls" })
+    );
+    expect(mockUpdateItem).toHaveBeenCalledWith(
+      itemId,
+      expect.any(Object),
+      [],
+      [],
+      [],
+      []
+    );
+  });
+
+  // (Test E) Background sync adds a tag while the user is editing. The
+  // delta-only mutation + lock-in seeding combo must NOT silently emit the
+  // sync-added tag as a phantom add or remove.
+  it("does not emit phantom diffs when the join updates from background sync", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const { useQuery } = await import("@powersync/react");
+
+    const itemId = "00000000-0000-4000-8000-0000000ed175";
+    const item = makeItem(itemId, "Coin Vanish");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+
+    const t1 = "00000000-0000-4000-8000-0000000000c1" as TagId;
+    const t2 = "00000000-0000-4000-8000-0000000000c2" as TagId;
+
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM item_tags")) {
+        return {
+          data: [
+            { item_id: itemId, tag_id: t1, tag_name: t1, color: null },
+            { item_id: itemId, tag_id: t2, tag_name: t2, color: null },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    const { rerender } = render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+    await waitFor(() => {
+      expect(capturedFormSheetProps.selectedTagIds).toEqual([t1, t2]);
+    });
+
+    // Background sync adds t3 to the join.
+    const t3 = "00000000-0000-4000-8000-0000000000c3" as TagId;
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM item_tags")) {
+        return {
+          data: [
+            { item_id: itemId, tag_id: t1, tag_name: t1, color: null },
+            { item_id: itemId, tag_id: t2, tag_name: t2, color: null },
+            { item_id: itemId, tag_id: t3, tag_name: t3, color: null },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<CollectView />);
+
+    // User saves without touching the picker — selection still [t1, t2],
+    // original still [t1, t2] (locked-in seed). Diff must be empty: t3 is
+    // preserved by the delta-only mutation hook with no client emission.
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "Coin Vanish" })
+    );
+    expect(mockUpdateItem).toHaveBeenCalledWith(
+      itemId,
+      expect.any(Object),
+      [],
+      [],
+      [],
+      []
+    );
+  });
+
+  // (Test F) Add path is never gated — relationsLoading must be false even
+  // when joins are still loading, because handleAddItem seeds [] up front.
+  it("does not gate the Add path while joins are loading", async () => {
+    const { useQuery } = await import("@powersync/react");
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      isLoading: true,
+      isFetching: true,
+      error: undefined,
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+
+    expect(capturedFormSheetProps.open).toBe(true);
+    expect(capturedFormSheetProps.relationsLoading).toBe(false);
+    expect(capturedFormSheetProps.selectedTagIds).toEqual([]);
+    expect(capturedFormSheetProps.selectedTrickIds).toEqual([]);
+
+    // Submit while joins are still isLoading: true. The Add path is NOT
+    // gated, so createItem must run with empty link arrays. A regression
+    // that wraps the create branch in a relationsLoading guard would skip
+    // the call here and fail this assertion.
+    await capturedFormSheetProps.onSubmit?.(
+      makeFormValues({ name: "New Prop" })
+    );
+    expect(mockCreateItem).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "New Prop" }),
+      [],
+      []
+    );
+  });
+
   it("rethrows when createTag fails (TagPicker owns the toast)", async () => {
     const { useTagMutations } = await import(
       "@/features/repertoire/hooks/use-tag-mutations"

--- a/src/features/collect/components/collect-view.tsx
+++ b/src/features/collect/components/collect-view.tsx
@@ -101,21 +101,17 @@ export function CollectView(): React.ReactElement {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deletingItemId, setDeletingItemId] = useState<ItemId | null>(null);
 
-  // ---------------------------------------------------------------------------
-  // Tag selection (local state for the form, not persisted until save)
-  // ---------------------------------------------------------------------------
-  const [selectedTagIds, setSelectedTagIds] = useState<TagId[]>([]);
-
-  // ---------------------------------------------------------------------------
-  // Trick selection (local state for the form, not persisted until save)
-  // ---------------------------------------------------------------------------
-  const [selectedTrickIds, setSelectedTrickIds] = useState<TrickId[]>([]);
-
-  // Snapshot of tag/trick IDs captured when edit form opens (stable diff baseline).
-  // Known cold-start race — if PowerSync join hasn't hydrated at click time, this
-  // starts empty. Tracked in a follow-up issue.
-  const [originalTagIds, setOriginalTagIds] = useState<TagId[]>([]);
-  const [originalTrickIds, setOriginalTrickIds] = useState<TrickId[]>([]);
+  // Selection state. `null` = "edit session not yet seeded from hydrated joins";
+  // a seeding effect below populates these once the join queries finish loading.
+  // Add path bypasses the sentinel: handleAddItem seeds `[]` directly.
+  const [selectedTagIds, setSelectedTagIds] = useState<TagId[] | null>(null);
+  const [selectedTrickIds, setSelectedTrickIds] = useState<TrickId[] | null>(
+    null
+  );
+  const [originalTagIds, setOriginalTagIds] = useState<TagId[] | null>(null);
+  const [originalTrickIds, setOriginalTrickIds] = useState<TrickId[] | null>(
+    null
+  );
 
   // ---------------------------------------------------------------------------
   // Data hooks
@@ -127,7 +123,11 @@ export function CollectView(): React.ReactElement {
     sort,
   });
 
-  const { item: editingItem, error: editingItemError } = useItem(editingItemId);
+  const {
+    item: editingItem,
+    error: editingItemError,
+    isLoading: editingItemLoading,
+  } = useItem(editingItemId);
   const { tags } = useTags();
   const { createItem, updateItem, deleteItem } = useItemMutations();
   const { createTag } = useTagMutations();
@@ -138,7 +138,11 @@ export function CollectView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   // Item-tags join query (build a Map<itemId, ParsedTag[]>)
   // ---------------------------------------------------------------------------
-  const { data: itemTagRows, error: itemTagError } = useQuery<ItemTagRow>(
+  const {
+    data: itemTagRows,
+    error: itemTagError,
+    isLoading: itemTagsLoading,
+  } = useQuery<ItemTagRow>(
     `SELECT it.item_id, t.id AS tag_id, t.name AS tag_name, t.color
      FROM item_tags it
      JOIN tags t ON it.tag_id = t.id
@@ -150,7 +154,11 @@ export function CollectView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   // Item-tricks join query (build a Map<itemId, LinkedTrick[]>)
   // ---------------------------------------------------------------------------
-  const { data: itemTrickRows, error: itemTrickError } = useQuery<ItemTrickRow>(
+  const {
+    data: itemTrickRows,
+    error: itemTrickError,
+    isLoading: itemTricksLoading,
+  } = useQuery<ItemTrickRow>(
     `SELECT itr.item_id, tr.id AS trick_id, tr.name AS trick_name
      FROM item_tricks itr
      JOIN tricks tr ON itr.trick_id = tr.id
@@ -158,6 +166,18 @@ export function CollectView(): React.ReactElement {
   );
 
   const itemTrickMap = buildItemTrickMap(itemTrickRows);
+
+  // True while an Edit session is open and any of: the item row, the tag join,
+  // or the trick join is still hydrating from local SQLite. Gates Save (so a
+  // keyboard submit can't write empty diffs against a stale [] baseline) and
+  // swaps the pickers for skeletons. Add path is never gated because
+  // handleAddItem seeds the selection arrays to [] up front.
+  const relationsLoading =
+    editingItemId !== null &&
+    (itemTagsLoading ||
+      itemTricksLoading ||
+      editingItemLoading ||
+      selectedTagIds === null);
 
   // ---------------------------------------------------------------------------
   // Available tricks for the trick picker (only when form sheet is open)
@@ -198,12 +218,46 @@ export function CollectView(): React.ReactElement {
       });
       setSheetOpen(false);
       setEditingItemId(null);
-      setSelectedTagIds([]);
-      setSelectedTrickIds([]);
-      setOriginalTagIds([]);
-      setOriginalTrickIds([]);
+      setSelectedTagIds(null);
+      setSelectedTrickIds(null);
+      setOriginalTagIds(null);
+      setOriginalTrickIds(null);
     }
   }, [editingItemId, editingItemError, t]);
+
+  // ---------------------------------------------------------------------------
+  // Lock-in seeding for an Edit session.
+  // Runs once the row + both join queries have hydrated, copying the current
+  // join slice into selected*/original* via functional setState. The `prev ??`
+  // guard makes seeding idempotent: subsequent re-runs (e.g. when the join map
+  // updates from background sync) leave existing state alone, preserving any
+  // user edits while the sheet is open.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (editingItemId === null) {
+      return;
+    }
+    if (itemTagsLoading || itemTricksLoading || editingItemLoading) {
+      return;
+    }
+
+    const tagSeed = (itemTagMap.get(editingItemId) ?? []).map((tag) => tag.id);
+    setSelectedTagIds((prev) => prev ?? tagSeed);
+    setOriginalTagIds((prev) => prev ?? tagSeed);
+
+    const trickSeed = (itemTrickMap.get(editingItemId) ?? []).map(
+      (trick) => trick.id
+    );
+    setSelectedTrickIds((prev) => prev ?? trickSeed);
+    setOriginalTrickIds((prev) => prev ?? trickSeed);
+  }, [
+    editingItemId,
+    itemTagsLoading,
+    itemTricksLoading,
+    editingItemLoading,
+    itemTagMap,
+    itemTrickMap,
+  ]);
 
   // ---------------------------------------------------------------------------
   // Surface critical query errors as a single, replaceable toast.
@@ -254,17 +308,33 @@ export function CollectView(): React.ReactElement {
       ? null
       : (items.find((item) => item.id === deletingItemId)?.name ?? null);
 
-  // Whether the tag selection has diverged from the snapshot (or is non-empty for new items)
-  const tagsDirty = editingItemId
-    ? selectedTagIds.length !== originalTagIds.length ||
-      selectedTagIds.some((id) => !originalTagIds.includes(id))
-    : selectedTagIds.length > 0;
+  // Whether the tag selection has diverged from the snapshot (or is non-empty for new items).
+  // While an edit session is still seeding (selected/original null), treat as not-dirty.
+  const tagsDirty = (() => {
+    if (editingItemId) {
+      if (selectedTagIds === null || originalTagIds === null) {
+        return false;
+      }
+      return (
+        selectedTagIds.length !== originalTagIds.length ||
+        selectedTagIds.some((id) => !originalTagIds.includes(id))
+      );
+    }
+    return selectedTagIds !== null && selectedTagIds.length > 0;
+  })();
 
-  // Whether the trick selection has diverged from the snapshot (or is non-empty for new items)
-  const tricksDirty = editingItemId
-    ? selectedTrickIds.length !== originalTrickIds.length ||
-      selectedTrickIds.some((id) => !originalTrickIds.includes(id))
-    : selectedTrickIds.length > 0;
+  const tricksDirty = (() => {
+    if (editingItemId) {
+      if (selectedTrickIds === null || originalTrickIds === null) {
+        return false;
+      }
+      return (
+        selectedTrickIds.length !== originalTrickIds.length ||
+        selectedTrickIds.some((id) => !originalTrickIds.includes(id))
+      );
+    }
+    return selectedTrickIds !== null && selectedTrickIds.length > 0;
+  })();
 
   // ---------------------------------------------------------------------------
   // Handlers
@@ -280,21 +350,14 @@ export function CollectView(): React.ReactElement {
   }
 
   function handleEditItem(id: ItemId): void {
+    // Defer snapshotting until the seeding effect runs against fully-hydrated
+    // joins. Issue #216: snapshotting here read from a possibly-empty map and
+    // produced silent no-op or silent unlink-of-all on save.
     setEditingItemId(id);
-
-    // Snapshot the current tag/trick IDs as the diff baseline for this edit session.
-    // Cold-start race: if the PowerSync join hasn't hydrated yet, both snapshot and
-    // selection start as []. Tracked as a follow-up issue.
-    const currentTags = itemTagMap.get(id) ?? [];
-    const currentTagIds = currentTags.map((tag) => tag.id);
-    setSelectedTagIds(currentTagIds);
-    setOriginalTagIds(currentTagIds);
-
-    const currentTricks = itemTrickMap.get(id) ?? [];
-    const currentTrickIds = currentTricks.map((trick) => trick.id);
-    setSelectedTrickIds(currentTrickIds);
-    setOriginalTrickIds(currentTrickIds);
-
+    setSelectedTagIds(null);
+    setSelectedTrickIds(null);
+    setOriginalTagIds(null);
+    setOriginalTrickIds(null);
     setSheetOpen(true);
   }
 
@@ -302,16 +365,34 @@ export function CollectView(): React.ReactElement {
     setSheetOpen(open);
     if (!open) {
       setEditingItemId(null);
-      setSelectedTagIds([]);
-      setSelectedTrickIds([]);
-      setOriginalTagIds([]);
-      setOriginalTrickIds([]);
+      setSelectedTagIds(null);
+      setSelectedTrickIds(null);
+      setOriginalTagIds(null);
+      setOriginalTrickIds(null);
     }
   }
 
   async function handleSubmit(data: ItemFormValues): Promise<void> {
     try {
       if (editingItemId) {
+        // Defense-in-depth against keyboard submit before the seeding effect
+        // has hydrated state. The Save button is also disabled via
+        // relationsLoading, but a stray Enter press could still fire submit.
+        if (
+          selectedTagIds === null ||
+          originalTagIds === null ||
+          selectedTrickIds === null ||
+          originalTrickIds === null
+        ) {
+          // Defense-in-depth path. Save is gated via relationsLoading; this
+          // branch should be unreachable. The warn surfaces it in telemetry
+          // if a stray keyboard submit ever beats the gate.
+          console.warn(
+            "[CollectView] Submit blocked: relations not yet hydrated"
+          );
+          return;
+        }
+
         const originalTagSet = new Set(originalTagIds);
         const currentTagSet = new Set(selectedTagIds);
         const addTagIds = selectedTagIds.filter(
@@ -340,16 +421,18 @@ export function CollectView(): React.ReactElement {
         );
         toast.success(t("itemUpdated"));
       } else {
-        await createItem(data, selectedTagIds, selectedTrickIds);
+        // Add path: handleAddItem seeded both selection arrays to [],
+        // so the `?? []` is a type guard, not a runtime fallback.
+        await createItem(data, selectedTagIds ?? [], selectedTrickIds ?? []);
         toast.success(t("itemCreated"));
       }
 
       setSheetOpen(false);
       setEditingItemId(null);
-      setSelectedTagIds([]);
-      setSelectedTrickIds([]);
-      setOriginalTagIds([]);
-      setOriginalTrickIds([]);
+      setSelectedTagIds(null);
+      setSelectedTrickIds(null);
+      setOriginalTagIds(null);
+      setOriginalTrickIds(null);
     } catch (error) {
       console.error("Item save failed:", error);
       const errorKey = getMutationErrorKey(error);
@@ -402,11 +485,16 @@ export function CollectView(): React.ReactElement {
   }
 
   function handleToggleTag(tagId: TagId): void {
-    setSelectedTagIds((prev) =>
-      prev.includes(tagId)
+    setSelectedTagIds((prev) => {
+      if (prev === null) {
+        // Unreachable in normal flow — the picker is replaced by a skeleton
+        // while selection is null. Defensive against stray callbacks.
+        return prev;
+      }
+      return prev.includes(tagId)
         ? prev.filter((id) => id !== tagId)
-        : [...prev, tagId]
-    );
+        : [...prev, tagId];
+    });
   }
 
   async function handleCreateTag(name: string): Promise<TagId> {
@@ -421,11 +509,14 @@ export function CollectView(): React.ReactElement {
   }
 
   function handleToggleTrick(trickId: TrickId): void {
-    setSelectedTrickIds((prev) =>
-      prev.includes(trickId)
+    setSelectedTrickIds((prev) => {
+      if (prev === null) {
+        return prev;
+      }
+      return prev.includes(trickId)
         ? prev.filter((id) => id !== trickId)
-        : [...prev, trickId]
-    );
+        : [...prev, trickId];
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -517,8 +608,9 @@ export function CollectView(): React.ReactElement {
         onToggleTag={handleToggleTag}
         onToggleTrick={handleToggleTrick}
         open={sheetOpen}
-        selectedTagIds={selectedTagIds}
-        selectedTrickIds={selectedTrickIds}
+        relationsLoading={relationsLoading}
+        selectedTagIds={selectedTagIds ?? []}
+        selectedTrickIds={selectedTrickIds ?? []}
         tagsDirty={tagsDirty}
         tricksDirty={tricksDirty}
         userBrands={userBrands}

--- a/src/features/collect/components/item-form-sheet.tsx
+++ b/src/features/collect/components/item-form-sheet.tsx
@@ -40,6 +40,12 @@ interface ItemFormSheetProps {
   onToggleTag: (tagId: TagId) => void;
   onToggleTrick: (trickId: TrickId) => void;
   open: boolean;
+  /**
+   * True while an Edit session's row + tag/trick joins are still hydrating.
+   * Disables Save (so a keyboard submit cannot fire against an unseeded
+   * baseline) and renders skeletons in place of the pickers. Issue #216.
+   */
+  relationsLoading?: boolean;
   selectedTagIds: TagId[];
   selectedTrickIds: TrickId[];
   tagsDirty?: boolean;
@@ -81,6 +87,7 @@ function ItemFormSheet({
   onSubmit,
   userBrands,
   userLocations,
+  relationsLoading = false,
   tagsDirty = false,
   tricksDirty = false,
 }: ItemFormSheetProps): React.ReactElement {
@@ -159,6 +166,7 @@ function ItemFormSheet({
                 onSubmit={handleFormSubmit}
                 onToggleTag={onToggleTag}
                 onToggleTrick={onToggleTrick}
+                relationsLoading={relationsLoading}
                 selectedTagIds={selectedTagIds}
                 selectedTrickIds={selectedTrickIds}
                 userBrands={userBrands}
@@ -181,7 +189,12 @@ function ItemFormSheet({
             >
               {t("cancel")}
             </Button>
-            <Button disabled={isSubmitting} form={FORM_ID} type="submit">
+            <Button
+              aria-busy={isSubmitting || relationsLoading}
+              disabled={isSubmitting || relationsLoading}
+              form={FORM_ID}
+              type="submit"
+            >
               {t("save")}
             </Button>
           </SheetFooter>

--- a/src/features/collect/components/item-form.tsx
+++ b/src/features/collect/components/item-form.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import type { TagId, TrickId } from "@/db/types";
 import { CategoryCombobox } from "@/features/repertoire/components/category-combobox";
@@ -91,6 +92,11 @@ interface ItemFormProps {
   onSubmit: (data: ItemFormValues) => void;
   onToggleTag: (tagId: TagId) => void;
   onToggleTrick: (trickId: TrickId) => void;
+  /**
+   * True while the parent's tag/trick join queries are still hydrating during
+   * an Edit session. The pickers are replaced with skeletons. Issue #216.
+   */
+  relationsLoading?: boolean;
   selectedTagIds: TagId[];
   selectedTrickIds: TrickId[];
   userBrands: string[];
@@ -145,6 +151,7 @@ function ItemForm({
   availableTricks,
   onToggleTrick,
   onDirtyChange,
+  relationsLoading = false,
   userBrands,
   userLocations,
 }: ItemFormProps): React.ReactElement {
@@ -184,6 +191,7 @@ function ItemForm({
   return (
     <Form {...form}>
       <form
+        aria-busy={relationsLoading}
         className="flex flex-col gap-4"
         id={formId}
         onSubmit={form.handleSubmit(onSubmit)}
@@ -469,44 +477,77 @@ function ItemForm({
         >
           <div className="flex flex-col gap-4 px-2 pb-2">
             <fieldset
-              aria-describedby="tags-limit-help"
+              aria-busy={relationsLoading}
+              aria-describedby={
+                relationsLoading ? undefined : "tags-limit-help"
+              }
               className="grid gap-2 border-none p-0"
             >
               <legend className="font-medium text-sm">{t("field.tags")}</legend>
-              <TagPicker
-                availableTags={availableTags}
-                maxTags={MAX_TAGS_PER_ITEM}
-                onCreateTag={onCreateTag}
-                onToggleTag={onToggleTag}
-                selectedTagIds={selectedTagIds}
-                translationNamespace="collect"
-              />
-              <p className="text-muted-foreground text-xs" id="tags-limit-help">
-                {selectedTagIds.length}/{MAX_TAGS_PER_ITEM}{" "}
-                {t("field.tags").toLowerCase()}
-              </p>
+              {relationsLoading ? (
+                <>
+                  <Skeleton
+                    aria-label={t("tagPicker.loading")}
+                    className="h-11 w-full"
+                  />
+                  <Skeleton className="h-3 w-20" />
+                </>
+              ) : (
+                <>
+                  <TagPicker
+                    availableTags={availableTags}
+                    maxTags={MAX_TAGS_PER_ITEM}
+                    onCreateTag={onCreateTag}
+                    onToggleTag={onToggleTag}
+                    selectedTagIds={selectedTagIds}
+                    translationNamespace="collect"
+                  />
+                  <p
+                    className="text-muted-foreground text-xs"
+                    id="tags-limit-help"
+                  >
+                    {selectedTagIds.length}/{MAX_TAGS_PER_ITEM}{" "}
+                    {t("field.tags").toLowerCase()}
+                  </p>
+                </>
+              )}
             </fieldset>
 
             <fieldset
-              aria-describedby="tricks-limit-help"
+              aria-busy={relationsLoading}
+              aria-describedby={
+                relationsLoading ? undefined : "tricks-limit-help"
+              }
               className="grid gap-2 border-none p-0"
             >
               <legend className="font-medium text-sm">
                 {t("field.linkedTricks")}
               </legend>
-              <TrickPicker
-                availableTricks={availableTricks}
-                maxTricks={MAX_TRICKS_PER_ITEM}
-                onToggleTrick={onToggleTrick}
-                selectedTrickIds={selectedTrickIds}
-              />
-              <p
-                className="text-muted-foreground text-xs"
-                id="tricks-limit-help"
-              >
-                {selectedTrickIds.length}/{MAX_TRICKS_PER_ITEM}{" "}
-                {t("field.linkedTricks").toLowerCase()}
-              </p>
+              {relationsLoading ? (
+                <>
+                  <Skeleton
+                    aria-label={t("trickPicker.loading")}
+                    className="h-11 w-full"
+                  />
+                  <Skeleton className="h-3 w-20" />
+                </>
+              ) : (
+                <>
+                  <TrickPicker
+                    availableTricks={availableTricks}
+                    maxTricks={MAX_TRICKS_PER_ITEM}
+                    onToggleTrick={onToggleTrick}
+                    selectedTrickIds={selectedTrickIds}
+                  />
+                  <p
+                    className="text-muted-foreground text-xs"
+                    id="tricks-limit-help"
+                  >
+                    {selectedTrickIds.length}/{MAX_TRICKS_PER_ITEM}{" "}
+                    {t("field.linkedTricks").toLowerCase()}
+                  </p>
+                </>
+              )}
             </fieldset>
 
             <FormField

--- a/src/features/repertoire/components/repertoire-view.test.tsx
+++ b/src/features/repertoire/components/repertoire-view.test.tsx
@@ -53,7 +53,7 @@ vi.mock("../hooks/use-tricks", () => ({
 }));
 
 vi.mock("../hooks/use-trick", () => ({
-  useTrick: vi.fn(() => ({ trick: null, isLoading: false })),
+  useTrick: vi.fn(() => ({ trick: null, isLoading: false, error: null })),
 }));
 
 vi.mock("../hooks/use-tags", () => ({
@@ -70,6 +70,9 @@ vi.mock("../hooks/use-trick-mutations", () => ({
     updateTrick: mockUpdateTrick,
     deleteTrick: mockDeleteTrick,
   })),
+  // Real implementation is `null` for non-typed errors and an i18n key for
+  // typed mutation errors. Tests reject with plain Error so null is correct.
+  getMutationErrorKey: vi.fn(() => null),
 }));
 
 vi.mock("../hooks/use-tag-mutations", () => ({
@@ -209,7 +212,11 @@ afterEach(async () => {
     error: null,
     isLoading: false,
   });
-  vi.mocked(useTrick).mockReturnValue({ trick: null, isLoading: false });
+  vi.mocked(useTrick).mockReturnValue({
+    trick: null,
+    isLoading: false,
+    error: null,
+  });
 
   // Restore mutation mock defaults (clearAllMocks strips implementations)
   mockCreateTrick.mockResolvedValue("new-trick-id");
@@ -464,6 +471,7 @@ describe("RepertoireView", () => {
     vi.mocked(useTrick).mockReturnValue({
       trick: makeTrick("trick-upd-1", "Silk Vanish"),
       isLoading: false,
+      error: null,
     });
 
     render(<RepertoireView />);
@@ -552,6 +560,7 @@ describe("RepertoireView", () => {
     vi.mocked(useTrick).mockReturnValue({
       trick: makeTrick("trick-tags-1", "Tagged Trick"),
       isLoading: false,
+      error: null,
     });
 
     render(<RepertoireView />);
@@ -758,6 +767,7 @@ describe("RepertoireView", () => {
     vi.mocked(useTrick).mockReturnValue({
       trick: makeTrick("trick-fail-upd", "Coin Warp"),
       isLoading: false,
+      error: null,
     });
     mockUpdateTrick.mockRejectedValueOnce(new Error("update failed"));
 
@@ -789,5 +799,346 @@ describe("RepertoireView", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("repertoire.saveFailed");
     });
+  });
+
+  it("routes typed save errors through getMutationErrorKey to a specific toast", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const { getMutationErrorKey } = await import(
+      "../hooks/use-trick-mutations"
+    );
+
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [makeTrick("trick-typed-err", "Vanishing Coin")],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick: makeTrick("trick-typed-err", "Vanishing Coin"),
+      isLoading: false,
+      error: null,
+    });
+
+    const typedError = new Error("trick missing — typed");
+    mockUpdateTrick.mockRejectedValueOnce(typedError);
+    vi.mocked(getMutationErrorKey).mockReturnValueOnce("errors.trickMissing");
+
+    render(<RepertoireView />);
+    await userEvent.click(screen.getByTestId("edit-trick-typed-err"));
+
+    await capturedFormSheetProps.onSubmit?.(
+      makeTrickFormValues({ name: "Vanishing Coin" })
+    );
+
+    expect(getMutationErrorKey).toHaveBeenCalledWith(typedError);
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "repertoire.errors.trickMissing"
+      );
+    });
+    // Generic fallback must not also fire when typed error is mapped.
+    expect(toast.error).not.toHaveBeenCalledWith("repertoire.saveFailed");
+  });
+
+  it("routes typed delete errors through getMutationErrorKey to a specific toast", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { getMutationErrorKey } = await import(
+      "../hooks/use-trick-mutations"
+    );
+
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [makeTrick("trick-typed-del", "Linking Rings")],
+      error: null,
+      isLoading: false,
+    });
+
+    const typedError = new Error("trick missing — typed");
+    mockDeleteTrick.mockRejectedValueOnce(typedError);
+    vi.mocked(getMutationErrorKey).mockReturnValueOnce("errors.trickMissing");
+
+    render(<RepertoireView />);
+    await userEvent.click(screen.getByTestId("delete-trick-typed-del"));
+    await userEvent.click(screen.getByTestId("confirm-delete"));
+
+    expect(getMutationErrorKey).toHaveBeenCalledWith(typedError);
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "repertoire.errors.trickMissing"
+      );
+    });
+    expect(toast.error).not.toHaveBeenCalledWith("repertoire.deleteFailed");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #216 — hydration-race regression coverage
+  // ---------------------------------------------------------------------------
+
+  // Helper for the trick-form's submit signature.
+  const makeTrickFormValues = (overrides: Record<string, unknown> = {}) =>
+    ({
+      name: "Test",
+      status: "new",
+      description: "",
+      category: "",
+      effectType: "",
+      difficulty: null,
+      duration: null,
+      performanceType: null,
+      angleSensitivity: null,
+      props: "",
+      music: "",
+      languages: [],
+      isCameraFriendly: null,
+      isSilent: null,
+      source: "",
+      videoUrl: "",
+      notes: "",
+      ...overrides,
+    }) as Parameters<NonNullable<TrickFormSheetProps["onSubmit"]>>[0];
+
+  // (Test B) Mirror of collect-view's headline regression — when Edit is
+  // clicked before trick_tags hydrates, the form sheet is gated and seeding
+  // waits. After hydration, saving without changes emits an empty diff.
+  it("seeds tag selection from hydrated trick_tags and never emits a stale diff (issue #216)", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const { useQuery } = await import("@powersync/react");
+
+    const trickId = "trick-216-headline";
+    const trick = makeTrick(trickId, "Twirling Cane");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [trick],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick,
+      isLoading: false,
+      error: null,
+    });
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      isLoading: true,
+      isFetching: true,
+      error: undefined,
+    });
+
+    const { rerender } = render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+    expect(capturedFormSheetProps.open).toBe(true);
+    expect(capturedFormSheetProps.relationsLoading).toBe(true);
+    expect(capturedFormSheetProps.selectedTagIds).toEqual([]);
+
+    // Defense-in-depth: keyboard submit while seeding must not call updateTrick.
+    await capturedFormSheetProps.onSubmit?.(
+      makeTrickFormValues({ name: "Twirling Cane" })
+    );
+    expect(mockUpdateTrick).not.toHaveBeenCalled();
+
+    // Hydrate the join.
+    const t1 = "tag-216-a" as TagId;
+    const t2 = "tag-216-b" as TagId;
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM trick_tags")) {
+        return {
+          data: [
+            { trick_id: trickId, tag_id: t1, tag_name: "A", color: null },
+            { trick_id: trickId, tag_id: t2, tag_name: "B", color: null },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<RepertoireView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.relationsLoading).toBe(false);
+      expect(capturedFormSheetProps.selectedTagIds).toEqual([t1, t2]);
+    });
+    // Post-seed selected === original, so tagsDirty stays false (no false-
+    // positive discard dialog).
+    expect(capturedFormSheetProps.tagsDirty).toBe(false);
+
+    await capturedFormSheetProps.onSubmit?.(
+      makeTrickFormValues({ name: "Twirling Cane" })
+    );
+    expect(mockUpdateTrick).toHaveBeenCalledWith(
+      trickId,
+      expect.any(Object),
+      [],
+      []
+    );
+  });
+
+  // (Test C) Repertoire counterpart of "reopen mid-load".
+  it("re-seeds cleanly when Edit is reopened after closing mid-load (repertoire)", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const { useQuery } = await import("@powersync/react");
+
+    const trickId = "trick-reopen";
+    const trick = makeTrick(trickId, "Floating Bill");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [trick],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick,
+      isLoading: false,
+      error: null,
+    });
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      isLoading: true,
+      isFetching: true,
+      error: undefined,
+    });
+
+    const { rerender } = render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+    expect(capturedFormSheetProps.relationsLoading).toBe(true);
+
+    act(() => {
+      capturedFormSheetProps.onOpenChange?.(false);
+    });
+    expect(capturedFormSheetProps.open).toBe(false);
+
+    const t1 = "tag-reopen-a" as TagId;
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM trick_tags")) {
+        return {
+          data: [{ trick_id: trickId, tag_id: t1, tag_name: "A", color: null }],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+    await waitFor(() => {
+      expect(capturedFormSheetProps.relationsLoading).toBe(false);
+      expect(capturedFormSheetProps.selectedTagIds).toEqual([t1]);
+    });
+
+    // Submit with no further interaction → diff must be empty. A regression
+    // where `selected` re-seeds but `original` stays stale at [] (or vice
+    // versa) would compute a phantom remove/add here and fail this assertion.
+    await capturedFormSheetProps.onSubmit?.(
+      makeTrickFormValues({ name: "Floating Bill" })
+    );
+    expect(mockUpdateTrick).toHaveBeenCalledWith(
+      trickId,
+      expect.any(Object),
+      [],
+      []
+    );
+  });
+
+  // (Test E) Background-sync mid-edit — phantom-diff prevention.
+  it("does not emit phantom tag diffs when trick_tags updates from background sync", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const { useQuery } = await import("@powersync/react");
+
+    const trickId = "trick-bg-sync";
+    const trick = makeTrick(trickId, "Linking Coins");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [trick],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick,
+      isLoading: false,
+      error: null,
+    });
+
+    const t1 = "tag-bg-a" as TagId;
+    const t2 = "tag-bg-b" as TagId;
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM trick_tags")) {
+        return {
+          data: [
+            { trick_id: trickId, tag_id: t1, tag_name: "A", color: null },
+            { trick_id: trickId, tag_id: t2, tag_name: "B", color: null },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    const { rerender } = render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+    await waitFor(() => {
+      expect(capturedFormSheetProps.selectedTagIds).toEqual([t1, t2]);
+    });
+
+    // Background sync adds t3.
+    const t3 = "tag-bg-c" as TagId;
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (typeof sql === "string" && sql.includes("FROM trick_tags")) {
+        return {
+          data: [
+            { trick_id: trickId, tag_id: t1, tag_name: "A", color: null },
+            { trick_id: trickId, tag_id: t2, tag_name: "B", color: null },
+            { trick_id: trickId, tag_id: t3, tag_name: "C", color: null },
+          ],
+          isLoading: false,
+          isFetching: false,
+          error: undefined,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<RepertoireView />);
+
+    // Save with no user-side changes — diff stays empty, t3 is preserved
+    // by the delta-only mutation hook.
+    await capturedFormSheetProps.onSubmit?.(
+      makeTrickFormValues({ name: "Linking Coins" })
+    );
+    expect(mockUpdateTrick).toHaveBeenCalledWith(
+      trickId,
+      expect.any(Object),
+      [],
+      []
+    );
   });
 });

--- a/src/features/repertoire/components/repertoire-view.tsx
+++ b/src/features/repertoire/components/repertoire-view.tsx
@@ -12,7 +12,10 @@ import { useTags } from "../hooks/use-tags";
 import { useTrick } from "../hooks/use-trick";
 import { useTrickCategories } from "../hooks/use-trick-categories";
 import { useTrickEffectTypes } from "../hooks/use-trick-effect-types";
-import { useTrickMutations } from "../hooks/use-trick-mutations";
+import {
+  getMutationErrorKey,
+  useTrickMutations,
+} from "../hooks/use-trick-mutations";
 import { useTricks } from "../hooks/use-tricks";
 import type { TrickFormValues } from "../schema";
 import type { ParsedTag, TrickWithTags } from "../types";
@@ -66,6 +69,9 @@ interface TrickItemRow {
 /** Debounce delay for the search input (milliseconds). */
 const SEARCH_DEBOUNCE_MS = 300;
 
+/** Stable toast id for the editing-trick load error (separate so it doesn't clobber the relations toast). */
+const LOAD_EDIT_TRICK_ERROR_TOAST_ID = "repertoire-load-edit-trick-error";
+
 /**
  * Main orchestration component for the repertoire feature.
  *
@@ -107,10 +113,12 @@ export function RepertoireView(): React.ReactElement {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deletingTrickId, setDeletingTrickId] = useState<TrickId | null>(null);
 
-  // ---------------------------------------------------------------------------
-  // Tag selection (local state for the form, not persisted until save)
-  // ---------------------------------------------------------------------------
-  const [selectedTagIds, setSelectedTagIds] = useState<TagId[]>([]);
+  // Tag selection state. `null` = "edit session not yet seeded from hydrated
+  // joins" — the seeding effect below populates these once the trick row +
+  // trick_tags query finish loading. Add path bypasses the sentinel:
+  // handleAddTrick seeds `[]` directly. Issue #216.
+  const [selectedTagIds, setSelectedTagIds] = useState<TagId[] | null>(null);
+  const [originalTagIds, setOriginalTagIds] = useState<TagId[] | null>(null);
 
   // ---------------------------------------------------------------------------
   // Data hooks
@@ -122,7 +130,11 @@ export function RepertoireView(): React.ReactElement {
     sort: SORT_MAP[sort],
   });
 
-  const { trick: editingTrick } = useTrick(editingTrickId);
+  const {
+    trick: editingTrick,
+    error: editingTrickError,
+    isLoading: editingTrickLoading,
+  } = useTrick(editingTrickId);
   const { tags } = useTags();
   const { createTrick, updateTrick, deleteTrick } = useTrickMutations();
   const { createTag } = useTagMutations();
@@ -132,7 +144,11 @@ export function RepertoireView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   // Trick-tags join query (build a Map<trickId, ParsedTag[]>)
   // ---------------------------------------------------------------------------
-  const { data: trickTagRows, error: trickTagError } = useQuery<TrickTagRow>(
+  const {
+    data: trickTagRows,
+    error: trickTagError,
+    isLoading: trickTagsLoading,
+  } = useQuery<TrickTagRow>(
     `SELECT tt.trick_id, t.id AS tag_id, t.name AS tag_name, t.color
      FROM trick_tags tt
      JOIN tags t ON tt.tag_id = t.id
@@ -140,6 +156,15 @@ export function RepertoireView(): React.ReactElement {
   );
 
   const trickTagMap = buildTrickTagMap(trickTagRows);
+
+  // True while an Edit session is open and the trick row or trick_tags join
+  // is still hydrating. Gates Save (so a keyboard submit can't write empty
+  // diffs against a stale [] baseline) and swaps the picker for a skeleton.
+  // Add path is never gated because handleAddTrick seeds the selection arrays
+  // up front. Issue #216.
+  const relationsLoading =
+    editingTrickId !== null &&
+    (trickTagsLoading || editingTrickLoading || selectedTagIds === null);
 
   // ---------------------------------------------------------------------------
   // Trick-items join query (build a Map<trickId, LinkedItem[]>)
@@ -159,6 +184,24 @@ export function RepertoireView(): React.ReactElement {
     }
   }, [trickTagError, trickItemError, t]);
 
+  // ---------------------------------------------------------------------------
+  // Editing trick load failure — close the sheet rather than render "add new"
+  // (mirrors collect-view's editingItemError handler).
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (editingTrickId && editingTrickError) {
+      console.error("Failed to load trick for editing:", editingTrickError);
+      // Do NOT pass error.message as description — PowerSync/SQLite messages
+      // can carry row context or query fragments. Full error already in
+      // console.error above for developer diagnostics.
+      toast.error(t("loadError"), { id: LOAD_EDIT_TRICK_ERROR_TOAST_ID });
+      setSheetOpen(false);
+      setEditingTrickId(null);
+      setSelectedTagIds(null);
+      setOriginalTagIds(null);
+    }
+  }, [editingTrickId, editingTrickError, t]);
+
   const trickItemMap = buildTrickItemMap(trickItemRows);
 
   const tricksWithTags: TrickWithTags[] = tricks.map((trick) => ({
@@ -172,16 +215,39 @@ export function RepertoireView(): React.ReactElement {
       ? null
       : (tricks.find((trick) => trick.id === deletingTrickId)?.name ?? null);
 
-  // Original tag IDs for the trick being edited (used to compute diff on save)
-  const editingTrickOriginalTagIds = editingTrickId
-    ? (trickTagMap.get(editingTrickId) ?? []).map((tag) => tag.id)
-    : ([] as TagId[]);
+  // Lock-in seeding for an Edit session.
+  // Runs once the trick row and trick_tags join have hydrated, copying the
+  // current join slice into selected/original via functional setState. The
+  // `prev ??` guard makes seeding idempotent: subsequent re-runs (e.g. when
+  // the join map updates from background sync) leave existing state alone,
+  // preserving any user edits while the sheet is open.
+  useEffect(() => {
+    if (editingTrickId === null) {
+      return;
+    }
+    if (trickTagsLoading || editingTrickLoading) {
+      return;
+    }
 
-  // Whether the tag selection has diverged from the original (or is non-empty for new tricks)
-  const tagsDirty = editingTrickId
-    ? selectedTagIds.length !== editingTrickOriginalTagIds.length ||
-      selectedTagIds.some((id) => !editingTrickOriginalTagIds.includes(id))
-    : selectedTagIds.length > 0;
+    const seed = (trickTagMap.get(editingTrickId) ?? []).map((tag) => tag.id);
+    setSelectedTagIds((prev) => prev ?? seed);
+    setOriginalTagIds((prev) => prev ?? seed);
+  }, [editingTrickId, trickTagsLoading, editingTrickLoading, trickTagMap]);
+
+  // Whether the tag selection has diverged from the snapshot (or is non-empty
+  // for new tricks). While an edit session is still seeding, treat as not-dirty.
+  const tagsDirty = (() => {
+    if (editingTrickId) {
+      if (selectedTagIds === null || originalTagIds === null) {
+        return false;
+      }
+      return (
+        selectedTagIds.length !== originalTagIds.length ||
+        selectedTagIds.some((id) => !originalTagIds.includes(id))
+      );
+    }
+    return selectedTagIds !== null && selectedTagIds.length > 0;
+  })();
 
   // ---------------------------------------------------------------------------
   // Handlers
@@ -190,16 +256,17 @@ export function RepertoireView(): React.ReactElement {
   function handleAddTrick(): void {
     setEditingTrickId(null);
     setSelectedTagIds([]);
+    setOriginalTagIds([]);
     setSheetOpen(true);
   }
 
   function handleEditTrick(id: TrickId): void {
+    // Defer snapshotting until the seeding effect runs against fully-hydrated
+    // joins. Issue #216: snapshotting here read from a possibly-empty map and
+    // produced a silent unlink window if the user clicked Save very fast.
     setEditingTrickId(id);
-
-    // Preload the current tag selection for this trick
-    const currentTags = trickTagMap.get(id) ?? [];
-    setSelectedTagIds(currentTags.map((tag) => tag.id));
-
+    setSelectedTagIds(null);
+    setOriginalTagIds(null);
     setSheetOpen(true);
   }
 
@@ -207,34 +274,53 @@ export function RepertoireView(): React.ReactElement {
     setSheetOpen(open);
     if (!open) {
       setEditingTrickId(null);
-      setSelectedTagIds([]);
+      setSelectedTagIds(null);
+      setOriginalTagIds(null);
     }
   }
 
   async function handleSubmit(data: TrickFormValues): Promise<void> {
     try {
       if (editingTrickId) {
-        const originalSet = new Set(editingTrickOriginalTagIds);
+        // Defense-in-depth against keyboard submit before the seeding effect
+        // has hydrated state. Save is also disabled via relationsLoading.
+        if (selectedTagIds === null || originalTagIds === null) {
+          // Defense-in-depth path. Save is gated via relationsLoading; this
+          // branch should be unreachable. The warn surfaces it in telemetry
+          // if a stray keyboard submit ever beats the gate.
+          console.warn(
+            "[RepertoireView] Submit blocked: relations not yet hydrated"
+          );
+          return;
+        }
+
+        const originalSet = new Set(originalTagIds);
         const currentSet = new Set(selectedTagIds);
 
         const addTagIds = selectedTagIds.filter((id) => !originalSet.has(id));
-        const removeTagIds = editingTrickOriginalTagIds.filter(
-          (id) => !currentSet.has(id)
-        );
+        const removeTagIds = originalTagIds.filter((id) => !currentSet.has(id));
 
         await updateTrick(editingTrickId, data, addTagIds, removeTagIds);
         toast.success(t("trickUpdated"));
       } else {
-        await createTrick(data, selectedTagIds);
+        // Add path: handleAddTrick seeded selectedTagIds to [],
+        // so the `?? []` is a type guard, not a runtime fallback.
+        await createTrick(data, selectedTagIds ?? []);
         toast.success(t("trickCreated"));
       }
 
       setSheetOpen(false);
       setEditingTrickId(null);
-      setSelectedTagIds([]);
+      setSelectedTagIds(null);
+      setOriginalTagIds(null);
     } catch (error) {
       console.error("Failed to save trick:", error);
-      toast.error(t("saveFailed"));
+      const errorKey = getMutationErrorKey(error);
+      if (errorKey) {
+        toast.error(t(errorKey));
+      } else {
+        toast.error(t("saveFailed"));
+      }
     }
   }
 
@@ -253,7 +339,12 @@ export function RepertoireView(): React.ReactElement {
       toast.success(t("trickDeleted"));
     } catch (error) {
       console.error("Failed to delete trick:", error);
-      toast.error(t("deleteFailed"));
+      const errorKey = getMutationErrorKey(error);
+      if (errorKey) {
+        toast.error(t(errorKey));
+      } else {
+        toast.error(t("deleteFailed"));
+      }
     } finally {
       setDeleteDialogOpen(false);
       setDeletingTrickId(null);
@@ -268,11 +359,16 @@ export function RepertoireView(): React.ReactElement {
   }
 
   function handleToggleTag(tagId: TagId): void {
-    setSelectedTagIds((prev) =>
-      prev.includes(tagId)
+    setSelectedTagIds((prev) => {
+      if (prev === null) {
+        // Unreachable in normal flow — the picker is replaced by a skeleton
+        // while selection is null. Defensive against stray callbacks.
+        return prev;
+      }
+      return prev.includes(tagId)
         ? prev.filter((id) => id !== tagId)
-        : [...prev, tagId]
-    );
+        : [...prev, tagId];
+    });
   }
 
   function handleCreateTag(name: string): Promise<TagId> {
@@ -364,7 +460,8 @@ export function RepertoireView(): React.ReactElement {
         onSubmit={handleSubmit}
         onToggleTag={handleToggleTag}
         open={sheetOpen}
-        selectedTagIds={selectedTagIds}
+        relationsLoading={relationsLoading}
+        selectedTagIds={selectedTagIds ?? []}
         tagsDirty={tagsDirty}
         trick={editingTrick}
       />

--- a/src/features/repertoire/components/trick-form-sheet.tsx
+++ b/src/features/repertoire/components/trick-form-sheet.tsx
@@ -28,6 +28,12 @@ interface TrickFormSheetProps {
   onSubmit: (data: TrickFormValues) => void;
   onToggleTag: (tagId: TagId) => void;
   open: boolean;
+  /**
+   * True while an Edit session's trick row + tag join are still hydrating.
+   * Disables Save (so a keyboard submit cannot fire against an unseeded
+   * baseline) and renders a skeleton in place of the picker. Issue #216.
+   */
+  relationsLoading?: boolean;
   selectedTagIds: TagId[];
   submitting?: boolean;
   tagsDirty?: boolean;
@@ -68,6 +74,7 @@ function TrickFormSheet({
   onSubmit,
   categories,
   effectTypes,
+  relationsLoading = false,
   submitting = false,
   tagsDirty = false,
 }: TrickFormSheetProps): React.ReactElement {
@@ -110,6 +117,7 @@ function TrickFormSheet({
               onDirtyChange={setFormDirty}
               onSubmit={onSubmit}
               onToggleTag={onToggleTag}
+              relationsLoading={relationsLoading}
               selectedTagIds={selectedTagIds}
               userCategories={categories}
               userEffectTypes={effectTypes}
@@ -131,7 +139,12 @@ function TrickFormSheet({
           >
             {t("cancel")}
           </Button>
-          <Button disabled={submitting} form={FORM_ID} type="submit">
+          <Button
+            aria-busy={submitting || relationsLoading}
+            disabled={submitting || relationsLoading}
+            form={FORM_ID}
+            type="submit"
+          >
             {t("save")}
           </Button>
         </SheetFooter>

--- a/src/features/repertoire/components/trick-form.tsx
+++ b/src/features/repertoire/components/trick-form.tsx
@@ -24,6 +24,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import type { TagId } from "@/db/types";
@@ -84,6 +85,11 @@ interface TrickFormProps {
   onDirtyChange?: (dirty: boolean) => void;
   onSubmit: (data: TrickFormValues) => void;
   onToggleTag: (tagId: TagId) => void;
+  /**
+   * True while the parent's tag join is still hydrating during an Edit
+   * session. The picker is replaced with a skeleton. Issue #216.
+   */
+  relationsLoading?: boolean;
   selectedTagIds: TagId[];
   userCategories: string[];
   userEffectTypes: string[];
@@ -145,6 +151,7 @@ function TrickForm({
   onToggleTag,
   onCreateTag,
   onDirtyChange,
+  relationsLoading = false,
   userCategories,
   userEffectTypes,
 }: TrickFormProps): React.ReactElement {
@@ -185,6 +192,7 @@ function TrickForm({
   return (
     <Form {...form}>
       <form
+        aria-busy={relationsLoading}
         className="flex flex-col gap-4"
         id={formId}
         onSubmit={form.handleSubmit(onSubmit)}
@@ -541,15 +549,25 @@ function TrickForm({
           title={t("section.organization")}
         >
           <div className="flex flex-col gap-4 px-2 pb-2">
-            <fieldset className="grid gap-2 border-none p-0">
+            <fieldset
+              aria-busy={relationsLoading}
+              className="grid gap-2 border-none p-0"
+            >
               <legend className="font-medium text-sm">{t("field.tags")}</legend>
-              <TagPicker
-                availableTags={availableTags}
-                maxTags={MAX_TAGS_PER_TRICK}
-                onCreateTag={onCreateTag}
-                onToggleTag={onToggleTag}
-                selectedTagIds={selectedTagIds}
-              />
+              {relationsLoading ? (
+                <Skeleton
+                  aria-label={t("tagPicker.loading")}
+                  className="h-11 w-full"
+                />
+              ) : (
+                <TagPicker
+                  availableTags={availableTags}
+                  maxTags={MAX_TAGS_PER_TRICK}
+                  onCreateTag={onCreateTag}
+                  onToggleTag={onToggleTag}
+                  selectedTagIds={selectedTagIds}
+                />
+              )}
             </fieldset>
 
             <FormField

--- a/src/features/repertoire/hooks/use-trick-mutations.test.ts
+++ b/src/features/repertoire/hooks/use-trick-mutations.test.ts
@@ -7,7 +7,10 @@ const tagId = (id: string) => id as TagId;
 
 // --- Mocks -----------------------------------------------------------
 
-const mockExecute = vi.fn().mockResolvedValue({ rowsAffected: 0 });
+// Default is rowsAffected: 1 because updateTrick now throws TrickNotFoundError
+// when its UPDATE matches no rows. Tests that need a different value override
+// per-call via mockResolvedValueOnce.
+const mockExecute = vi.fn().mockResolvedValue({ rowsAffected: 1 });
 const mockWriteTransaction = vi.fn(
   async (cb: (tx: { execute: typeof mockExecute }) => Promise<void>) => {
     await cb({ execute: mockExecute });
@@ -743,9 +746,10 @@ describe("use-trick-mutations", () => {
     });
 
     it("restores soft-deleted tag association instead of inserting", async () => {
-      // When the restore UPDATE affects a row, no INSERT should follow
+      // When the restore UPDATE affects a row, no INSERT should follow.
+      // Trick UPDATE must return rowsAffected: 1 (otherwise TrickNotFoundError).
       mockExecute
-        .mockResolvedValueOnce({ rowsAffected: 0 }) // trick UPDATE
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // trick UPDATE
         .mockResolvedValueOnce({ rowsAffected: 1 }); // restore UPDATE hits a row
 
       const { useTrickMutations } = await getHookExports();
@@ -785,6 +789,12 @@ describe("use-trick-mutations", () => {
     });
 
     it("inserts new tag associations", async () => {
+      // Trick UPDATE returns 1 (row matched). Restore UPDATE returns 0 so the
+      // INSERT branch fires.
+      mockExecute
+        .mockResolvedValueOnce({ rowsAffected: 1 }) // trick UPDATE
+        .mockResolvedValueOnce({ rowsAffected: 0 }); // restore UPDATE — no row to restore
+
       const { useTrickMutations } = await getHookExports();
       const { updateTrick } = useTrickMutations();
 
@@ -887,6 +897,44 @@ describe("use-trick-mutations", () => {
           []
         )
       ).rejects.toThrow("Failed to update trick: DB locked");
+    });
+
+    it("throws TrickNotFoundError when the UPDATE matches no rows", async () => {
+      // The trick UPDATE returns rowsAffected: 0 — row was deleted upstream
+      // or never existed. The new guard at use-trick-mutations.ts should
+      // surface this as a typed error so the UI can route through
+      // getMutationErrorKey to a localised toast.
+      mockExecute.mockResolvedValueOnce({ rowsAffected: 0 });
+
+      const { useTrickMutations, TrickNotFoundError } = await getHookExports();
+      const { updateTrick } = useTrickMutations();
+
+      await expect(
+        updateTrick(
+          trickId("trick-missing"),
+          {
+            name: "Trick",
+            description: "",
+            category: "",
+            effectType: "",
+            difficulty: null,
+            status: "new",
+            duration: null,
+            performanceType: null,
+            angleSensitivity: null,
+            props: "",
+            music: "",
+            languages: [],
+            isCameraFriendly: null,
+            isSilent: null,
+            notes: "",
+            source: "",
+            videoUrl: "",
+          },
+          [],
+          []
+        )
+      ).rejects.toBeInstanceOf(TrickNotFoundError);
     });
 
     it("throws when no authenticated user", async () => {
@@ -1072,6 +1120,25 @@ describe("use-trick-mutations", () => {
       expect(trackEvent).toHaveBeenCalledWith("trick_deleted");
     });
 
+    it("throws TrickNotFoundError when soft-delete matches no rows", async () => {
+      // SELECT name returns a row, but the UPDATE that soft-deletes the
+      // trick reports rowsAffected: 0 — race with another deleter or stale
+      // id from the UI. The typed error lets the UI surface a specific toast.
+      mockExecute
+        .mockResolvedValueOnce({
+          rowsAffected: 1,
+          rows: { item: () => ({ name: "Snapshot Name" }), length: 1 },
+        }) // SELECT name
+        .mockResolvedValueOnce({ rowsAffected: 0 }); // UPDATE tricks (soft-delete)
+
+      const { useTrickMutations, TrickNotFoundError } = await getHookExports();
+      const { deleteTrick } = useTrickMutations();
+
+      await expect(
+        deleteTrick(trickId("trick-already-gone"))
+      ).rejects.toBeInstanceOf(TrickNotFoundError);
+    });
+
     it("wraps execution errors with descriptive message", async () => {
       mockExecute.mockRejectedValueOnce(new Error("Connection lost"));
       const { useTrickMutations } = await getHookExports();
@@ -1157,6 +1224,32 @@ describe("use-trick-mutations", () => {
       );
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe("getMutationErrorKey", () => {
+    it("maps TrickNotFoundError to errors.trickMissing", async () => {
+      const { getMutationErrorKey, TrickNotFoundError } =
+        await getHookExports();
+
+      expect(getMutationErrorKey(new TrickNotFoundError())).toBe(
+        "errors.trickMissing"
+      );
+    });
+
+    it("returns null for a generic Error", async () => {
+      const { getMutationErrorKey } = await getHookExports();
+
+      expect(getMutationErrorKey(new Error("network down"))).toBeNull();
+    });
+
+    it("returns null for a non-Error rejection value", async () => {
+      const { getMutationErrorKey } = await getHookExports();
+
+      expect(getMutationErrorKey("oops")).toBeNull();
+      expect(getMutationErrorKey(undefined)).toBeNull();
+      expect(getMutationErrorKey(null)).toBeNull();
+      expect(getMutationErrorKey({ tag: "TRICK_NOT_FOUND" })).toBeNull();
     });
   });
 });

--- a/src/features/repertoire/hooks/use-trick-mutations.ts
+++ b/src/features/repertoire/hooks/use-trick-mutations.ts
@@ -24,6 +24,50 @@ interface UseTrickMutationsReturn {
   ) => Promise<void>;
 }
 
+/**
+ * Typed mutation error. The `tag` field discriminates error kinds so the UI
+ * toast boundary can map each tag to a localized message without relying on
+ * the English `message` text. Mirrors the pattern in `use-item-mutations.ts`.
+ */
+class TrickNotFoundError extends Error {
+  readonly tag = "TRICK_NOT_FOUND" as const;
+  constructor() {
+    super("TRICK_NOT_FOUND");
+    this.name = "TrickNotFoundError";
+  }
+}
+
+type TypedMutationError = TrickNotFoundError;
+
+function isTypedMutationError(error: unknown): error is TypedMutationError {
+  return error instanceof TrickNotFoundError;
+}
+
+type TypedMutationErrorTag = TypedMutationError["tag"];
+
+/**
+ * Maps each typed error tag to an i18n key. The `satisfies` clause makes
+ * this map exhaustive at compile time — adding a new typed error class
+ * without updating this map fails `tsc`.
+ */
+const MUTATION_ERROR_I18N_KEYS = {
+  TRICK_NOT_FOUND: "errors.trickMissing",
+} as const satisfies Record<TypedMutationErrorTag, string>;
+
+/**
+ * Maps a caught mutation error to its i18n key, or `null` if it's not a
+ * typed mutation error. Consumers use this at toast boundaries to replace
+ * the `instanceof` chain duplication across call sites.
+ */
+export function getMutationErrorKey(error: unknown): string | null {
+  if (!isTypedMutationError(error)) {
+    return null;
+  }
+  return MUTATION_ERROR_I18N_KEYS[error.tag];
+}
+
+export { TrickNotFoundError };
+
 /** Converts an empty string to null for nullable text columns. */
 function emptyToNull(value: string | undefined): string | null {
   return value?.trim() || null;
@@ -260,18 +304,15 @@ export function useTrickMutations(): UseTrickMutationsReturn {
           userId,
         ];
 
-        await tx.execute(TRICK_UPDATE_SQL, updateParams);
-
-        // Remove tag associations by soft-deleting the junction rows.
-        for (const tagId of removeTagIds) {
-          await tx.execute(
-            "UPDATE trick_tags SET deleted_at = ?, updated_at = ? WHERE trick_id = ? AND tag_id = ? AND user_id = ? AND deleted_at IS NULL",
-            [now, now, id, tagId, userId]
-          );
+        const updateResult = await tx.execute(TRICK_UPDATE_SQL, updateParams);
+        if (!updateResult.rowsAffected) {
+          throw new TrickNotFoundError();
         }
 
-        // Add new tag associations (restore soft-deleted rows first to avoid duplicates).
-        for (const tagId of addTagIds) {
+        // Closure helper to keep the outer function's cognitive complexity
+        // under the linter's threshold. Restores a soft-deleted junction row
+        // if one exists, otherwise inserts a new junction row.
+        async function linkTag(tagId: TagId): Promise<void> {
           const restored = await tx.execute(
             "UPDATE trick_tags SET deleted_at = NULL, updated_at = ? WHERE trick_id = ? AND tag_id = ? AND user_id = ? AND deleted_at IS NOT NULL",
             [now, id, tagId, userId]
@@ -283,6 +324,19 @@ export function useTrickMutations(): UseTrickMutationsReturn {
               [junctionId, userId, id, tagId, now, now]
             );
           }
+        }
+
+        // Remove tag associations by soft-deleting the junction rows.
+        for (const tagId of removeTagIds) {
+          await tx.execute(
+            "UPDATE trick_tags SET deleted_at = ?, updated_at = ? WHERE trick_id = ? AND tag_id = ? AND user_id = ? AND deleted_at IS NULL",
+            [now, now, id, tagId, userId]
+          );
+        }
+
+        // Add new tag associations (restore soft-deleted rows first to avoid duplicates).
+        for (const tagId of addTagIds) {
+          await linkTag(tagId);
         }
 
         await safeLogEvent(tx, {
@@ -297,6 +351,10 @@ export function useTrickMutations(): UseTrickMutationsReturn {
 
       trackEvent("trick_updated");
     } catch (error: unknown) {
+      // Re-throw typed errors so the UI can map them to specific i18n keys.
+      if (isTypedMutationError(error)) {
+        throw error;
+      }
       const message =
         error instanceof Error ? error.message : "Unknown error updating trick";
       throw new Error(`Failed to update trick: ${message}`, { cause: error });
@@ -323,7 +381,7 @@ export function useTrickMutations(): UseTrickMutationsReturn {
           [now, now, id, userId]
         );
         if (!result.rowsAffected) {
-          throw new Error("Trick not found or already deleted");
+          throw new TrickNotFoundError();
         }
         await tx.execute(
           "UPDATE trick_tags SET deleted_at = ?, updated_at = ? WHERE trick_id = ? AND user_id = ? AND deleted_at IS NULL",
@@ -346,6 +404,10 @@ export function useTrickMutations(): UseTrickMutationsReturn {
 
       trackEvent("trick_deleted");
     } catch (error: unknown) {
+      // Re-throw typed errors so the UI can map them to specific i18n keys.
+      if (isTypedMutationError(error)) {
+        throw error;
+      }
       const message =
         error instanceof Error ? error.message : "Unknown error deleting trick";
       throw new Error(`Failed to delete trick: ${message}`, { cause: error });

--- a/src/features/repertoire/hooks/use-trick.test.ts
+++ b/src/features/repertoire/hooks/use-trick.test.ts
@@ -45,7 +45,7 @@ describe("useTrick", () => {
     const { useTrick } = await getHook();
     const result = useTrick(null);
 
-    expect(result).toEqual({ trick: null, isLoading: false });
+    expect(result).toEqual({ trick: null, isLoading: false, error: null });
     expect(mockUseQuery).toHaveBeenCalledWith("SELECT 1 WHERE 0", []);
   });
 
@@ -79,7 +79,28 @@ describe("useTrick", () => {
       "SELECT * FROM tricks WHERE id = ? AND deleted_at IS NULL",
       ["nonexistent-id"]
     );
-    expect(result).toEqual({ trick: null, isLoading: false });
+    expect(result).toEqual({ trick: null, isLoading: false, error: null });
+  });
+
+  it("surfaces error from useQuery when query fails", async () => {
+    const queryError = new Error("SQLite I/O failure");
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: queryError,
+    });
+
+    const { useTrick } = await getHook();
+    const result = useTrick("trick-abc");
+
+    // Lock the full shape — a regression that propagates `error` but flips
+    // `isLoading` to true (stalling the UI) would not fail a property-only
+    // assertion but does fail this structural lock.
+    expect(result).toEqual({
+      trick: null,
+      isLoading: false,
+      error: queryError,
+    });
   });
 
   it("passes through isLoading from useQuery when id is provided", async () => {

--- a/src/features/repertoire/hooks/use-trick.ts
+++ b/src/features/repertoire/hooks/use-trick.ts
@@ -5,6 +5,7 @@ import type { ParsedTrick } from "../types";
 import { parseTrickRow, type TrickRow } from "./parse-trick";
 
 interface UseTrickResult {
+  error: Error | null;
   isLoading: boolean;
   trick: ParsedTrick | null;
 }
@@ -20,14 +21,14 @@ export function useTrick(id: string | null): UseTrickResult {
   const sql = id
     ? "SELECT * FROM tricks WHERE id = ? AND deleted_at IS NULL"
     : "SELECT 1 WHERE 0";
-  const { data, isLoading } = useQuery<TrickRow>(sql, id ? [id] : []);
+  const { data, isLoading, error } = useQuery<TrickRow>(sql, id ? [id] : []);
 
   if (!id) {
-    return { trick: null, isLoading: false };
+    return { trick: null, isLoading: false, error: null };
   }
 
   const first = data[0];
   const trick = first ? parseTrickRow(first) : null;
 
-  return { trick, isLoading };
+  return { trick, isLoading, error: error ?? null };
 }

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -97,7 +97,8 @@
       "addedTag": "Tag {name} hinzugefügt",
       "removedTag": "Tag {name} entfernt",
       "createdTag": "Tag {name} erstellt und hinzugefügt",
-      "createFailed": "Tag konnte nicht erstellt werden"
+      "createFailed": "Tag konnte nicht erstellt werden",
+      "loading": "Tags werden geladen…"
     },
     "trickCount": "{count, plural, one {# Trick} other {# Tricks}}",
     "sort": {
@@ -182,7 +183,10 @@
       "tagNameTooLong": "Der Tag-Name darf maximal 50 Zeichen lang sein"
     },
     "linkedItems": "Verknüpfte Objekte",
-    "noLinkedItems": "Nicht mit Objekten verknüpft."
+    "noLinkedItems": "Nicht mit Objekten verknüpft.",
+    "errors": {
+      "trickMissing": "Dieser Trick wurde bereits gelöscht oder nicht gefunden."
+    }
   },
   "landing": {
     "tagline": "Trainieren. Planen. Auftreten. Hebe deine Magie auf ein neues Level.",
@@ -337,7 +341,8 @@
       "addedTag": "Tag {name} hinzugefügt",
       "removedTag": "Tag {name} entfernt",
       "createdTag": "Tag {name} erstellt und hinzugefügt",
-      "createFailed": "Tag konnte nicht erstellt werden"
+      "createFailed": "Tag konnte nicht erstellt werden",
+      "loading": "Tags werden geladen…"
     },
     "trickPicker": {
       "search": "Tricks suchen...",
@@ -345,7 +350,8 @@
       "selectedTricks": "Verknüpfte Tricks",
       "remove": "{name} trennen",
       "addedTrick": "{name} verknüpft",
-      "removedTrick": "{name} getrennt"
+      "removedTrick": "{name} getrennt",
+      "loading": "Tricks werden geladen…"
     },
     "validation": {
       "nameRequired": "Name ist erforderlich",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -97,7 +97,8 @@
       "addedTag": "Added tag {name}",
       "removedTag": "Removed tag {name}",
       "createdTag": "Created and added tag {name}",
-      "createFailed": "Failed to create tag"
+      "createFailed": "Failed to create tag",
+      "loading": "Loading tags…"
     },
     "trickCount": "{count, plural, one {# trick} other {# tricks}}",
     "sort": {
@@ -182,7 +183,10 @@
       "tagNameTooLong": "Tag name must be 50 characters or less"
     },
     "linkedItems": "Linked items",
-    "noLinkedItems": "Not linked to any items."
+    "noLinkedItems": "Not linked to any items.",
+    "errors": {
+      "trickMissing": "This trick was already deleted or not found."
+    }
   },
   "landing": {
     "tagline": "Train. Plan. Perform. Elevate your magic.",
@@ -337,7 +341,8 @@
       "addedTag": "Added tag {name}",
       "removedTag": "Removed tag {name}",
       "createdTag": "Created and added tag {name}",
-      "createFailed": "Failed to create tag"
+      "createFailed": "Failed to create tag",
+      "loading": "Loading tags…"
     },
     "trickPicker": {
       "search": "Search tricks...",
@@ -345,7 +350,8 @@
       "selectedTricks": "Linked tricks",
       "remove": "Unlink {name}",
       "addedTrick": "Linked {name}",
-      "removedTrick": "Unlinked {name}"
+      "removedTrick": "Unlinked {name}",
+      "loading": "Loading tricks…"
     },
     "validation": {
       "nameRequired": "Name is required",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -97,7 +97,8 @@
       "addedTag": "Etiqueta {name} añadida",
       "removedTag": "Etiqueta {name} eliminada",
       "createdTag": "Etiqueta {name} creada y añadida",
-      "createFailed": "Error al crear la etiqueta"
+      "createFailed": "Error al crear la etiqueta",
+      "loading": "Cargando etiquetas…"
     },
     "trickCount": "{count, plural, one {# truco} other {# trucos}}",
     "sort": {
@@ -182,7 +183,10 @@
       "tagNameTooLong": "El nombre de la etiqueta debe tener 50 caracteres o menos"
     },
     "linkedItems": "Objetos vinculados",
-    "noLinkedItems": "No está vinculado a ningún objeto."
+    "noLinkedItems": "No está vinculado a ningún objeto.",
+    "errors": {
+      "trickMissing": "Este truco ya se ha eliminado o no se ha encontrado."
+    }
   },
   "landing": {
     "tagline": "Entrena. Planifica. Actúa. Eleva tu magia.",
@@ -337,7 +341,8 @@
       "addedTag": "Etiqueta {name} añadida",
       "removedTag": "Etiqueta {name} eliminada",
       "createdTag": "Etiqueta {name} creada y añadida",
-      "createFailed": "Error al crear la etiqueta"
+      "createFailed": "Error al crear la etiqueta",
+      "loading": "Cargando etiquetas…"
     },
     "trickPicker": {
       "search": "Buscar trucos...",
@@ -345,7 +350,8 @@
       "selectedTricks": "Trucos vinculados",
       "remove": "Desvincular {name}",
       "addedTrick": "{name} vinculado",
-      "removedTrick": "{name} desvinculado"
+      "removedTrick": "{name} desvinculado",
+      "loading": "Cargando trucos…"
     },
     "validation": {
       "nameRequired": "El nombre es obligatorio",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -97,7 +97,8 @@
       "addedTag": "Tag {name} ajouté",
       "removedTag": "Tag {name} retiré",
       "createdTag": "Tag {name} créé et ajouté",
-      "createFailed": "Échec de la création du tag"
+      "createFailed": "Échec de la création du tag",
+      "loading": "Chargement des tags…"
     },
     "trickCount": "{count, plural, one {# tour} other {# tours}}",
     "sort": {
@@ -182,7 +183,10 @@
       "tagNameTooLong": "Le nom du tag doit contenir 50 caractères ou moins"
     },
     "linkedItems": "Objets associés",
-    "noLinkedItems": "Non associé à aucun objet."
+    "noLinkedItems": "Non associé à aucun objet.",
+    "errors": {
+      "trickMissing": "Ce tour a déjà été supprimé ou est introuvable."
+    }
   },
   "landing": {
     "tagline": "S'entraîner. Planifier. Performer. Sublimer sa magie.",
@@ -337,7 +341,8 @@
       "addedTag": "Tag {name} ajouté",
       "removedTag": "Tag {name} retiré",
       "createdTag": "Tag {name} créé et ajouté",
-      "createFailed": "Échec de la création du tag"
+      "createFailed": "Échec de la création du tag",
+      "loading": "Chargement des tags…"
     },
     "trickPicker": {
       "search": "Rechercher des tours...",
@@ -345,7 +350,8 @@
       "selectedTricks": "Tours associés",
       "remove": "Dissocier {name}",
       "addedTrick": "{name} associé",
-      "removedTrick": "{name} dissocié"
+      "removedTrick": "{name} dissocié",
+      "loading": "Chargement des tours…"
     },
     "validation": {
       "nameRequired": "Le nom est requis",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -97,7 +97,8 @@
       "addedTag": "Tag {name} aggiunto",
       "removedTag": "Tag {name} rimosso",
       "createdTag": "Tag {name} creato e aggiunto",
-      "createFailed": "Creazione del tag non riuscita"
+      "createFailed": "Creazione del tag non riuscita",
+      "loading": "Caricamento dei tag…"
     },
     "trickCount": "{count, plural, one {# trucco} other {# trucchi}}",
     "sort": {
@@ -182,7 +183,10 @@
       "tagNameTooLong": "Il nome del tag deve contenere al massimo 50 caratteri"
     },
     "linkedItems": "Oggetti collegati",
-    "noLinkedItems": "Non collegato a nessun oggetto."
+    "noLinkedItems": "Non collegato a nessun oggetto.",
+    "errors": {
+      "trickMissing": "Questo trucco è già stato eliminato o non è stato trovato."
+    }
   },
   "landing": {
     "tagline": "Allenati. Pianifica. Esibisciti. Eleva la tua magia.",
@@ -337,7 +341,8 @@
       "addedTag": "Tag {name} aggiunto",
       "removedTag": "Tag {name} rimosso",
       "createdTag": "Tag {name} creato e aggiunto",
-      "createFailed": "Creazione del tag non riuscita"
+      "createFailed": "Creazione del tag non riuscita",
+      "loading": "Caricamento dei tag…"
     },
     "trickPicker": {
       "search": "Cerca trucchi...",
@@ -345,7 +350,8 @@
       "selectedTricks": "Trucchi collegati",
       "remove": "Scollega {name}",
       "addedTrick": "{name} collegato",
-      "removedTrick": "{name} scollegato"
+      "removedTrick": "{name} scollegato",
+      "loading": "Caricamento dei trucchi…"
     },
     "validation": {
       "nameRequired": "Il nome è obbligatorio",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -97,7 +97,8 @@
       "addedTag": "Tag {name} toegevoegd",
       "removedTag": "Tag {name} verwijderd",
       "createdTag": "Tag {name} aangemaakt en toegevoegd",
-      "createFailed": "Kan tag niet aanmaken"
+      "createFailed": "Kan tag niet aanmaken",
+      "loading": "Tags laden…"
     },
     "trickCount": "{count, plural, one {# truc} other {# trucs}}",
     "sort": {
@@ -182,7 +183,10 @@
       "tagNameTooLong": "Tagnaam mag maximaal 50 tekens bevatten"
     },
     "linkedItems": "Gekoppelde items",
-    "noLinkedItems": "Niet gekoppeld aan items."
+    "noLinkedItems": "Niet gekoppeld aan items.",
+    "errors": {
+      "trickMissing": "Deze truc is al verwijderd of niet gevonden."
+    }
   },
   "landing": {
     "tagline": "Trainen. Plannen. Optreden. Til je magie naar een hoger niveau.",
@@ -337,7 +341,8 @@
       "addedTag": "Tag {name} toegevoegd",
       "removedTag": "Tag {name} verwijderd",
       "createdTag": "Tag {name} aangemaakt en toegevoegd",
-      "createFailed": "Kan tag niet aanmaken"
+      "createFailed": "Kan tag niet aanmaken",
+      "loading": "Tags laden…"
     },
     "trickPicker": {
       "search": "Trucs zoeken...",
@@ -345,7 +350,8 @@
       "selectedTricks": "Gekoppelde trucs",
       "remove": "{name} ontkoppelen",
       "addedTrick": "{name} gekoppeld",
-      "removedTrick": "{name} ontkoppeld"
+      "removedTrick": "{name} ontkoppeld",
+      "loading": "Trucs laden…"
     },
     "validation": {
       "nameRequired": "Naam is verplicht",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -97,7 +97,8 @@
       "addedTag": "Etiqueta {name} adicionada",
       "removedTag": "Etiqueta {name} removida",
       "createdTag": "Etiqueta {name} criada e adicionada",
-      "createFailed": "Falha ao criar etiqueta"
+      "createFailed": "Falha ao criar etiqueta",
+      "loading": "A carregar etiquetas…"
     },
     "trickCount": "{count, plural, one {# truque} other {# truques}}",
     "sort": {
@@ -182,7 +183,10 @@
       "tagNameTooLong": "O nome da etiqueta deve ter 50 caracteres ou menos"
     },
     "linkedItems": "Objetos associados",
-    "noLinkedItems": "Não está associado a nenhum objeto."
+    "noLinkedItems": "Não está associado a nenhum objeto.",
+    "errors": {
+      "trickMissing": "Este truque já foi eliminado ou não foi encontrado."
+    }
   },
   "landing": {
     "tagline": "Treinar. Planear. Apresentar. Eleve a sua magia.",
@@ -337,7 +341,8 @@
       "addedTag": "Etiqueta {name} adicionada",
       "removedTag": "Etiqueta {name} removida",
       "createdTag": "Etiqueta {name} criada e adicionada",
-      "createFailed": "Falha ao criar etiqueta"
+      "createFailed": "Falha ao criar etiqueta",
+      "loading": "A carregar etiquetas…"
     },
     "trickPicker": {
       "search": "Pesquisar truques...",
@@ -345,7 +350,8 @@
       "selectedTricks": "Truques associados",
       "remove": "Desassociar {name}",
       "addedTrick": "{name} associado",
-      "removedTrick": "{name} desassociado"
+      "removedTrick": "{name} desassociado",
+      "loading": "A carregar truques…"
     },
     "validation": {
       "nameRequired": "O nome é obrigatório",


### PR DESCRIPTION
## Summary

Fixes #216 — silent tag/trick unlink when Edit is clicked before PowerSync join queries finish hydrating.

**Root cause.** Both `collect-view` and `repertoire-view` snapshotted `selectedTagIds` / `selectedTrickIds` from PowerSync join maps at click time. On a cold start (or any hydration window) those maps were still empty, so the snapshot was `[]`. Saving with that stale baseline diffed against `[]` and silently unlinked every existing tag/trick — and on the trick path, an unhydrated `useTrick` row could let a keyboard submit overwrite the row with RHF defaults (`name=""`).

**Fix.** Sentinel-null state + lock-in seeding effect:

- Selection state starts as `null` (not `[]`), so emptiness is unambiguous.
- A seeding `useEffect` populates `selected*` and `original*` exactly once, gated on the row + join queries having finished loading.
- Save is `disabled` and `aria-busy` while any join (or the row itself) is hydrating; the tag/trick pickers render as accessible skeletons in place.
- `handleSubmit` has defense-in-depth: any null selection short-circuits with a `console.warn`.

Snapshot semantics for delta-only mutations are preserved — background-sync-added relations during an open Edit are NOT phantom-unlinked.

**Typed-error parity (tricks).** Added `TrickNotFoundError` + `getMutationErrorKey` in `use-trick-mutations`, mirroring the canonical pattern already in `use-item-mutations`. Toast boundaries now map mutation errors to localized keys instead of inspecting english `Error.message` text. Adds `repertoire.errors.trickMissing` in all 7 locales.

**A11y polish.**
- `motion-safe:animate-pulse` on `Skeleton` (respects `prefers-reduced-motion`).
- `aria-busy` on the form, the relations fieldsets, and the Save button (Save lives outside the `<form>`, so it gets its own attribute).
- Conditional `aria-describedby` on the item-form fieldsets to avoid a dangling IDREF during the loading window.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (`item-form.tsx`, `use-trick-mutations.test.ts`)
- [x] `pnpm test:run` — **1729/1729 pass** (3 new tests for `getMutationErrorKey`; 4 new typed-error toast routing + TrickNotFoundError positive tests; full-shape lock for `useTrick.error`; race-fix coverage in collect-view + repertoire-view tests)
- [x] `pnpm sync:check` — clean
- [x] `pnpm i18n:check` — clean (4 new keys × 7 locales)
- [ ] Manual QA in dev: hard refresh → click Edit immediately → pickers show skeletons, Save disabled → within ~1s pickers populate, Save enables → save with no changes → no phantom unlink.
- [ ] Two-device test: edit on device A; on device B open Edit on the same item — picker reflects A's sync; save on B without changes does not re-emit any link mutations.

## Reviews

This change went through 4 rounds of `/review` and converged at zero findings. All 12 substantive findings (race-fix correctness, typed-error infrastructure, dangling aria-describedby, missing direct unit tests, etc.) are addressed.

Closes #216