### PR TITLE
feat: lock down sequence/function ACLs + enforce synced-table GRANT discipline

### DIFF
--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -10,7 +10,8 @@ Run these in a single parallel batch (they're independent — save time):
 2. `pnpm typecheck` — tsc -b
 3. `pnpm test:run` — Vitest single run
 4. `pnpm sync:check` — PowerSync artifacts vs Drizzle schema drift
-5. `pnpm i18n:check` — 7-locale key parity
+5. `pnpm sync:check:grants` — synced-table GRANT discipline (issue #254)
+6. `pnpm i18n:check` — 7-locale key parity
 
 For each step: one line — `✓ <step>` on success, or `✗ <step>: <short error>` with the tail of the failing output on a new line.
 

--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -19,6 +19,10 @@ paths:
    - `event_log`: `GRANT SELECT, INSERT` + `GRANT UPDATE (deleted_at, updated_at)` (audit-trail invariant — no DELETE, no payload mutation from clients).
    - Server-only tables (`users`, `user_preferences`): `GRANT SELECT` only.
    - RLS policies stay defense-in-depth on top of GRANTs — the GRANT layer is the new enforcement floor; RLS narrows by `user_id`.
+   - **Enforced statically.** `pnpm sync:check:grants` (issue #254) runs in pre-commit and CI; it parses every `src/db/migrations/*.sql` with index ≥ 21 and fails when a synced-table `CREATE TABLE` lacks a matching `GRANT … TO authenticated;` in the same file. The synced-table list is sourced from `src/sync/synced-columns.ts` (canonical, generated from Drizzle).
+4. **Sequences and `SECURITY DEFINER` functions inherit the same discipline.** As of `0021_lockdown_sequence_function_acls.sql` (issue #253), schema `public` also has no default privileges on sequences or functions for `authenticated`.
+   - Any new `CREATE SEQUENCE` (or sequence-defaulted column) on a synced table MUST include `GRANT USAGE, SELECT ON SEQUENCE <name> TO authenticated;` in the same migration. Without it, `nextval()` fails for `authenticated`-role clients.
+   - Any new `SECURITY DEFINER` function in `public` MUST include `REVOKE EXECUTE ON FUNCTION <name>(...) FROM PUBLIC, authenticated;` and grant `EXECUTE` only to the roles that legitimately need it. The default-ACL revoke neutralizes the auto-grant, but the `PUBLIC` revoke is also needed because `CREATE FUNCTION` grants `EXECUTE` to `PUBLIC` regardless of default ACLs.
 
 ## Rollback / recovery
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Sync artifacts staleness check
         run: pnpm sync:check
 
+      - name: Synced-table GRANT discipline check
+        run: pnpm sync:check:grants
+
       - name: Check migration drift
         if: github.event_name == 'push' || github.event.pull_request.user.login != 'dependabot[bot]'
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,12 +125,15 @@ Two Postgres roles exist on Neon. Today, **all server-side code paths use `neond
 
 The `authenticated` role is currently exercised only by the JWT-aware client paths the codebase does not yet use directly (Neon Data API, JWT-forwarded PowerSync sync — both anticipated, not active). Migration `0020_lockdown_authenticated_grants.sql` (issue #245) hardens what `authenticated` CAN see/do **before** any code path actually authenticates as that role:
 
-- Schema `public` has **no default privileges** for `authenticated`. Every `CREATE TABLE` synced via PowerSync MUST include an explicit `GRANT <subset> ON <table> TO authenticated;` line in the **same migration file**. Future synced tables added without a GRANT will be invisible to any future `authenticated`-role client (PowerSync queries return empty).
+- Schema `public` has **no default privileges** for `authenticated`. Every `CREATE TABLE` synced via PowerSync MUST include an explicit `GRANT <subset> ON <table> TO authenticated;` line in the **same migration file**. Future synced tables added without a GRANT will be invisible to any future `authenticated`-role client (PowerSync queries return empty). Enforced statically by `pnpm sync:check:grants` (issue #254) — runs in pre-commit (Lefthook) and CI; fails the build when a synced-table `CREATE TABLE` lacks a matching `GRANT … TO authenticated;` in the same migration (idx ≥ 21).
 - The canonical per-table grant matrix lives in `0020`. Reference shape:
   - Standard user-data tables (12): `SELECT, INSERT, UPDATE, DELETE`.
   - `push_subscriptions`: `SELECT, INSERT, UPDATE` — no `DELETE` for clients (cleanup of expired subs is server-side).
   - `event_log`: `SELECT, INSERT` + column-level `UPDATE (deleted_at, updated_at)` only — no `DELETE`, no payload mutation. Audit-trail invariant.
   - Server-only tables (`users`, `user_preferences`): `SELECT` only.
+- Migration `0021_lockdown_sequence_function_acls.sql` (issue #253) extends the lockdown to **sequences** (no `USAGE`/`UPDATE` for `authenticated`) and **functions** (no `EXECUTE`). Today the schema uses UUID PKs and has zero `SECURITY DEFINER` functions, so the holes were dormant — but the new defaults guard against future SERIAL/IDENTITY columns and `SECURITY DEFINER` helpers, both of which would otherwise auto-grant privileges that bypass RLS and column-level GRANTs.
+  - Any new `CREATE SEQUENCE` (or sequence-defaulted column) on a synced table MUST include `GRANT USAGE, SELECT ON SEQUENCE <name> TO authenticated;` in the same migration.
+  - Any new `SECURITY DEFINER` function in `public` MUST include explicit `REVOKE EXECUTE ON FUNCTION <name>(...) FROM PUBLIC, authenticated;` plus targeted `GRANT EXECUTE` only to the roles that need it.
 
 **The 422 gate in `src/app/api/powersync/batch/route.ts:122-144` IS still the only enforcement of the `event_log` audit-trail invariant on the live write path** — because that path runs as `neondb_owner` and bypasses both the new `authenticated` GRANTs and RLS. Do not weaken or remove the 422 gate without first migrating the upload route to a JWT-forwarding `authenticated`-role connection. The DB GRANT lockdown is forward-positioning + hardening against an accidental `DATABASE_URL` swap to a less-privileged role; it is not a replacement for the application-layer check today.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,3 +17,8 @@ pre-commit:
         - "src/sync/synced-columns.ts"
         - "powersync/sync-config.yaml"
         - "scripts/generate-sync.ts"
+    - run: pnpm sync:check:grants
+      glob:
+        - "src/db/migrations/*.sql"
+        - "src/sync/synced-columns.ts"
+        - "scripts/check-grants.ts"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "i18n:check": "tsx scripts/check-i18n.ts",
     "sync:generate": "tsx scripts/generate-sync.ts",
     "sync:check": "tsx scripts/check-sync.ts",
+    "sync:check:grants": "tsx scripts/check-grants.ts",
     "sync:validate": "tsx scripts/powersync.ts validate --validate-only=sync-config",
     "sync:deploy": "tsx scripts/powersync.ts deploy sync-config",
     "email:dev": "email dev --dir src/emails --port 3030",

--- a/scripts/check-grants.test.ts
+++ b/scripts/check-grants.test.ts
@@ -1,0 +1,659 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  checkMigrationFile,
+  checkMigrationsDir,
+  findCreatedSyncedTables,
+  findGrantedToAuthenticated,
+  hasRevokeExecuteFromPublicAndAuthenticated,
+  listEnforcedMigrations,
+  parseGrantees,
+  parseGrantTargets,
+  stripSqlComments,
+} from "./check-grants";
+
+const SYNCED = new Set<string>(["tricks", "setlists", "event_log", "tags"]);
+
+describe("stripSqlComments", () => {
+  it("removes line comments through end-of-line", () => {
+    const sql = `CREATE TABLE "tricks" (id uuid); -- with comment\nGRANT SELECT ON "tricks" TO authenticated;`;
+    const out = stripSqlComments(sql);
+    expect(out).not.toContain("with comment");
+    expect(out).toContain('CREATE TABLE "tricks"');
+    expect(out).toContain("GRANT SELECT");
+  });
+
+  it("removes block comments including across newlines", () => {
+    const sql = `/* leading\nblock\ncomment */\nCREATE TABLE "tricks" (id uuid);`;
+    const out = stripSqlComments(sql);
+    expect(out).not.toContain("leading");
+    expect(out).not.toContain("block");
+    expect(out).toContain('CREATE TABLE "tricks"');
+  });
+
+  it("does not strip non-comment text inside dollar-quoted bodies", () => {
+    // Documents the actual behavior — stripSqlComments is not dollar-quote
+    // aware. A body free of comment markers passes through unchanged. A `--`
+    // or `/* */` inside a body would still be stripped (known limitation; the
+    // check accepts the false-negative tradeoff because real migrations don't
+    // bury GRANTs inside function bodies).
+    const sql = `DO $$ BEGIN GRANT SELECT ON "tricks" TO authenticated; END $$;`;
+    expect(stripSqlComments(sql)).toContain("GRANT SELECT");
+  });
+});
+
+describe("parseGrantTargets", () => {
+  it("extracts a single quoted identifier", () => {
+    expect(parseGrantTargets('"tricks"')).toEqual(["tricks"]);
+  });
+
+  it("extracts a single unquoted identifier", () => {
+    expect(parseGrantTargets("tricks")).toEqual(["tricks"]);
+  });
+
+  it("extracts multiple comma-separated identifiers across newlines", () => {
+    const target = `
+      "tricks", "setlists",
+      "event_log"
+    `;
+    expect(parseGrantTargets(target)).toEqual([
+      "tricks",
+      "setlists",
+      "event_log",
+    ]);
+  });
+
+  it("extracts both schema and table from schema-qualified target", () => {
+    // Pinning current behavior: IDENTIFIER_RE walks every identifier, so the
+    // schema name appears alongside the table. The check ignores unknown names
+    // (not in SYNCED_TABLE_NAMES), so the membership semantic works regardless.
+    expect(parseGrantTargets("public.event_log")).toEqual([
+      "public",
+      "event_log",
+    ]);
+  });
+});
+
+describe("parseGrantees", () => {
+  it("normalizes case and strips quotes", () => {
+    expect(parseGrantees('AUTHENTICATED, "Foo"')).toEqual([
+      "authenticated",
+      "foo",
+    ]);
+  });
+});
+
+describe("findCreatedSyncedTables", () => {
+  it("returns synced tables present in CREATE TABLE statements", () => {
+    const sql = `
+      CREATE TABLE "tricks" (id uuid PRIMARY KEY);
+      CREATE TABLE IF NOT EXISTS "setlists" (id uuid PRIMARY KEY);
+    `;
+    expect([...findCreatedSyncedTables(sql, SYNCED)]).toEqual([
+      "tricks",
+      "setlists",
+    ]);
+  });
+
+  it("matches unquoted CREATE TABLE identifiers", () => {
+    const sql = "CREATE TABLE tricks (id uuid PRIMARY KEY);";
+    expect([...findCreatedSyncedTables(sql, SYNCED)]).toEqual(["tricks"]);
+  });
+
+  it("captures the table from schema-qualified CREATE TABLE", () => {
+    const sql = `
+      CREATE TABLE public.tricks (id uuid PRIMARY KEY);
+      CREATE TABLE "public"."setlists" (id uuid PRIMARY KEY);
+    `;
+    expect([...findCreatedSyncedTables(sql, SYNCED)]).toEqual([
+      "tricks",
+      "setlists",
+    ]);
+  });
+
+  it("ignores non-synced tables (e.g., server-only)", () => {
+    const sql = `CREATE TABLE "users" (id uuid PRIMARY KEY);`;
+    expect([...findCreatedSyncedTables(sql, SYNCED)]).toEqual([]);
+  });
+});
+
+describe("findGrantedToAuthenticated", () => {
+  it("captures a single-table GRANT", () => {
+    const sql = `GRANT SELECT, INSERT ON "tricks" TO authenticated;`;
+    expect([...findGrantedToAuthenticated(sql)]).toEqual(["tricks"]);
+  });
+
+  it("captures multi-table multi-line GRANT", () => {
+    const sql = `
+      GRANT SELECT, INSERT, UPDATE, DELETE ON
+        "tricks", "setlists",
+        "tags"
+      TO authenticated;
+    `;
+    expect([...findGrantedToAuthenticated(sql)].sort()).toEqual([
+      "setlists",
+      "tags",
+      "tricks",
+    ]);
+  });
+
+  it("captures column-scoped GRANTs (event_log audit pattern)", () => {
+    const sql = `
+      GRANT SELECT, INSERT ON "event_log" TO authenticated;
+      GRANT UPDATE ("deleted_at", "updated_at") ON "event_log" TO authenticated;
+    `;
+    expect([...findGrantedToAuthenticated(sql)]).toEqual(["event_log"]);
+  });
+
+  it("captures GRANT with the optional TABLE keyword", () => {
+    const sql = `GRANT SELECT ON TABLE "tricks" TO authenticated;`;
+    expect([...findGrantedToAuthenticated(sql)]).toEqual(["tricks"]);
+  });
+
+  it("matches multi-grantee GRANT regardless of authenticated position", () => {
+    const trailing = `GRANT SELECT ON "tricks" TO authenticated, viewer;`;
+    expect([...findGrantedToAuthenticated(trailing)]).toEqual(["tricks"]);
+    const leading = `GRANT SELECT ON "setlists" TO viewer, authenticated;`;
+    expect([...findGrantedToAuthenticated(leading)]).toEqual(["setlists"]);
+  });
+
+  it("does not match REVOKE statements", () => {
+    const sql = `REVOKE ALL ON TABLE "tricks" FROM authenticated;`;
+    expect([...findGrantedToAuthenticated(sql)]).toEqual([]);
+  });
+
+  it("does not match GRANT to other roles only", () => {
+    const sql = `GRANT SELECT ON "tricks" TO neondb_owner;`;
+    expect([...findGrantedToAuthenticated(sql)]).toEqual([]);
+  });
+});
+
+describe("hasRevokeExecuteFromPublicAndAuthenticated", () => {
+  it("matches a combined REVOKE FROM PUBLIC, authenticated", () => {
+    const sql = "REVOKE EXECUTE ON FUNCTION foo() FROM PUBLIC, authenticated;";
+    expect(hasRevokeExecuteFromPublicAndAuthenticated(sql)).toBe(true);
+  });
+
+  it("matches two separate REVOKE statements covering both roles", () => {
+    const sql = `
+      REVOKE EXECUTE ON FUNCTION foo() FROM PUBLIC;
+      REVOKE EXECUTE ON FUNCTION foo() FROM authenticated;
+    `;
+    expect(hasRevokeExecuteFromPublicAndAuthenticated(sql)).toBe(true);
+  });
+
+  it("matches REVOKE EXECUTE ON ALL FUNCTIONS form", () => {
+    const sql = `
+      REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
+      REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM authenticated;
+    `;
+    expect(hasRevokeExecuteFromPublicAndAuthenticated(sql)).toBe(true);
+  });
+
+  it("returns false when only PUBLIC is revoked", () => {
+    const sql = "REVOKE EXECUTE ON FUNCTION foo() FROM PUBLIC;";
+    expect(hasRevokeExecuteFromPublicAndAuthenticated(sql)).toBe(false);
+  });
+
+  it("returns false when only authenticated is revoked", () => {
+    const sql = "REVOKE EXECUTE ON FUNCTION foo() FROM authenticated;";
+    expect(hasRevokeExecuteFromPublicAndAuthenticated(sql)).toBe(false);
+  });
+});
+
+describe("checkMigrationFile", () => {
+  it("reports failure when a synced table is created without a GRANT", () => {
+    const sql = `CREATE TABLE "tricks" (id uuid PRIMARY KEY);`;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("tricks");
+    expect(failures[0]?.file).toBe("0021_test.sql");
+    expect(failures[0]?.message).toContain("0021_test.sql");
+    expect(failures[0]?.message).toContain('"tricks"');
+    expect(failures[0]?.message).toContain(".claude/rules/migrations.md §3");
+  });
+
+  it("passes when a single-table GRANT covers the new table", () => {
+    const sql = `
+      CREATE TABLE "tricks" (id uuid PRIMARY KEY);
+      GRANT SELECT, INSERT, UPDATE, DELETE ON "tricks" TO authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("passes when a multi-table GRANT covers all created synced tables", () => {
+    const sql = `
+      CREATE TABLE "tricks" (id uuid PRIMARY KEY);
+      CREATE TABLE "setlists" (id uuid PRIMARY KEY);
+      GRANT SELECT, INSERT, UPDATE, DELETE ON
+        "tricks", "setlists"
+      TO authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("passes for the event_log column-scoped GRANT pattern", () => {
+    const sql = `
+      CREATE TABLE "event_log" (id uuid PRIMARY KEY);
+      GRANT SELECT, INSERT ON "event_log" TO authenticated;
+      GRANT UPDATE ("deleted_at", "updated_at") ON "event_log" TO authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("passes for schema-qualified CREATE TABLE with matching schema-qualified GRANT", () => {
+    const sql = `
+      CREATE TABLE public.tricks (id uuid PRIMARY KEY);
+      GRANT SELECT, INSERT, UPDATE, DELETE ON public.tricks TO authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("passes when GRANT lists authenticated alongside other grantees", () => {
+    const sql = `
+      CREATE TABLE "tricks" (id uuid PRIMARY KEY);
+      GRANT SELECT ON "tricks" TO authenticated, neondb_owner;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("ignores a commented-out GRANT (line comment)", () => {
+    // F1 regression guard — a `-- GRANT ...` line MUST NOT satisfy the check.
+    const sql = `
+      CREATE TABLE "tricks" (id uuid PRIMARY KEY);
+      -- GRANT SELECT ON "tricks" TO authenticated;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("tricks");
+  });
+
+  it("ignores a commented-out GRANT (block comment)", () => {
+    const sql = `
+      CREATE TABLE "setlists" (id uuid PRIMARY KEY);
+      /* GRANT SELECT ON "setlists" TO authenticated; */
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("setlists");
+  });
+
+  it("ignores a commented-out CREATE TABLE", () => {
+    // Symmetrical to the above — a comment that mentions CREATE TABLE must
+    // not be treated as a real CREATE TABLE.
+    const sql = `
+      -- CREATE TABLE "tricks" (id uuid PRIMARY KEY);
+      /* CREATE TABLE "setlists" (id uuid PRIMARY KEY); */
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("ignores non-synced (server-only) tables created without GRANT", () => {
+    const sql = `CREATE TABLE "users" (id uuid PRIMARY KEY);`;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("fails when a GRANT exists but targets a different table than the one created", () => {
+    const sql = `
+      CREATE TABLE "tricks" (id uuid PRIMARY KEY);
+      GRANT SELECT, INSERT, UPDATE, DELETE ON "setlists" TO authenticated;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("tricks");
+  });
+
+  it("reports one failure per ungranted synced table when multiple are created", () => {
+    const sql = `
+      CREATE TABLE "tricks" (id uuid PRIMARY KEY);
+      CREATE TABLE "setlists" (id uuid PRIMARY KEY);
+      GRANT SELECT ON "tricks" TO authenticated;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures.map((f) => f.subject)).toEqual(["setlists"]);
+  });
+
+  it("flags SECURITY DEFINER function without REVOKE EXECUTE FROM PUBLIC, authenticated", () => {
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toContain("foo");
+    expect(failures[0]?.message).toContain("SECURITY DEFINER");
+    expect(failures[0]?.message).toContain(".claude/rules/migrations.md §4");
+  });
+
+  it("flags SECURITY DEFINER function with only PUBLIC revoked", () => {
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE EXECUTE ON FUNCTION foo() FROM PUBLIC;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.message).toContain("SECURITY DEFINER");
+  });
+
+  it("passes SECURITY DEFINER function with bare-name REVOKE (no signature)", () => {
+    // PostgreSQL accepts `REVOKE EXECUTE ON FUNCTION foo FROM …;` without
+    // parens when the function name is unambiguous. The pairing must still
+    // recognize coverage for that form.
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE EXECUTE ON FUNCTION foo FROM PUBLIC, authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("passes SECURITY DEFINER function with combined REVOKE", () => {
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE EXECUTE ON FUNCTION foo() FROM PUBLIC, authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("ignores SECURITY DEFINER mentioned only in comments", () => {
+    // A prose mention of SECURITY DEFINER in a header comment must not
+    // trigger the check (the strip-comments pass clears it before scanning).
+    const sql = `
+      -- This migration discusses SECURITY DEFINER as a concept.
+      ALTER DEFAULT PRIVILEGES FOR ROLE neondb_owner IN SCHEMA public
+        REVOKE ALL ON SEQUENCES FROM authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("does not flag SECURITY DEFINER on non-synced-related migrations", () => {
+    // No CREATE FUNCTION → no SECURITY DEFINER mention in real SQL → no failure.
+    const sql = `
+      ALTER DEFAULT PRIVILEGES FOR ROLE neondb_owner IN SCHEMA public
+        REVOKE ALL ON FUNCTIONS FROM authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("flags only the unpaired SECURITY DEFINER function when one of two has a REVOKE", () => {
+    // F1 per-function pairing — a REVOKE for foo() does NOT cover bar(). The
+    // file-level coarse check would have falsely passed this case.
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      CREATE FUNCTION bar() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 2 $$;
+      REVOKE EXECUTE ON FUNCTION foo() FROM PUBLIC, authenticated;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("bar");
+    expect(failures[0]?.message).toContain('"bar"');
+  });
+
+  it("flags both unpaired SECURITY DEFINER functions with separate failures", () => {
+    // F1 — multi-function should yield one failure per missing pairing, not a
+    // joined `foo, bar` subject.
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      CREATE FUNCTION bar() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 2 $$;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(2);
+    expect(failures.map((f) => f.subject).sort()).toEqual(["bar", "foo"]);
+  });
+
+  it("ignores invoker-rights functions when paired with a SECURITY DEFINER", () => {
+    // Mixed file: only the SECURITY DEFINER function should be checked. The
+    // invoker-rights one is exempt from the pairing requirement.
+    const sql = `
+      CREATE FUNCTION definer_fn() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      CREATE FUNCTION invoker_fn() RETURNS int LANGUAGE sql AS $$ SELECT 2 $$;
+      REVOKE EXECUTE ON FUNCTION definer_fn() FROM PUBLIC, authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("passes SECURITY DEFINER functions covered by a broad-sweep ALL FUNCTIONS REVOKE", () => {
+    // F1 — the broad-sweep `REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA …` form
+    // covers every function in that schema for the listed grantees.
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      CREATE FUNCTION bar() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 2 $$;
+      REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC, authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("treats two separate broad-sweep REVOKEs (one per grantee) as combined coverage", () => {
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
+      REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("combines a partial broad-sweep with a named REVOKE to cover a function", () => {
+    // Hybrid: the broad sweep gets PUBLIC, the named REVOKE gets authenticated.
+    // Together they cover foo().
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
+      REVOKE EXECUTE ON FUNCTION foo() FROM authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("falls back to <function> sentinel when SECURITY DEFINER appears outside CREATE FUNCTION", () => {
+    // ALTER FUNCTION ... SECURITY DEFINER promotes an existing function. The
+    // CREATE_FUNCTION_NAME_RE doesn't match ALTER, so the per-function pairing
+    // can't attribute the keyword to a name — fall back to the coarse check
+    // and a `<function>` sentinel subject.
+    const sql = "ALTER FUNCTION old_fn() SECURITY DEFINER;";
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("<function>");
+    expect(failures[0]?.message).toContain("SECURITY DEFINER");
+    expect(failures[0]?.message).toContain(".claude/rules/migrations.md §4");
+  });
+
+  it("does not use sentinel when the coarse fallback REVOKE is satisfied", () => {
+    // Same ALTER FUNCTION scenario but a file-level REVOKE covers both
+    // grantees — fallback path is satisfied, no failure.
+    const sql = `
+      ALTER FUNCTION old_fn() SECURITY DEFINER;
+      REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC, authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("rejects a named REVOKE on a non-public schema for a public-schema definer", () => {
+    // F-A — bare-name keying without schema enforcement let `audit.foo` REVOKE
+    // satisfy a `public.foo` definer. The pairing must require schema match.
+    const sql = `
+      CREATE FUNCTION public.foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE EXECUTE ON FUNCTION audit.foo() FROM PUBLIC, authenticated;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("foo");
+  });
+
+  it("rejects a broad-sweep REVOKE on a non-public schema for a public-schema definer", () => {
+    // F-A — `IN SCHEMA <other>` broad sweeps must not credit public-schema
+    // definer functions. The rule's scope is schema `public` only.
+    const sql = `
+      CREATE FUNCTION public.foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA other_schema FROM PUBLIC, authenticated;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("foo");
+  });
+
+  it("matches schema-qualified CREATE FUNCTION with schema-qualified REVOKE", () => {
+    // F-A — both sides reference public explicitly; pairing is satisfied.
+    const sql = `
+      CREATE FUNCTION public.foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE EXECUTE ON FUNCTION public.foo() FROM PUBLIC, authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("treats unqualified CREATE FUNCTION as public-schema (search_path default)", () => {
+    // F-A — unqualified CREATE FUNCTION lands in public under the default
+    // search_path used by these migrations. Pairing with a public-qualified
+    // REVOKE must succeed.
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE EXECUTE ON FUNCTION public.foo() FROM PUBLIC, authenticated;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("ignores SECURITY DEFINER functions declared in non-public schemas", () => {
+    // F-A — the rule's scope is schema `public`. A definer function in
+    // `audit` (or any other schema) is out of scope and must not trigger
+    // the check.
+    const sql = `
+      CREATE FUNCTION audit.foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+    `;
+    expect(checkMigrationFile("0021_test.sql", sql, SYNCED)).toEqual([]);
+  });
+
+  it("flags orphan SECURITY DEFINER even when a non-public CREATE FUNCTION precedes it", () => {
+    // S-A — `hasOrphanSecurityDefiner` must filter span-defining CREATE
+    // FUNCTION matches by schema. A non-public CREATE FUNCTION (out of scope)
+    // would otherwise establish a span that swallows a real public-schema
+    // orphan SECURITY DEFINER like `ALTER FUNCTION public.foo() SECURITY
+    // DEFINER`, silently shipping the privilege-escalation primitive.
+    const sql = `
+      CREATE FUNCTION other.helper() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;
+      ALTER FUNCTION public.privileged() SECURITY DEFINER;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("<function>");
+    expect(failures[0]?.message).toContain("SECURITY DEFINER");
+  });
+
+  it("flags unpaired definer when partial broad-sweep + named REVOKE only cover one of two functions", () => {
+    // F-B — locks in that broad-sweep accumulation works across multiple
+    // definer functions while still requiring per-function coverage. The
+    // broad-sweep covers PUBLIC for everything; a named REVOKE adds
+    // authenticated for `foo` only — `bar` remains unpaired.
+    const sql = `
+      CREATE FUNCTION foo() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      CREATE FUNCTION bar() RETURNS int LANGUAGE sql SECURITY DEFINER AS $$ SELECT 2 $$;
+      REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
+      REVOKE EXECUTE ON FUNCTION foo() FROM authenticated;
+    `;
+    const failures = checkMigrationFile("0021_test.sql", sql, SYNCED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.subject).toBe("bar");
+  });
+});
+
+describe("listEnforcedMigrations", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "check-grants-list-"));
+    writeFileSync(join(tmpDir, "0019_legacy.sql"), "", "utf-8");
+    writeFileSync(join(tmpDir, "0020_lockdown.sql"), "", "utf-8");
+    writeFileSync(join(tmpDir, "0021_grants.sql"), "", "utf-8");
+    writeFileSync(join(tmpDir, "0022_more_grants.sql"), "", "utf-8");
+    // Files that should be ignored:
+    writeFileSync(join(tmpDir, "README.md"), "", "utf-8");
+    writeFileSync(join(tmpDir, "not-a-migration.sql"), "", "utf-8");
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns sorted migrations at or above the cutoff", () => {
+    const result = listEnforcedMigrations(tmpDir, 21);
+    expect(result).toEqual(["0021_grants.sql", "0022_more_grants.sql"]);
+    expect(result).not.toContain("0019_legacy.sql");
+    expect(result).not.toContain("0020_lockdown.sql");
+  });
+
+  it("includes the predecessor when cutoff is lowered (inclusive boundary)", () => {
+    // F5 boundary pin — verifies idx === enforceFromIndex is included AND
+    // idx === enforceFromIndex - 1 is excluded. Catches a `>=` → `>` regression.
+    expect(listEnforcedMigrations(tmpDir, 20)).toEqual([
+      "0020_lockdown.sql",
+      "0021_grants.sql",
+      "0022_more_grants.sql",
+    ]);
+  });
+
+  it("excludes pre-cutoff migrations", () => {
+    expect(listEnforcedMigrations(tmpDir, 100)).toEqual([]);
+  });
+
+  it("ignores files that do not match the NNNN_*.sql pattern", () => {
+    const all = listEnforcedMigrations(tmpDir, 0);
+    expect(all).not.toContain("README.md");
+    expect(all).not.toContain("not-a-migration.sql");
+  });
+});
+
+describe("checkMigrationsDir", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "check-grants-dir-"));
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("ignores legacy migrations below ENFORCE_FROM_INDEX (idx < 21)", () => {
+    writeFileSync(
+      join(tmpDir, "0001_legacy.sql"),
+      `CREATE TABLE "tricks" (id uuid PRIMARY KEY);`,
+      "utf-8"
+    );
+    const failures = checkMigrationsDir(tmpDir, { syncedTables: SYNCED });
+    expect(failures).toEqual([]);
+  });
+
+  it("flags an in-scope migration that creates a synced table without GRANT", () => {
+    writeFileSync(
+      join(tmpDir, "0021_broken.sql"),
+      `CREATE TABLE "setlists" (id uuid PRIMARY KEY);`,
+      "utf-8"
+    );
+    const failures = checkMigrationsDir(tmpDir, { syncedTables: SYNCED });
+    const broken = failures.find((f) => f.file === "0021_broken.sql");
+    expect(broken).toBeDefined();
+    expect(broken?.subject).toBe("setlists");
+  });
+
+  it("does not satisfy the requirement with a GRANT in a different migration file", () => {
+    writeFileSync(
+      join(tmpDir, "0022_creates.sql"),
+      `CREATE TABLE "event_log" (id uuid PRIMARY KEY);`,
+      "utf-8"
+    );
+    writeFileSync(
+      join(tmpDir, "0023_grants_after.sql"),
+      `GRANT SELECT, INSERT ON "event_log" TO authenticated;`,
+      "utf-8"
+    );
+    const failures = checkMigrationsDir(tmpDir, { syncedTables: SYNCED });
+    const creating = failures.find((f) => f.file === "0022_creates.sql");
+    expect(creating).toBeDefined();
+    expect(creating?.subject).toBe("event_log");
+  });
+
+  it("passes against the real src/db/migrations directory (smoke)", () => {
+    // End-to-end guard: the canonical migrations tree must always satisfy
+    // the GRANT discipline. Catches regressions locally during `pnpm test:run`
+    // before CI's `pnpm sync:check:grants` step does.
+    const realMigrationsDir = join(process.cwd(), "src", "db", "migrations");
+    expect(checkMigrationsDir(realMigrationsDir)).toEqual([]);
+  });
+});

--- a/scripts/check-grants.ts
+++ b/scripts/check-grants.ts
@@ -1,0 +1,462 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SYNCED_TABLE_NAMES } from "../src/sync/synced-columns";
+
+// Migrations < 21 predate the GRANT discipline introduced by 0020 (issue #245)
+// and created tables under the old permissive default ACL — they don't (and
+// shouldn't retroactively) carry GRANT lines. Lift this constant only if the
+// historical baseline ever shifts.
+const ENFORCE_FROM_INDEX = 21;
+
+const MIGRATION_FILENAME_RE = /^(\d{4})_.+\.sql$/;
+// Allows an optional schema prefix (`public.tricks`, `"public"."tricks"`); the
+// captured group is the bare table name. Without the prefix branch, hand-written
+// schema-qualified DDL would silently bypass the check.
+const CREATE_TABLE_RE =
+  /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"?[a-zA-Z_][a-zA-Z0-9_]*"?\s*\.\s*)?"?([a-zA-Z_][a-zA-Z0-9_]*)"?/gi;
+// Captures every `GRANT … ON [TABLE] <targets> TO <grantees>;` in one pass; the
+// `(.+?)` target group spans newlines, and the `(?:TABLE\s+)?` skip handles the
+// optional `TABLE` keyword. Membership of `authenticated` in the grantee list is
+// checked downstream so multi-role lists in any order match correctly.
+const GRANT_RE = /GRANT\s+[^;]*?\sON\s+(?:TABLE\s+)?(.+?)\s+TO\s+([^;]+);/gis;
+const IDENTIFIER_RE = /"([a-zA-Z_][a-zA-Z0-9_]*)"|([a-zA-Z_][a-zA-Z0-9_]*)/g;
+const SECURITY_DEFINER_RE = /\bSECURITY\s+DEFINER\b/i;
+// Catches `REVOKE ... EXECUTE ... FROM ...;` in any of the supported shapes
+// (`ON FUNCTION foo()`, `ON ALL FUNCTIONS IN SCHEMA public`, `ALL PRIVILEGES`).
+const REVOKE_EXECUTE_RE =
+  /REVOKE\s+[^;]*?\bEXECUTE\b[^;]*?\bFROM\s+([^;]+);/gis;
+// Captures `CREATE [OR REPLACE] FUNCTION [<schema>.]<name>`. Optional schema is
+// group 1; bare function name is group 2. Capturing the schema lets the caller
+// scope SECURITY DEFINER attribution to schema `public` only — which is the sole
+// scope of the migrations.md §4 rule. A `CREATE FUNCTION other.foo …` is out of
+// scope (different schema, not subject to the lockdown discipline).
+const CREATE_FUNCTION_NAME_RE =
+  /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:"?([a-zA-Z_][a-zA-Z0-9_]*)"?\s*\.\s*)?"?([a-zA-Z_][a-zA-Z0-9_]*)"?/gi;
+// Captures `REVOKE [EXECUTE|ALL [PRIVILEGES]] ON FUNCTION [<schema>.]<name>[(<args>)] FROM <list>;`.
+// Schema is group 1 (optional); function name is group 2; FROM grantee list is
+// group 3. The argument signature is optional — PostgreSQL accepts the bare
+// form `ON FUNCTION foo FROM …;` when the name is unambiguous. The `[^)]*`
+// inside the parens stays on one signature.
+const REVOKE_NAMED_FUNCTION_RE =
+  /REVOKE\s+(?:EXECUTE|ALL(?:\s+PRIVILEGES)?)\s+ON\s+FUNCTION\s+(?:"?([a-zA-Z_][a-zA-Z0-9_]*)"?\s*\.\s*)?"?([a-zA-Z_][a-zA-Z0-9_]*)"?\s*(?:\([^)]*\))?\s+FROM\s+([^;]+);/gis;
+// Captures `REVOKE [EXECUTE|ALL [PRIVILEGES]] ON ALL FUNCTIONS IN SCHEMA public FROM <list>;`.
+// Schema is anchored to `public` (the sole scope of the rule) so a sweep over
+// a different schema cannot credit a public-schema definer function. FROM
+// grantee list is group 1.
+const REVOKE_ALL_FUNCTIONS_RE =
+  /REVOKE\s+(?:EXECUTE|ALL(?:\s+PRIVILEGES)?)\s+ON\s+ALL\s+FUNCTIONS\s+IN\s+SCHEMA\s+"?public"?\s+FROM\s+([^;]+);/gis;
+
+// True when `schema` is undefined (unqualified — defaults to `public` under the
+// search_path used by these migrations) or literally `public`. Used to scope
+// SECURITY DEFINER attribution and named-REVOKE coverage to the public schema —
+// the sole scope of the migrations.md §4 rule.
+function isPublicSchema(schema: string | undefined): boolean {
+  return schema === undefined || schema.toLowerCase() === "public";
+}
+
+type Failure = {
+  readonly file: string;
+  readonly subject: string;
+  readonly message: string;
+};
+
+// Strips line comments (`-- … <eol>`) and block comments (`/* … */`) so that
+// regex matches operate only on real SQL — a commented-out GRANT must not
+// satisfy the check, and a comment that mentions `CREATE TABLE` must not
+// trigger a false positive.
+//
+// Accepted limitation: not string-literal aware. A `--` or `/* */` sequence
+// inside a `'…'` string literal (including dynamic SQL embedded in a
+// `DO $$ … $$;` body via `EXECUTE '…'`) is stripped as if it were a comment.
+// In practice DDL migrations don't bury comment-like text in literals, and
+// the only failure mode is over-stripping (which can suppress a real GRANT
+// or CREATE TABLE token that lives inside a literal — not a real-world
+// pattern in this tree). Tightening to a full PG tokenizer is a larger lift
+// than this static check warrants.
+function stripSqlComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " ");
+}
+
+function parseGrantTargets(target: string): readonly string[] {
+  const names: string[] = [];
+  for (const match of target.matchAll(IDENTIFIER_RE)) {
+    const name = match[1] ?? match[2];
+    if (name) {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+// Splits a `TO ...;` grantee list (e.g. `authenticated, "neondb_owner"`) into a
+// normalized array of identifiers, lowercase and unquoted.
+function parseGrantees(grantees: string): readonly string[] {
+  return grantees
+    .split(",")
+    .map((g) => g.trim().replace(/^"|"$/g, "").toLowerCase());
+}
+
+function findCreatedSyncedTables(
+  sql: string,
+  syncedTables: ReadonlySet<string>
+): ReadonlySet<string> {
+  const created = new Set<string>();
+  for (const match of sql.matchAll(CREATE_TABLE_RE)) {
+    const name = match[1];
+    if (name && syncedTables.has(name)) {
+      created.add(name);
+    }
+  }
+  return created;
+}
+
+function findGrantedToAuthenticated(sql: string): ReadonlySet<string> {
+  const granted = new Set<string>();
+  for (const match of sql.matchAll(GRANT_RE)) {
+    const targets = match[1] ?? "";
+    const grantees = parseGrantees(match[2] ?? "");
+    if (!grantees.includes("authenticated")) {
+      continue;
+    }
+    for (const name of parseGrantTargets(targets)) {
+      granted.add(name);
+    }
+  }
+  return granted;
+}
+
+// Returns the names of `CREATE FUNCTION`s declared with `SECURITY DEFINER` in
+// `sql`. Each CREATE FUNCTION match defines a span (this match.index → next
+// match.index, or EOF for the last); SECURITY DEFINER appearing in a span is
+// attributed to that function. Out-of-CREATE SECURITY DEFINER (e.g.,
+// `ALTER FUNCTION foo() SECURITY DEFINER`) only triggers the `<function>`
+// sentinel fallback when no CREATE FUNCTION exists in the file — if a
+// CREATE FUNCTION's span happens to enclose an ALTER FUNCTION's keyword,
+// attribution lands on the CREATE'd function (accepted limitation; no such
+// migration exists in tree today).
+function findSecurityDefinerFunctionNames(sql: string): readonly string[] {
+  const matches = [...sql.matchAll(CREATE_FUNCTION_NAME_RE)];
+  const names: string[] = [];
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    const schema = match?.[1];
+    const name = match?.[2];
+    const start = match?.index;
+    if (!name || start === undefined || !isPublicSchema(schema)) {
+      continue;
+    }
+    const end = matches[i + 1]?.index ?? sql.length;
+    if (SECURITY_DEFINER_RE.test(sql.slice(start, end))) {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+type RevokeCoverage = {
+  readonly broadSweepGrantees: ReadonlySet<string>;
+  readonly namedFunctionGrantees: ReadonlyMap<string, ReadonlySet<string>>;
+};
+
+// Aggregates REVOKE EXECUTE coverage in one pass. Broad-sweep REVOKEs
+// (`ON ALL FUNCTIONS IN SCHEMA …`) apply to every function; named REVOKEs
+// (`ON FUNCTION foo(…)`) apply to that one function only. Two named REVOKEs
+// for the same function (e.g., FROM PUBLIC + FROM authenticated) merge into
+// one grantee set. `REVOKE ALL [PRIVILEGES]` forms are treated as covering
+// EXECUTE since they revoke a superset.
+function analyzeRevokeExecute(sql: string): RevokeCoverage {
+  const broad = new Set<string>();
+  for (const match of sql.matchAll(REVOKE_ALL_FUNCTIONS_RE)) {
+    for (const g of parseGrantees(match[1] ?? "")) {
+      broad.add(g);
+    }
+  }
+  const named = new Map<string, Set<string>>();
+  for (const match of sql.matchAll(REVOKE_NAMED_FUNCTION_RE)) {
+    const schema = match[1];
+    const name = match[2];
+    if (!(name && isPublicSchema(schema))) {
+      continue;
+    }
+    let set = named.get(name);
+    if (!set) {
+      set = new Set();
+      named.set(name, set);
+    }
+    for (const g of parseGrantees(match[3] ?? "")) {
+      set.add(g);
+    }
+  }
+  return { broadSweepGrantees: broad, namedFunctionGrantees: named };
+}
+
+// Per-function pairing check (issue #253, .claude/rules/migrations.md §4): each
+// SECURITY DEFINER function MUST be paired with a REVOKE EXECUTE that covers
+// both PUBLIC and authenticated. A function is covered if either:
+//   1. A broad-sweep REVOKE (`ON ALL FUNCTIONS IN SCHEMA …`) covers both
+//      grantees in this file, or
+//   2. A named REVOKE for that function — combined with any broad-sweep
+//      grantees — covers both PUBLIC and authenticated.
+// `CREATE FUNCTION` auto-grants EXECUTE to PUBLIC, and `authenticated`
+// inherits via PUBLIC; missing the pair lets `authenticated` invoke the
+// definer function and bypass RLS + column GRANTs.
+function findFunctionsWithMissingRevoke(
+  sql: string,
+  definerNames: readonly string[]
+): readonly string[] {
+  if (definerNames.length === 0) {
+    return [];
+  }
+  const { broadSweepGrantees, namedFunctionGrantees } =
+    analyzeRevokeExecute(sql);
+  if (
+    broadSweepGrantees.has("public") &&
+    broadSweepGrantees.has("authenticated")
+  ) {
+    return [];
+  }
+  const missing: string[] = [];
+  for (const name of definerNames) {
+    const grantees = new Set(broadSweepGrantees);
+    const fnGrantees = namedFunctionGrantees.get(name);
+    if (fnGrantees) {
+      for (const g of fnGrantees) {
+        grantees.add(g);
+      }
+    }
+    if (!(grantees.has("public") && grantees.has("authenticated"))) {
+      missing.push(name);
+    }
+  }
+  return missing;
+}
+
+// Non-global detector for `CREATE [OR REPLACE] FUNCTION` — used to classify a
+// statement as a function declaration without mutating regex state.
+const CREATE_FUNCTION_DETECT_RE = /\bCREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\b/i;
+// Anchored detector for a dollar-quote opener at the current cursor position
+// (`$$` or `$tag$`). Hot path inside `splitTopLevelStatements`, which is why
+// it lives at module scope rather than inline.
+const DOLLAR_QUOTE_OPEN_RE = /^\$([a-zA-Z_][a-zA-Z0-9_]*)?\$/;
+
+// Splits SQL into top-level statements at `;`, respecting dollar-quoted bodies
+// (`$$ … $$`, `$tag$ … $tag$`). String literals (`'…'`) are not handled
+// specially — DDL migrations don't typically contain semicolons inside string
+// literals, and a stray `';'` would only over-split, never under-split. Used by
+// `hasOrphanSecurityDefiner` to determine whether a SECURITY DEFINER mention
+// sits inside a CREATE FUNCTION declaration (shielded) or outside any (orphan).
+function splitTopLevelStatements(sql: string): readonly string[] {
+  const statements: string[] = [];
+  let current = "";
+  let i = 0;
+  let dollarTag: string | null = null;
+  while (i < sql.length) {
+    if (dollarTag === null) {
+      const open = DOLLAR_QUOTE_OPEN_RE.exec(sql.slice(i));
+      if (open) {
+        dollarTag = open[1] ?? "";
+        current += open[0];
+        i += open[0].length;
+        continue;
+      }
+      if (sql[i] === ";") {
+        statements.push(`${current};`);
+        current = "";
+        i++;
+        continue;
+      }
+      current += sql[i];
+      i++;
+    } else {
+      const close = `$${dollarTag}$`;
+      if (sql.startsWith(close, i)) {
+        current += close;
+        i += close.length;
+        dollarTag = null;
+        continue;
+      }
+      current += sql[i];
+      i++;
+    }
+  }
+  if (current.trim() !== "") {
+    statements.push(current);
+  }
+  return statements;
+}
+
+// True when any top-level statement contains SECURITY DEFINER outside a
+// CREATE FUNCTION declaration (e.g., `ALTER FUNCTION foo() SECURITY DEFINER;`,
+// or `CREATE PROCEDURE … SECURITY DEFINER`). This is the trigger for the
+// `<function>` sentinel fallback. Statement-level scoping (vs the previous
+// span-tiling approach) blocks two regressions: (a) a non-public CREATE
+// FUNCTION's "span" silently shielding a real public-schema orphan SD via
+// span-extension to EOF, and (b) SD inside a non-public CREATE FUNCTION body
+// being treated as orphan because schema-filtered span definition leaves the
+// body uncovered. Accepted limitation (symmetric to F-A's): a DO block whose
+// body literally contains the text "SECURITY DEFINER" (e.g., dynamic SQL like
+// `EXECUTE 'CREATE FUNCTION … SECURITY DEFINER …'`) would flag as orphan
+// here. Zero such migrations exist in tree; tightening would require
+// statement-introspection inside dollar-quoted bodies.
+function hasOrphanSecurityDefiner(sql: string): boolean {
+  for (const stmt of splitTopLevelStatements(sql)) {
+    if (
+      SECURITY_DEFINER_RE.test(stmt) &&
+      !CREATE_FUNCTION_DETECT_RE.test(stmt)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Coarse fallback: when SECURITY DEFINER appears outside any CREATE FUNCTION
+// (e.g., `ALTER FUNCTION foo() SECURITY DEFINER`), the per-function pairing
+// can't attribute the keyword to a specific name. This file-level check at
+// least asserts that some REVOKE EXECUTE covering both PUBLIC and authenticated
+// exists somewhere in the file.
+function hasRevokeExecuteFromPublicAndAuthenticated(sql: string): boolean {
+  let foundPublic = false;
+  let foundAuthenticated = false;
+  for (const match of sql.matchAll(REVOKE_EXECUTE_RE)) {
+    const grantees = parseGrantees(match[1] ?? "");
+    if (grantees.includes("public")) {
+      foundPublic = true;
+    }
+    if (grantees.includes("authenticated")) {
+      foundAuthenticated = true;
+    }
+  }
+  return foundPublic && foundAuthenticated;
+}
+
+function checkMigrationFile(
+  filename: string,
+  rawSql: string,
+  syncedTables: ReadonlySet<string>
+): readonly Failure[] {
+  const sql = stripSqlComments(rawSql);
+  const failures: Failure[] = [];
+
+  const created = findCreatedSyncedTables(sql, syncedTables);
+  if (created.size > 0) {
+    const granted = findGrantedToAuthenticated(sql);
+    for (const table of created) {
+      if (!granted.has(table)) {
+        failures.push({
+          file: filename,
+          subject: table,
+          message: `${filename}: synced table "${table}" was created without a matching \`GRANT … TO authenticated;\` in the same migration. Since 0020, schema \`public\` has no default privileges for \`authenticated\` — add an explicit GRANT in this migration. See .claude/rules/migrations.md §3.`,
+        });
+      }
+    }
+  }
+
+  if (SECURITY_DEFINER_RE.test(sql)) {
+    // Per-function pairing for SECURITY DEFINER functions in schema `public`
+    // (the sole scope of the rule). Non-public-schema definer functions are
+    // out of scope and produce zero entries here.
+    for (const fn of findFunctionsWithMissingRevoke(
+      sql,
+      findSecurityDefinerFunctionNames(sql)
+    )) {
+      failures.push({
+        file: filename,
+        subject: fn,
+        message: `${filename}: SECURITY DEFINER function "${fn}" declared without a matching \`REVOKE EXECUTE ON FUNCTION ${fn}(...) FROM PUBLIC, authenticated;\` (or broad-sweep \`REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC, authenticated;\`) in the same migration. \`CREATE FUNCTION\` grants EXECUTE to PUBLIC by default and \`authenticated\` inherits via PUBLIC — bypassing RLS and column GRANTs. See .claude/rules/migrations.md §4.`,
+      });
+    }
+    // Orphan SECURITY DEFINER (outside any CREATE FUNCTION span — e.g.,
+    // `ALTER FUNCTION foo() SECURITY DEFINER`). The script can't pair this
+    // to a CREATE'd function name, so it falls back to the coarse file-level
+    // REVOKE check + `<function>` sentinel.
+    if (
+      hasOrphanSecurityDefiner(sql) &&
+      !hasRevokeExecuteFromPublicAndAuthenticated(sql)
+    ) {
+      failures.push({
+        file: filename,
+        subject: "<function>",
+        message: `${filename}: SECURITY DEFINER appears outside any CREATE FUNCTION declaration this script can identify. Add a per-function \`REVOKE EXECUTE … FROM PUBLIC, authenticated;\` (or a broad-sweep \`REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC, authenticated;\`) in the same migration. See .claude/rules/migrations.md §4.`,
+      });
+    }
+  }
+
+  return failures;
+}
+
+function listEnforcedMigrations(
+  migrationsDir: string,
+  enforceFromIndex: number
+): readonly string[] {
+  const matches: string[] = [];
+  for (const file of readdirSync(migrationsDir)) {
+    const match = file.match(MIGRATION_FILENAME_RE);
+    if (!match) {
+      continue;
+    }
+    const idx = Number.parseInt(match[1] ?? "", 10);
+    if (Number.isFinite(idx) && idx >= enforceFromIndex) {
+      matches.push(file);
+    }
+  }
+  return matches.sort();
+}
+
+type CheckOptions = {
+  readonly syncedTables?: ReadonlySet<string>;
+  readonly enforceFromIndex?: number;
+};
+
+function checkMigrationsDir(
+  migrationsDir: string,
+  options: CheckOptions = {}
+): readonly Failure[] {
+  const synced = options.syncedTables ?? new Set<string>(SYNCED_TABLE_NAMES);
+  const enforceFromIndex = options.enforceFromIndex ?? ENFORCE_FROM_INDEX;
+  const files = listEnforcedMigrations(migrationsDir, enforceFromIndex);
+  const failures: Failure[] = [];
+  for (const file of files) {
+    const sql = readFileSync(join(migrationsDir, file), "utf-8");
+    failures.push(...checkMigrationFile(file, sql, synced));
+  }
+  return failures;
+}
+
+function main(): void {
+  const projectRoot = join(import.meta.dirname, "..");
+  const migrationsDir = join(projectRoot, "src", "db", "migrations");
+  const failures = checkMigrationsDir(migrationsDir);
+
+  if (failures.length > 0) {
+    console.error("Synced-table GRANT discipline check failed:");
+    for (const failure of failures) {
+      console.error(`  - ${failure.message}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Synced-table GRANT discipline check passed.");
+}
+
+export type { CheckOptions, Failure };
+export {
+  checkMigrationFile,
+  checkMigrationsDir,
+  findCreatedSyncedTables,
+  findGrantedToAuthenticated,
+  hasRevokeExecuteFromPublicAndAuthenticated,
+  listEnforcedMigrations,
+  parseGrantees,
+  parseGrantTargets,
+  stripSqlComments,
+};
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === process.argv[1];
+
+if (invokedDirectly) {
+  main();
+}

--- a/src/db/migrations/0021_lockdown_sequence_function_acls.sql
+++ b/src/db/migrations/0021_lockdown_sequence_function_acls.sql
@@ -1,0 +1,58 @@
+-- 0021: lock down sequence and function privileges for `authenticated` (issue #253).
+--
+-- Follow-up to 0020 (#245). 0020 revoked the default table ACL but intentionally left
+-- pg_default_acl for sequences (U/USAGE) and functions (X/EXECUTE) on schema public
+-- granting to `authenticated`. Today's tree uses uuid().defaultRandom() PKs everywhere
+-- (no SERIAL/IDENTITY) and has zero SECURITY DEFINER functions in public (audited via
+-- pg_proc on 2026-05-03 — see issue #253 for the audit query + result), so the holes
+-- are dormant. They become live the moment a future migration adds:
+--   - a SERIAL/IDENTITY column or `CREATE SEQUENCE` on a synced table — `authenticated`
+--     would silently auto-grant USAGE on the sequence, allowing out-of-band `nextval()`
+--     to burn IDs or `currval()` for enumeration.
+--   - a `SECURITY DEFINER` function in public — `authenticated` would silently auto-grant
+--     EXECUTE, a privilege-escalation primitive that bypasses RLS and column GRANTs.
+--
+-- This migration:
+--   1. Asserts current_user = neondb_owner — same grantor-consistency invariant as 0020,
+--      since ALTER DEFAULT PRIVILEGES is keyed on the grantor.
+--   2. Revokes default sequence + function ACLs for `authenticated` so future objects
+--      created in public are inaccessible to that role unless explicitly granted.
+--   3. Sweeps existing function EXECUTE grants (covers the 3 invoker-rights helpers
+--      `set_updated_at`, `bump_updated_at_on_fk_null`, `show_db_tree`). The
+--      `REVOKE EXECUTE ON ALL FUNCTIONS` form is signature-agnostic and matches the
+--      spirit of the default-ACL revoke.
+--
+-- Going forward, mirroring 0020's table convention:
+--   - Any new `CREATE SEQUENCE` (or sequence-defaulted column) on a synced table MUST
+--     include `GRANT USAGE, SELECT ON SEQUENCE … TO authenticated;` in the same migration.
+--   - Any new `SECURITY DEFINER` function in public MUST include explicit
+--     `REVOKE EXECUTE … FROM PUBLIC, authenticated;` plus targeted GRANTs as needed.
+--
+-- Runs inside one PL/pgSQL anonymous DO block — one HTTP call under @neondatabase/serverless,
+-- one implicit transaction. All-or-nothing application.
+--
+-- ROLLBACK / RECOVERY: forward-only. If a future migration legitimately needs a sequence or
+-- function accessible to `authenticated`, ship the explicit GRANT in that migration; do not
+-- revert the default-ACL revoke.
+
+DO $$ BEGIN
+  IF current_user <> 'neondb_owner' THEN
+    RAISE EXCEPTION
+      'Migration 0021 must run as neondb_owner to ensure ALTER DEFAULT PRIVILEGES grantor consistency; got: %',
+      current_user;
+  END IF;
+
+  ALTER DEFAULT PRIVILEGES FOR ROLE neondb_owner IN SCHEMA public
+    REVOKE ALL ON SEQUENCES FROM authenticated;
+
+  ALTER DEFAULT PRIVILEGES FOR ROLE neondb_owner IN SCHEMA public
+    REVOKE ALL ON FUNCTIONS FROM authenticated;
+
+  -- Safe for the trigger functions (set_updated_at, bump_updated_at_on_fk_null):
+  -- PostgreSQL checks trigger-function EXECUTE against the trigger DEFINER
+  -- (neondb_owner here), not the firing user — so REVOKE EXECUTE from
+  -- authenticated does not break BEFORE/AFTER triggers on synced tables.
+  -- (See PG docs: "Triggers" — run-time permission checks are performed
+  -- against the user that defined the trigger.)
+  REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM authenticated;
+END $$;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1777558792560,
       "tag": "0020_lockdown_authenticated_grants",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1777814835235,
+      "tag": "0021_lockdown_sequence_function_acls",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #253 and #254 in one PR — the migration and the static enforcer for it ship together.

**Migration `0021_lockdown_sequence_function_acls.sql`** extends the `authenticated`-role default-ACL lockdown from tables (introduced by `0020`/#245) to **sequences** and **functions** in schema `public`. Today's schema uses UUID PKs and has zero `SECURITY DEFINER` functions (audited via `pg_proc` 2026-05-03), so the holes are dormant — but the new defaults guard against future `SERIAL`/`IDENTITY` columns and `SECURITY DEFINER` helpers, both of which would otherwise auto-grant privileges to `authenticated` that bypass RLS and column-level GRANTs. The migration also sweeps existing function `EXECUTE` grants from `authenticated`. Same `current_user = neondb_owner` invariant as `0020` for grantor consistency.

**`scripts/check-grants.ts`** is a static analyzer that runs in pre-commit (lefthook) and CI (`pnpm sync:check:grants`). It enforces two rules from `.claude/rules/migrations.md`:

- **§3** — every `CREATE TABLE` for a synced table (idx ≥ 21) must include a matching `GRANT … TO authenticated;` in the same migration.
- **§4** — every `SECURITY DEFINER` function in schema `public` must be paired with `REVOKE EXECUTE … FROM PUBLIC, authenticated;` (per-function or a broad-sweep `REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public`).

The checker handles schema-qualified DDL, dollar-quoted bodies, comment stripping, bare-name `REVOKE` forms, broad-sweep accumulation, and orphan `SECURITY DEFINER` (e.g., `ALTER FUNCTION … SECURITY DEFINER`) via a `<function>` sentinel fallback.

Synced-table list is sourced from `src/sync/synced-columns.ts` (canonical, generated from Drizzle).

## Test plan

- [x] `pnpm test:run scripts/check-grants.test.ts` — 65 unit tests + 1 smoke test against the real `src/db/migrations/` directory all pass
- [x] `pnpm sync:check:grants` passes against the current tree
- [x] `pnpm exec tsc --noEmit` clean
- [x] Pre-commit hook (lefthook) glob covers `src/db/migrations/*.sql`, `src/sync/synced-columns.ts`, `scripts/check-grants.ts`
- [x] CI step `Synced-table GRANT discipline check` wired in `.github/workflows/ci.yml`
- [ ] After merge: apply via `mcp__neon__reset_from_parent` + `pnpm db:migrate` on `dev/julien` to verify the migration runs cleanly