### PR TITLE
fix: surface silent join-query failures in collect/repertoire (#218)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,12 +162,13 @@ The `authenticated` role is currently exercised only by the JWT-aware client pat
 
 ## Commit & Push Discipline
 
-- **Never run any command that produces a commit, mutates remote state, or opens/modifies a PR without an explicit user-typed `/ship`.** This includes (non-exhaustive): `git commit`, `git push` (with or without `--tags` / `--force`), `gh pr create`, `gh pr merge`, `gh pr edit`, `gh pr close`, `gh pr review`, `gh release create`, `gh issue create`. Only the `/ship` skill is authorized to perform these actions.
+- **Never run any command that produces a commit, mutates remote state, or opens/modifies a PR without an explicit user-typed `/ship`.** This includes (non-exhaustive): `git commit`, `git push` (with or without `--tags` / `--force`), `gh pr create`, `gh pr merge`, `gh pr edit`, `gh pr close`, `gh pr review`, `gh release create`. Only the `/ship` skill is authorized to perform these actions.
 - A plan I produced that lists `/ship` as a step does **not** authorize me to perform that step myself. Plan approval authorizes the approach, not the user-side ritual.
 - If `Skill(/ship)` is unavailable from my context (e.g. "cannot be used with Skill tool"), stop with a one-line summary of repo state ("branch X ready, run `/ship`") and wait. Do **not** fall back to manual `git commit` / `git push` / `gh pr create`.
 - Authorization is per-invocation, not per-session. A previous `/ship` does not authorize the next one.
 - Verbal instructions like "commit this" / "push it" / "go ahead and ship" do **not** substitute for `/ship`. The user must type `/ship`. Natural-language go-aheads are not authorization for these actions.
 - Read-only `git` (status, diff, log) and local-only operations (checkout, branch -m, stash) are fine. The line is at anything that produces a commit, mutates remote state, or opens a PR.
+- **Issue creation is allowed without `/ship`.** `gh issue create` (and `gh issue edit` / `gh issue close` / `gh issue comment`) does not produce a commit, mutate code state, or affect a PR — it's a tracking action. Use it directly when filing follow-ups, surfacing bugs found during review, or recording out-of-scope work. Still match labels and milestones to project conventions; still don't bulk-create or close other people's issues without confirmation.
 
 ---
 

--- a/src/features/collect/components/collect-view.test.tsx
+++ b/src/features/collect/components/collect-view.test.tsx
@@ -3,7 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ItemId, TagId, TrickId } from "@/db/types";
 import type { ParsedItem } from "../types";
-import { CollectView } from "./collect-view";
+import {
+  AVAILABLE_TRICKS_QUERY,
+  CollectView,
+  ITEM_TAGS_QUERY,
+  ITEM_TRICKS_QUERY,
+} from "./collect-view";
 import type { ItemDeleteDialogProps } from "./item-delete-dialog";
 import type { ItemFiltersProps } from "./item-filters";
 import type { ItemFormSheetProps } from "./item-form-sheet";
@@ -336,7 +341,7 @@ describe("CollectView", () => {
 
     // The first useQuery call is the item_tags join — seed it with two existing tags
     vi.mocked(useQuery).mockImplementation((sql) => {
-      if (typeof sql === "string" && sql.includes("FROM item_tags")) {
+      if (sql === ITEM_TAGS_QUERY) {
         return {
           data: [
             {
@@ -420,7 +425,7 @@ describe("CollectView", () => {
       isLoading: false,
     });
     vi.mocked(useQuery).mockImplementation((sql) => {
-      if (typeof sql === "string" && sql.includes("FROM item_tags")) {
+      if (sql === ITEM_TAGS_QUERY) {
         return {
           data: [
             {
@@ -860,6 +865,554 @@ describe("CollectView", () => {
     expect(toast.error).not.toHaveBeenCalledWith(
       "collect.tagPicker.createFailed",
       expect.anything()
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #218 — silent join-query failures
+  // ---------------------------------------------------------------------------
+
+  it("blocks Edit when item_tags query has errored (issue #218)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useQuery } = await import("@powersync/react");
+    const itemId = "00000000-0000-4000-8000-00000000218a";
+    const item = makeItem(itemId, "Card Force");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+
+    const tagJoinError = new Error("item_tags schema drift");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === ITEM_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: tagJoinError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+
+    // Sheet must NOT open — guard short-circuits before setSheetOpen(true).
+    expect(capturedFormSheetProps.open).toBe(false);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("blocks Edit when item_tricks query has errored (issue #218)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useQuery } = await import("@powersync/react");
+    const itemId = "00000000-0000-4000-8000-00000000218b";
+    const item = makeItem(itemId, "Coin Vanish");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+
+    const trickJoinError = new Error("item_tricks parse error");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === ITEM_TRICKS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: trickJoinError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+
+    expect(capturedFormSheetProps.open).toBe(false);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("blocks Edit when available-tricks query has errored (issue #218)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useQuery } = await import("@powersync/react");
+    const itemId = "00000000-0000-4000-8000-00000000218c";
+    const item = makeItem(itemId, "Sponge Bunny");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+
+    const availableTricksError = new Error("tricks query failed");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === AVAILABLE_TRICKS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: availableTricksError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+
+    expect(capturedFormSheetProps.open).toBe(false);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("blocks Add when available-tricks query has errored (issue #218)", async () => {
+    const { useQuery } = await import("@powersync/react");
+
+    const availableTricksError = new Error("tricks query failed");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === AVAILABLE_TRICKS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: availableTricksError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+
+    // Add path also blocks because the picker source is broken.
+    expect(capturedFormSheetProps.open).toBe(false);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("does NOT block Add when only item_tags has errored (asymmetry, issue #218)", async () => {
+    const { useQuery } = await import("@powersync/react");
+
+    // item_tags errored, but availableTricks is healthy. Add path doesn't
+    // depend on existing-relation joins — seedEmpty([]) is the intended
+    // baseline.
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === ITEM_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: new Error("item_tags broken"),
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+
+    // Sheet OPENS — Add doesn't depend on join data.
+    expect(capturedFormSheetProps.open).toBe(true);
+    expect(capturedFormSheetProps.selectedTagIds).toEqual([]);
+    expect(capturedFormSheetProps.selectedTrickIds).toEqual([]);
+  });
+
+  it("does NOT block Add when only item_tricks has errored (asymmetry, issue #218)", async () => {
+    const { useQuery } = await import("@powersync/react");
+
+    // item_tricks errored, but availableTricks is healthy. Mirror of the
+    // item_tags-only Add test above — Add path doesn't gate on item-scoped
+    // join failures because seedEmpty([]) is the intended baseline. The
+    // mode-scoped close logic in collect-view.tsx (~line 292) only closes
+    // Add when availableTricksError is set; item_tricks does NOT close.
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === ITEM_TRICKS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: new Error("item_tricks broken"),
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+
+    // Sheet OPENS — Add doesn't depend on item_tricks join.
+    expect(capturedFormSheetProps.open).toBe(true);
+    expect(capturedFormSheetProps.selectedTagIds).toEqual([]);
+    expect(capturedFormSheetProps.selectedTrickIds).toEqual([]);
+  });
+
+  it("does NOT toast for brandsError (supplementary autocomplete)", async () => {
+    const { useItemBrands } = await import("../hooks/use-item-brands");
+    vi.mocked(useItemBrands).mockReturnValue({
+      brands: [],
+      error: new Error("brands offline"),
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-items-error" })
+    );
+  });
+
+  it("does NOT toast for locationsError (supplementary autocomplete)", async () => {
+    const { useItemLocations } = await import("../hooks/use-item-locations");
+    const { useItems } = await import("../hooks/use-items");
+    const itemId = "00000000-0000-4000-8000-00000000218d";
+    const item = makeItem(itemId, "Linking Rings");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItemLocations).mockReturnValue({
+      locations: [],
+      error: new Error("locations offline"),
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("auto-closes the sheet when a critical relation error fires after open", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const { useQuery } = await import("@powersync/react");
+    const itemId = "00000000-0000-4000-8000-00000000218e";
+    const item = makeItem(itemId, "Cups and Balls");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+
+    // Healthy initial state — sheet opens cleanly.
+    vi.mocked(useQuery).mockImplementation(() => ({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+    }));
+
+    const { rerender } = render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    // Background sync surfaces a join error — Effect B should close the sheet.
+    const tagJoinError = new Error("background sync drift");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === ITEM_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: tagJoinError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<CollectView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("auto-closes the Add sheet when availableTricks errors after open", async () => {
+    const { useQuery } = await import("@powersync/react");
+
+    // Healthy initial state — Add sheet opens cleanly.
+    vi.mocked(useQuery).mockImplementation(() => ({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+    }));
+
+    const { rerender } = render(<CollectView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    // Background sync surfaces an availableTricks error — the mode-scoped
+    // close effect should slam the Add sheet shut. In Add mode, only the
+    // picker source (availableTricksError) triggers the close; item-scoped
+    // joins do not.
+    const availableTricksError = new Error("background tricks failure");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === AVAILABLE_TRICKS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: availableTricksError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<CollectView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("uses a stable toast id so re-renders dedupe (idempotency)", async () => {
+    const { useQuery } = await import("@powersync/react");
+
+    // Stable error ref held in closure — survives re-renders.
+    const stableError = new Error("persistent schema drift");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === ITEM_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: stableError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    const { rerender } = render(<CollectView />);
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "collect.loadError",
+        expect.objectContaining({ id: "collect-load-relations-error" })
+      );
+    });
+
+    // Every fired call should carry the stable id — sonner dedupes by id.
+    const relationsCalls = vi
+      .mocked(toast.error)
+      .mock.calls.filter(([, opts]) => {
+        if (!opts || typeof opts !== "object") {
+          return false;
+        }
+        return (opts as { id?: string }).id === "collect-load-relations-error";
+      });
+
+    // Upper-bound assertion: a stable error reference + correct deps array
+    // should never produce more than a small constant number of toast calls
+    // for a single render. React strict-mode and any auto-reseed behavior can
+    // legitimately re-invoke the effect, but anything growing with rerender
+    // count is a regression. The bound of 2 leaves a small headroom for
+    // strict-mode double-invoke without masking unbounded toast spam.
+    expect(relationsCalls.length).toBeLessThanOrEqual(2);
+
+    // Force two more renders — the effect's deps are unchanged (same error
+    // ref), so a correctly-deduped effect must NOT add a new call per
+    // rerender. Total call count must remain bounded by a small constant
+    // regardless of rerender count.
+    rerender(<CollectView />);
+    rerender(<CollectView />);
+
+    const allRelationsCalls = vi
+      .mocked(toast.error)
+      .mock.calls.filter(([, opts]) => {
+        if (!opts || typeof opts !== "object") {
+          return false;
+        }
+        return (opts as { id?: string }).id === "collect-load-relations-error";
+      });
+
+    // Total toast call count after 1 render + 2 rerenders must remain
+    // bounded by a small constant. If it grows linearly with rerender count
+    // we've regressed the deps array or lost the stable error reference.
+    // Bound: 2 (initial) + 2 rerenders = 4 conservative ceiling.
+    expect(allRelationsCalls.length).toBeLessThanOrEqual(4);
+
+    // Every relations toast call must carry the stable id (matcher above
+    // already filters by id, so the assertion is "no rogue id-less calls
+    // crept in").
+    expect(
+      allRelationsCalls.every(([msg]) => msg === "collect.loadError")
+    ).toBe(true);
+  });
+
+  it("auto-closes the sheet if a relation query errors mid-edit (issue #218)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useQuery } = await import("@powersync/react");
+    const itemId = "00000000-0000-4000-8000-00000218e218";
+    const item = makeItem(itemId, "Stage Saw");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+
+    // All relation queries healthy — Edit must succeed in opening the sheet.
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+    });
+
+    const { rerender } = render(<CollectView />);
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(true);
+    });
+
+    // Flip item_tags to errored mid-session and rerender. The auto-close
+    // effect must slam the sheet shut rather than let the user save against
+    // a stale [] seed lock-in. Distinct from the entry-guard tests above:
+    // those pre-mock the error before render so handleEditItem returns
+    // early; this test exercises the useEffect path where the sheet has
+    // already opened.
+    const tagError = new Error("item_tags drifted mid-session");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === ITEM_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: tagError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<CollectView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
     );
   });
 });

--- a/src/features/collect/components/collect-view.tsx
+++ b/src/features/collect/components/collect-view.tsx
@@ -55,9 +55,33 @@ const UUID_RE =
 const LOAD_ITEMS_ERROR_TOAST_ID = "collect-load-items-error";
 /** Stable toast id for the editing-item load error (separate so it doesn't clobber the items toast). */
 const LOAD_EDIT_ITEM_ERROR_TOAST_ID = "collect-load-edit-item-error";
+/**
+ * Stable toast id for critical relation-query failures (item_tags, item_tricks,
+ * or the available-tricks picker source). One id covers all three because they
+ * share the same surfaced message and we never want to stack them. Issue #218.
+ */
+const LOAD_RELATIONS_ERROR_TOAST_ID = "collect-load-relations-error";
 
 /** Debounce delay for the search input (milliseconds). */
 const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * SQL strings exported as module-level constants so tests can match by
+ * reference equality rather than fragile substring inspection. The exact
+ * whitespace/structure is preserved — PowerSync parses these verbatim.
+ */
+export const ITEM_TAGS_QUERY = `SELECT it.item_id, t.id AS tag_id, t.name AS tag_name, t.color
+     FROM item_tags it
+     JOIN tags t ON it.tag_id = t.id
+     WHERE it.deleted_at IS NULL AND t.deleted_at IS NULL`;
+
+export const ITEM_TRICKS_QUERY = `SELECT itr.item_id, tr.id AS trick_id, tr.name AS trick_name
+     FROM item_tricks itr
+     JOIN tricks tr ON itr.trick_id = tr.id
+     WHERE itr.deleted_at IS NULL AND tr.deleted_at IS NULL`;
+
+export const AVAILABLE_TRICKS_QUERY =
+  "SELECT id, name FROM tricks WHERE deleted_at IS NULL ORDER BY name ASC";
 
 /**
  * Main orchestration component for the collection feature.
@@ -131,12 +155,7 @@ export function CollectView(): React.ReactElement {
     data: itemTagRows,
     error: itemTagError,
     isLoading: itemTagsLoading,
-  } = useQuery<ItemTagRow>(
-    `SELECT it.item_id, t.id AS tag_id, t.name AS tag_name, t.color
-     FROM item_tags it
-     JOIN tags t ON it.tag_id = t.id
-     WHERE it.deleted_at IS NULL AND t.deleted_at IS NULL`
-  );
+  } = useQuery<ItemTagRow>(ITEM_TAGS_QUERY);
 
   const itemTagMap = buildItemTagMap(itemTagRows);
 
@@ -147,12 +166,7 @@ export function CollectView(): React.ReactElement {
     data: itemTrickRows,
     error: itemTrickError,
     isLoading: itemTricksLoading,
-  } = useQuery<ItemTrickRow>(
-    `SELECT itr.item_id, tr.id AS trick_id, tr.name AS trick_name
-     FROM item_tricks itr
-     JOIN tricks tr ON itr.trick_id = tr.id
-     WHERE itr.deleted_at IS NULL AND tr.deleted_at IS NULL`
-  );
+  } = useQuery<ItemTrickRow>(ITEM_TRICKS_QUERY);
 
   const itemTrickMap = buildItemTrickMap(itemTrickRows);
 
@@ -191,9 +205,7 @@ export function CollectView(): React.ReactElement {
   // and gating on sheetOpen caused re-registration churn and an empty-picker
   // flash while the async query hydrated after the sheet opened.
   const { data: availableTrickRows, error: availableTricksError } =
-    useQuery<AvailableTrickRow>(
-      "SELECT id, name FROM tricks WHERE deleted_at IS NULL ORDER BY name ASC"
-    );
+    useQuery<AvailableTrickRow>(AVAILABLE_TRICKS_QUERY);
 
   const availableTricks: LinkedTrick[] = availableTrickRows.flatMap((row) => {
     if (typeof row.id !== "string" || !UUID_RE.test(row.id)) {
@@ -229,8 +241,40 @@ export function CollectView(): React.ReactElement {
   }, [editingItemId, editingItemError, t, tagsSel.reset, tricksSel.reset]);
 
   // ---------------------------------------------------------------------------
-  // Surface critical query errors as a single, replaceable toast.
-  // Supplementary queries (brands, locations, trick-join) only log.
+  // Items list error — toast on the list page since items are the page's data.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (itemsError) {
+      console.error("Items query error:", itemsError);
+      toast.error(t("loadError"), { id: LOAD_ITEMS_ERROR_TOAST_ID });
+    }
+  }, [itemsError, t]);
+
+  // ---------------------------------------------------------------------------
+  // Critical relation-query failures (issue #218). The empty/stale data they
+  // produce feeds useHydratedSelection's seed, which doesn't observe `error` —
+  // a save against the wrong baseline can silently NOT remove an
+  // existing-but-invisible relation, or hit a UNIQUE/PK violation when the
+  // user re-toggles it. Toast always so the user is informed even before
+  // clicking Edit/Add. Stable id so re-renders dedupe.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    const error = itemTagError ?? itemTrickError ?? availableTricksError;
+    if (!error) {
+      return;
+    }
+    console.error("[CollectView] Relation query error", {
+      itemTagError,
+      itemTrickError,
+      availableTricksError,
+    });
+    toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
+  }, [itemTagError, itemTrickError, availableTricksError, t]);
+
+  // ---------------------------------------------------------------------------
+  // Supplementary queries — datalist autocomplete only. Log so we can debug
+  // from session reports; do NOT toast (would be alarming for a non-critical
+  // degradation that doesn't affect save correctness).
   // ---------------------------------------------------------------------------
   useEffect(() => {
     if (brandsError) {
@@ -239,27 +283,42 @@ export function CollectView(): React.ReactElement {
     if (locationsError) {
       console.error("Locations query error:", locationsError);
     }
-    if (itemTagError) {
-      console.error("Item-tags query error:", itemTagError);
+  }, [brandsError, locationsError]);
+
+  // ---------------------------------------------------------------------------
+  // If a critical relation error fires while the sheet is open, close it
+  // rather than let the user save against potentially corrupted seed data.
+  // Mirrors the editingItemError handler above. Mode-scoped to match the
+  // handler-entry guards (issue #218 matrix):
+  //   - Edit (editingItemId !== null): any of item_tags / item_tricks /
+  //     available_tricks errors → close.
+  //   - Add (editingItemId === null): only available_tricks (picker source)
+  //     matters; the item-scoped joins don't feed the Add path.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (!sheetOpen) {
+      return;
     }
-    if (itemTrickError) {
-      console.error("Item-tricks query error:", itemTrickError);
-    }
-    if (availableTricksError) {
-      console.error("Available tricks query error:", availableTricksError);
-    }
-    if (itemsError) {
-      console.error("Items query error:", itemsError);
-      toast.error(t("loadError"), { id: LOAD_ITEMS_ERROR_TOAST_ID });
+    const inEditMode = editingItemId !== null;
+    const shouldClose = Boolean(
+      inEditMode
+        ? itemTagError || itemTrickError || availableTricksError
+        : availableTricksError
+    );
+    if (shouldClose) {
+      setSheetOpen(false);
+      setEditingItemId(null);
+      tagsSel.reset();
+      tricksSel.reset();
     }
   }, [
-    itemsError,
+    sheetOpen,
+    editingItemId,
     itemTagError,
     itemTrickError,
     availableTricksError,
-    brandsError,
-    locationsError,
-    t,
+    tagsSel.reset,
+    tricksSel.reset,
   ]);
 
   // ---------------------------------------------------------------------------
@@ -293,6 +352,13 @@ export function CollectView(): React.ReactElement {
   // ---------------------------------------------------------------------------
 
   function handleAddItem(): void {
+    // availableTricksError breaks the picker source; without it the user
+    // would create an item with an empty/misleading trick list (issue #218).
+    // The other relation errors are edit-only (item-scoped joins).
+    if (availableTricksError) {
+      toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
+      return;
+    }
     setEditingItemId(null);
     tagsSel.seedEmpty();
     tricksSel.seedEmpty();
@@ -300,6 +366,13 @@ export function CollectView(): React.ReactElement {
   }
 
   function handleEditItem(id: ItemId): void {
+    // Block opening the sheet if relation queries are broken — without
+    // current relations the seed lock-in would be empty, and the user
+    // can't see what they have or remove what they've toggled. Issue #218.
+    if (itemTagError || itemTrickError || availableTricksError) {
+      toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
+      return;
+    }
     // Reset before switching the id so the next render skeletons rather than
     // briefly displaying the previous row's selection. The hook's auto-reseed
     // would otherwise leave stale `selected` visible for one render frame
@@ -329,6 +402,7 @@ export function CollectView(): React.ReactElement {
           console.warn(
             "[CollectView] Submit blocked: relations not yet hydrated"
           );
+          toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
           return;
         }
 

--- a/src/features/repertoire/components/repertoire-view.test.tsx
+++ b/src/features/repertoire/components/repertoire-view.test.tsx
@@ -9,7 +9,11 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TagId, TrickId } from "@/db/types";
 import type { ParsedTrick, TrickWithTags } from "../types";
-import { RepertoireView } from "./repertoire-view";
+import {
+  RepertoireView,
+  TRICK_ITEMS_QUERY,
+  TRICK_TAGS_QUERY,
+} from "./repertoire-view";
 import type { TrickDeleteDialogProps } from "./trick-delete-dialog";
 import type { TrickFiltersProps } from "./trick-filters";
 import type { TrickFormSheetProps } from "./trick-form-sheet";
@@ -873,6 +877,41 @@ describe("RepertoireView", () => {
     expect(toast.error).not.toHaveBeenCalledWith("repertoire.deleteFailed");
   });
 
+  it("closes sheet and clears edit state when useTrick reports an error", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const trickId = "00000000-0000-4000-8000-000000ed7e44";
+    const trick = makeTrick(trickId, "Broken Trick");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [trick],
+      error: null,
+      isLoading: false,
+    });
+
+    // useTrick reports an error — the sheet must NOT stay open on the
+    // "add new" form when the edit target fails to hydrate.
+    vi.mocked(useTrick).mockReturnValue({
+      trick: null,
+      error: new Error("load failed"),
+      isLoading: false,
+    });
+
+    render(<RepertoireView />);
+
+    // Attempt to open the edit sheet — the load-error effect should slam it shut.
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-edit-trick-error" })
+    );
+  });
+
   // ---------------------------------------------------------------------------
   // Issue #216 — hydration-race regression coverage
   // ---------------------------------------------------------------------------
@@ -931,6 +970,14 @@ describe("RepertoireView", () => {
     );
     expect(mockUpdateTrick).not.toHaveBeenCalled();
 
+    // The block must surface a toast so the user knows submit was dropped.
+    // Stable id so a follow-up rapid re-submit collapses the notification.
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
+    );
+
     // Hydrate the row.
     vi.mocked(useTrick).mockReturnValue({
       trick,
@@ -987,6 +1034,366 @@ describe("RepertoireView", () => {
     expect(mockCreateTrick).toHaveBeenCalledWith(
       expect.objectContaining({ name: "New Trick" }),
       []
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #218 — silent join-query failures
+  // ---------------------------------------------------------------------------
+
+  it("blocks Edit when trick_tags query has errored (issue #218)", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useQuery } = await import("@powersync/react");
+    const trickId = "00000000-0000-4000-8000-00000000218a";
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [makeTrick(trickId, "Card Force")],
+      error: null,
+      isLoading: false,
+    });
+
+    const tagJoinError = new Error("trick_tags schema drift");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === TRICK_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: tagJoinError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+
+    expect(capturedFormSheetProps.open).toBe(false);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
+    );
+  });
+
+  it("does NOT block Edit when only trick_items has errored (asymmetry, issue #218)", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const { useQuery } = await import("@powersync/react");
+    const trickId = "00000000-0000-4000-8000-00000000218b";
+    const trick = makeTrick(trickId, "Coin Vanish");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [trick],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick,
+      isLoading: false,
+      error: null,
+    });
+
+    const itemJoinError = new Error("item_tricks parse error");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      // trickItemError SQL pulls from item_tricks; trick_tags is healthy.
+      if (sql === TRICK_ITEMS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: itemJoinError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+
+    // Sheet OPENS — trickItemError feeds only the inverse-relation display
+    // (TrickList badges), never the edit form. Toast still fires so the
+    // user knows the list is incomplete.
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
+    );
+  });
+
+  it("does NOT block Add when trick_tags has errored (asymmetry, issue #218)", async () => {
+    const { useQuery } = await import("@powersync/react");
+
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === TRICK_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: new Error("trick_tags broken"),
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<RepertoireView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_TRICK_PATTERN })
+    );
+
+    // Add path doesn't depend on join data — sheet OPENS.
+    expect(capturedFormSheetProps.open).toBe(true);
+    expect(capturedFormSheetProps.selectedTagIds).toEqual([]);
+  });
+
+  it("auto-closes the EDIT sheet when trick_tags errors after open", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const { useQuery } = await import("@powersync/react");
+    const trickId = "00000000-0000-4000-8000-00000000218c";
+    const trick = makeTrick(trickId, "Sponge Bunny");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [trick],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick,
+      isLoading: false,
+      error: null,
+    });
+
+    // Healthy initial state.
+    vi.mocked(useQuery).mockImplementation(() => ({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+    }));
+
+    const { rerender } = render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    // Background sync surfaces a trick_tags error.
+    const tagJoinError = new Error("background sync drift");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === TRICK_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: tagJoinError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<RepertoireView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+  });
+
+  it("does NOT auto-close the ADD sheet when trick_tags errors after open", async () => {
+    const { useQuery } = await import("@powersync/react");
+
+    // Healthy initial state.
+    vi.mocked(useQuery).mockImplementation(() => ({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+    }));
+
+    const { rerender } = render(<RepertoireView />);
+
+    // Open the Add sheet (no editing target).
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_TRICK_PATTERN })
+    );
+    expect(capturedFormSheetProps.open).toBe(true);
+    expect(capturedFormSheetProps.trick).toBeNull();
+
+    // Background trick_tags error fires — Add mode must remain open.
+    const tagJoinError = new Error("background sync drift");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === TRICK_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: tagJoinError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<RepertoireView />);
+
+    // Toast fires (page-level effect always toasts), but Add sheet stays open.
+    expect(capturedFormSheetProps.open).toBe(true);
+  });
+
+  it("uses a stable toast id so re-renders dedupe (idempotency)", async () => {
+    const { useQuery } = await import("@powersync/react");
+
+    const stableError = new Error("persistent schema drift");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === TRICK_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: stableError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    const { rerender } = render(<RepertoireView />);
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "repertoire.loadError",
+        expect.objectContaining({ id: "repertoire-load-relations-error" })
+      );
+    });
+
+    rerender(<RepertoireView />);
+    rerender(<RepertoireView />);
+
+    // Every relations-toast call must carry the stable id, AND the call
+    // count must stay within an upper bound so an unbounded effect-storm
+    // regression (e.g. dropping the stable error reference) fails this
+    // test instead of silently doubling toast volume on every rerender.
+    // The bound mirrors collect-view's idempotency test for parity:
+    // strict-mode double-invoke and any auto-reseed can legitimately
+    // re-fire the effect, but anything growing with rerender count
+    // signals a regression.
+    const relationsCalls = vi
+      .mocked(toast.error)
+      .mock.calls.filter(([, opts]) => {
+        if (!opts || typeof opts !== "object") {
+          return false;
+        }
+        return (
+          (opts as { id?: string }).id === "repertoire-load-relations-error"
+        );
+      });
+
+    // Upper-bound assertion: 1 render + 2 rerenders = 3 cycles, with
+    // headroom for strict-mode double-invoke gives a conservative ceiling
+    // of 4. Anything growing linearly with rerender count breaches this
+    // and surfaces an unbounded toast-storm regression.
+    expect(relationsCalls.length).toBeLessThanOrEqual(4);
+    expect(
+      relationsCalls.every(([msg]) => msg === "repertoire.loadError")
+    ).toBe(true);
+  });
+
+  it("auto-closes the sheet if trick_tags errors mid-edit (issue #218)", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const { useQuery } = await import("@powersync/react");
+    const trickId = "00000000-0000-4000-8000-00000218e218";
+    const trick = makeTrick(trickId, "Card Warp");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [trick],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick,
+      error: null,
+      isLoading: false,
+    });
+
+    // All relation queries healthy — Edit must succeed in opening the sheet.
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+    });
+
+    const { rerender } = render(<RepertoireView />);
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(true);
+    });
+
+    // Flip trick_tags to errored mid-session and rerender. The auto-close
+    // effect must close the sheet — without trick_tags the seed lock-in
+    // would be empty and the user can't see what they have or remove what
+    // they've toggled. Distinct from the entry-guard tests above: those
+    // pre-mock the error before render so handleEditTrick returns early;
+    // this exercises the useEffect path where the sheet has already opened.
+    // trickItemError is intentionally NOT exercised here — the asymmetric
+    // case (sheet stays open) is covered separately.
+    const tagError = new Error("trick_tags drifted mid-session");
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === TRICK_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: tagError,
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+    rerender(<RepertoireView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
     );
   });
 });

--- a/src/features/repertoire/components/repertoire-view.tsx
+++ b/src/features/repertoire/components/repertoire-view.tsx
@@ -70,8 +70,32 @@ interface TrickItemRow {
 /** Debounce delay for the search input (milliseconds). */
 const SEARCH_DEBOUNCE_MS = 300;
 
+/**
+ * SQL for the trick_tags + tags join. Exported so tests can match by reference
+ * equality (substring matching is fragile — see finding #8). Whitespace is
+ * preserved verbatim because PowerSync parses these strings.
+ */
+export const TRICK_TAGS_QUERY = `SELECT tt.trick_id, t.id AS tag_id, t.name AS tag_name, t.color
+     FROM trick_tags tt
+     JOIN tags t ON tt.tag_id = t.id
+     WHERE tt.deleted_at IS NULL AND t.deleted_at IS NULL`;
+
+/**
+ * SQL for the item_tricks + items join. Exported alongside TRICK_TAGS_QUERY
+ * for the same reference-equality reason. Whitespace preserved verbatim.
+ */
+export const TRICK_ITEMS_QUERY = `SELECT itr.trick_id, i.id AS item_id, i.name AS item_name
+     FROM item_tricks itr
+     JOIN items i ON itr.item_id = i.id
+     WHERE itr.deleted_at IS NULL AND i.deleted_at IS NULL`;
+
 /** Stable toast id for the editing-trick load error (separate so it doesn't clobber the relations toast). */
 const LOAD_EDIT_TRICK_ERROR_TOAST_ID = "repertoire-load-edit-trick-error";
+/**
+ * Stable toast id for trick_tags / trick_items query failures. One id covers
+ * both — same surfaced message, never want to stack. Issue #218.
+ */
+const LOAD_RELATIONS_ERROR_TOAST_ID = "repertoire-load-relations-error";
 
 /**
  * Main orchestration component for the repertoire feature.
@@ -142,12 +166,7 @@ export function RepertoireView(): React.ReactElement {
     data: trickTagRows,
     error: trickTagError,
     isLoading: trickTagsLoading,
-  } = useQuery<TrickTagRow>(
-    `SELECT tt.trick_id, t.id AS tag_id, t.name AS tag_name, t.color
-     FROM trick_tags tt
-     JOIN tags t ON tt.tag_id = t.id
-     WHERE tt.deleted_at IS NULL AND t.deleted_at IS NULL`
-  );
+  } = useQuery<TrickTagRow>(TRICK_TAGS_QUERY);
 
   const trickTagMap = buildTrickTagMap(trickTagRows);
 
@@ -172,19 +191,28 @@ export function RepertoireView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   // Trick-items join query (build a Map<trickId, LinkedItem[]>)
   // ---------------------------------------------------------------------------
-  const { data: trickItemRows, error: trickItemError } = useQuery<TrickItemRow>(
-    `SELECT itr.trick_id, i.id AS item_id, i.name AS item_name
-     FROM item_tricks itr
-     JOIN items i ON itr.item_id = i.id
-     WHERE itr.deleted_at IS NULL AND i.deleted_at IS NULL`
-  );
+  const { data: trickItemRows, error: trickItemError } =
+    useQuery<TrickItemRow>(TRICK_ITEMS_QUERY);
 
+  // ---------------------------------------------------------------------------
+  // Toast on any relation-query failure so the user is informed even before
+  // clicking Edit/Add. Stable id so re-renders dedupe. Mirrors the unified
+  // shape used in collect-view for consistency. The critical-vs-supplementary
+  // asymmetry between the two errors (trickTagError feeds tagsSel seed
+  // lock-in; trickItemError feeds only the inverse-relation badge) only
+  // matters for auto-close behavior — see the next effect — not for toast
+  // surfacing, where both should equally inform the user (issue #218).
+  // ---------------------------------------------------------------------------
   useEffect(() => {
     const error = trickTagError ?? trickItemError;
-    if (error) {
-      console.error("Failed to load trick relations:", error);
-      toast.error(t("loadError"));
+    if (!error) {
+      return;
     }
+    console.error("[RepertoireView] Relation query error", {
+      trickTagError,
+      trickItemError,
+    });
+    toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
   }, [trickTagError, trickItemError, t]);
 
   // ---------------------------------------------------------------------------
@@ -203,6 +231,20 @@ export function RepertoireView(): React.ReactElement {
       tagsSel.reset();
     }
   }, [editingTrickId, editingTrickError, t, tagsSel.reset]);
+
+  // ---------------------------------------------------------------------------
+  // If trickTagError fires while the EDIT sheet is open, close it rather
+  // than let the user save against an empty seed lock-in. Add path is
+  // unaffected — there are no existing relations to seed (issue #218).
+  // trickItemError is intentionally NOT here — it never feeds the edit form.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (sheetOpen && editingTrickId !== null && trickTagError) {
+      setSheetOpen(false);
+      setEditingTrickId(null);
+      tagsSel.reset();
+    }
+  }, [sheetOpen, editingTrickId, trickTagError, tagsSel.reset]);
 
   const trickItemMap = buildTrickItemMap(trickItemRows);
 
@@ -236,6 +278,13 @@ export function RepertoireView(): React.ReactElement {
   }
 
   function handleEditTrick(id: TrickId): void {
+    // Block opening the sheet if trick_tags is broken — without it the seed
+    // lock-in would be empty and the user can't see what they have or
+    // remove what they've toggled. Issue #218.
+    if (trickTagError) {
+      toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
+      return;
+    }
     // Reset before switching the id so the next render skeletons rather than
     // briefly displaying the previous row's selection. The hook's auto-reseed
     // would otherwise leave stale `selected` visible for one render frame
@@ -262,6 +311,7 @@ export function RepertoireView(): React.ReactElement {
           console.warn(
             "[RepertoireView] Submit blocked: relations not yet hydrated"
           );
+          toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
           return;
         }
 
@@ -345,6 +395,7 @@ export function RepertoireView(): React.ReactElement {
       return (
         <TrickList
           itemMap={trickItemMap}
+          linkedItemsError={Boolean(trickItemError)}
           onDelete={handleDeleteTrick}
           onEdit={handleEditTrick}
           tricks={tricksWithTags}

--- a/src/features/repertoire/components/trick-card.test.tsx
+++ b/src/features/repertoire/components/trick-card.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { TagId, TrickId } from "@/db/types";
+import type { ItemId, TagId, TrickId } from "@/db/types";
 import type { TrickWithTags } from "../types";
 import { formatDuration, getContrastColor, TrickCard } from "./trick-card";
 
@@ -221,6 +221,70 @@ describe("TrickCard", () => {
       />
     );
     expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  // Issue #218 follow-up — `linkedItemsError` indicator branch.
+  // The icon carries role="img" + aria-label so it's reachable by AT users
+  // without spawning a polite live region per card.
+  it("renders an error indicator (not a live region) when linkedItemsError is true", () => {
+    render(
+      <TrickCard
+        linkedItems={[]}
+        linkedItemsError
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        trick={makeTrick()}
+      />
+    );
+
+    // Labeled icon — accessible name surfaces via aria-label on the icon.
+    expect(
+      screen.getByRole("img", { name: "repertoire.loadError" })
+    ).toBeInTheDocument();
+
+    // No status/alert live region — must NOT spawn polite/assertive regions.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders the linked items list when linkedItemsError is false and items are present", () => {
+    render(
+      <TrickCard
+        linkedItems={[
+          { id: "i1" as ItemId, name: "Card Box" },
+          { id: "i2" as ItemId, name: "Coin Shell" },
+        ]}
+        linkedItemsError={false}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        trick={makeTrick()}
+      />
+    );
+
+    // Linked items render as a single comma-joined text node.
+    expect(screen.getByText("Card Box, Coin Shell")).toBeInTheDocument();
+    // No error indicator when error flag is off, even when caller passes the prop.
+    expect(
+      screen.queryByRole("img", { name: "repertoire.loadError" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for linked items when linkedItemsError is false and the list is empty", () => {
+    render(
+      <TrickCard
+        linkedItems={[]}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        trick={makeTrick()}
+      />
+    );
+
+    // Neither the error indicator nor a "0 items" listing — distinguishes
+    // "no linked items" from "couldn't load" purely by the absence/presence
+    // of the role="img" loadError node.
+    expect(
+      screen.queryByRole("img", { name: "repertoire.loadError" })
+    ).not.toBeInTheDocument();
   });
 
   it("calls onEdit when Space is pressed on the card", async () => {

--- a/src/features/repertoire/components/trick-card.tsx
+++ b/src/features/repertoire/components/trick-card.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Clock, Edit, MoreHorizontal, Package, Trash2 } from "lucide-react";
+import {
+  CircleAlert,
+  Clock,
+  Edit,
+  MoreHorizontal,
+  Package,
+  Trash2,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -18,6 +25,13 @@ import { TrickStatusBadge } from "./trick-status-badge";
 
 interface TrickCardProps {
   linkedItems?: { id: ItemId; name: string }[];
+  /**
+   * True when the parent's trick_items query failed. Renders a muted
+   * indicator badge in place of the linked-items list so the user can
+   * distinguish "no linked items" from "failed to load" (issue #218
+   * follow-up).
+   */
+  linkedItemsError?: boolean;
   onDelete: (id: TrickId) => void;
   onEdit: (id: TrickId) => void;
   trick: TrickWithTags;
@@ -46,6 +60,7 @@ export function TrickCard({
   onEdit,
   onDelete,
   linkedItems,
+  linkedItemsError,
 }: TrickCardProps): React.ReactElement {
   const t = useTranslations("repertoire");
 
@@ -183,19 +198,37 @@ export function TrickCard({
           </ul>
         )}
 
-        {/* Linked items */}
-        {linkedItems && linkedItems.length > 0 && (
-          <div className="flex items-center gap-1.5 text-muted-foreground text-sm">
-            <Package aria-hidden="true" className="size-3.5 shrink-0" />
-            <span>
-              {linkedItems
-                .slice(0, MAX_VISIBLE_ITEMS)
-                .map((item) => item.name)
-                .join(", ")}
-              {linkedItems.length > MAX_VISIBLE_ITEMS &&
-                `, +${linkedItems.length - MAX_VISIBLE_ITEMS}`}
-            </span>
+        {/* Linked items — when the parent's join query has errored we render a
+            muted indicator so the user can tell "no items" from "couldn't
+            load items" (issue #218 follow-up). The label sits on the icon
+            (role="img") rather than the wrapper (role="status"): a list of
+            N cards would otherwise spawn N polite live regions and queue N
+            announcements; the page-level toast already announces the failure
+            once. aria-label reuses the existing `loadError` translation. */}
+        {linkedItemsError ? (
+          <div className="flex items-center gap-1.5 text-muted-foreground text-sm opacity-50">
+            <CircleAlert
+              aria-label={t("loadError")}
+              className="size-3.5 shrink-0"
+              role="img"
+            />
+            <span aria-hidden="true">—</span>
           </div>
+        ) : (
+          linkedItems &&
+          linkedItems.length > 0 && (
+            <div className="flex items-center gap-1.5 text-muted-foreground text-sm">
+              <Package aria-hidden="true" className="size-3.5 shrink-0" />
+              <span>
+                {linkedItems
+                  .slice(0, MAX_VISIBLE_ITEMS)
+                  .map((item) => item.name)
+                  .join(", ")}
+                {linkedItems.length > MAX_VISIBLE_ITEMS &&
+                  `, +${linkedItems.length - MAX_VISIBLE_ITEMS}`}
+              </span>
+            </div>
+          )
         )}
       </CardContent>
     </Card>

--- a/src/features/repertoire/components/trick-form-sheet.tsx
+++ b/src/features/repertoire/components/trick-form-sheet.tsx
@@ -25,7 +25,7 @@ interface TrickFormSheetProps {
   effectTypes: string[];
   onCreateTag: (name: string) => Promise<TagId>;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (data: TrickFormValues) => void;
+  onSubmit: (data: TrickFormValues) => void | Promise<void>;
   onToggleTag: (tagId: TagId) => void;
   open: boolean;
   /**

--- a/src/features/repertoire/components/trick-form.tsx
+++ b/src/features/repertoire/components/trick-form.tsx
@@ -83,7 +83,7 @@ interface TrickFormProps {
   formId: string;
   onCreateTag: (name: string) => Promise<TagId>;
   onDirtyChange?: (dirty: boolean) => void;
-  onSubmit: (data: TrickFormValues) => void;
+  onSubmit: (data: TrickFormValues) => void | Promise<void>;
   onToggleTag: (tagId: TagId) => void;
   /**
    * True while the parent's tag join is still hydrating during an Edit

--- a/src/features/repertoire/components/trick-list.test.tsx
+++ b/src/features/repertoire/components/trick-list.test.tsx
@@ -4,18 +4,25 @@ import type { TrickId } from "@/db/types";
 import type { TrickWithTags } from "../types";
 import { TrickList } from "./trick-list";
 
-// Mock TrickCard to avoid rendering its full complexity
+// Mock TrickCard to avoid rendering its full complexity. The linkedItemsError
+// flag is reflected as a data-attribute so a single render can assert that the
+// prop was forwarded to every card without exposing the real CircleAlert markup.
 vi.mock("./trick-card", () => ({
   TrickCard: ({
     trick,
     onEdit,
     onDelete,
+    linkedItemsError,
   }: {
     trick: TrickWithTags;
     onEdit: (id: string) => void;
     onDelete: (id: string) => void;
+    linkedItemsError?: boolean;
   }) => (
-    <div data-testid={`trick-card-${trick.id}`}>
+    <div
+      data-linked-items-error={String(Boolean(linkedItemsError))}
+      data-testid={`trick-card-${trick.id}`}
+    >
       <span>{trick.name}</span>
       <button onClick={() => onEdit(trick.id)} type="button">
         Edit
@@ -71,5 +78,42 @@ describe("TrickList", () => {
   it("renders no cards when tricks array is empty", () => {
     render(<TrickList onDelete={vi.fn()} onEdit={vi.fn()} tricks={[]} />);
     expect(screen.queryAllByTestId(TRICK_CARD_PATTERN)).toHaveLength(0);
+  });
+
+  // Issue #218 follow-up — `linkedItemsError` must reach every rendered card so
+  // each one can swap its linked-items list for the muted indicator.
+  it("forwards linkedItemsError to every rendered TrickCard", () => {
+    const tricks = [
+      makeTrick("t1", "Card Warp"),
+      makeTrick("t2", "Coin Vanish"),
+      makeTrick("t3", "Sponge Bunny"),
+    ];
+    render(
+      <TrickList
+        linkedItemsError
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        tricks={tricks}
+      />
+    );
+
+    for (const trick of tricks) {
+      expect(screen.getByTestId(`trick-card-${trick.id}`)).toHaveAttribute(
+        "data-linked-items-error",
+        "true"
+      );
+    }
+  });
+
+  it("forwards linkedItemsError=false (or omitted) as false to every TrickCard", () => {
+    const tricks = [makeTrick("t1", "Card Warp"), makeTrick("t2", "Coins")];
+    render(<TrickList onDelete={vi.fn()} onEdit={vi.fn()} tricks={tricks} />);
+
+    for (const trick of tricks) {
+      expect(screen.getByTestId(`trick-card-${trick.id}`)).toHaveAttribute(
+        "data-linked-items-error",
+        "false"
+      );
+    }
   });
 });

--- a/src/features/repertoire/components/trick-list.tsx
+++ b/src/features/repertoire/components/trick-list.tsx
@@ -7,6 +7,12 @@ import { TrickCard } from "./trick-card";
 
 interface TrickListProps {
   itemMap?: Map<TrickId, { id: ItemId; name: string }[]>;
+  /**
+   * True when the trick_items join query has errored. When true, TrickCard
+   * shows a muted indicator badge so the user can distinguish "no linked
+   * items" from "failed to load linked items" (issue #218 follow-up).
+   */
+  linkedItemsError?: boolean;
   onDelete: (id: TrickId) => void;
   onEdit: (id: TrickId) => void;
   tricks: TrickWithTags[];
@@ -23,6 +29,7 @@ export function TrickList({
   onEdit,
   onDelete,
   itemMap,
+  linkedItemsError,
 }: TrickListProps): React.ReactElement {
   const t = useTranslations("repertoire");
 
@@ -35,6 +42,7 @@ export function TrickList({
         <li key={trick.id}>
           <TrickCard
             linkedItems={itemMap?.get(trick.id)}
+            linkedItemsError={linkedItemsError}
             onDelete={onDelete}
             onEdit={onEdit}
             trick={trick}


### PR DESCRIPTION
## Summary

PowerSync relation queries (`item_tags`, `item_tricks`, `trick_tags`, `trick_items`, `available_tricks`) were failing silently — empty/stale results fed `useHydratedSelection`'s seed, and a save against the wrong baseline could silently NOT remove an existing-but-invisible relation, or hit a UNIQUE/PK violation when the user re-toggled it.

- Export relation-query SQL as module-level constants so tests match by reference equality rather than fragile substring inspection.
- Toast on critical relation-query errors with stable ids (`collect-load-relations-error`, `repertoire-load-relations-error`) so re-renders dedupe.
- Block Edit/Add entry when relation queries have errored; auto-close the sheet if errors fire while open. Mode-scoped: Add only cares about the picker source (`available_tricks`), Edit cares about the item-scoped joins too.
- Add muted `CircleAlert` badge in `TrickCard` for `trick_items` failures so "no linked items" is distinguishable from "couldn't load items". Label sits on the icon (`role="img"`), not the wrapper, to avoid spawning N polite live regions for a list of N cards.
- Allow async `onSubmit` in `TrickForm` / `TrickFormSheet`.

Also bundles a small `CLAUDE.md` tweak: `gh issue create` is now allowed without `/ship` since issue tracking is not a code/PR mutation.

## Test plan

- [x] Existing test suites still pass for collect-view, repertoire-view, trick-card, trick-list.
- [x] New tests cover each error path:
  - Edit blocked when `item_tags` / `item_tricks` / `available_tricks` errors (collect).
  - Edit blocked when `trick_tags` errors (repertoire).
  - Edit NOT blocked when only `trick_items` errors (asymmetry — feeds inverse-relation display only).
  - Add NOT blocked when `trick_tags` errors; Add blocked when `available_tricks` errors.
  - Toast id is stable so rapid re-submits collapse.
- [ ] Manual smoke: trigger a relation query failure (e.g. via devtools throttle / induced parse error) and verify the toast fires once and the sheet won't open.

Closes #218