### PR TITLE
fix: surface useTags/categories/effect-types query errors (#263)

### DIFF
--- a/src/features/collect/components/collect-view.test.tsx
+++ b/src/features/collect/components/collect-view.test.tsx
@@ -80,7 +80,7 @@ vi.mock("../hooks/use-item-mutations", async (importOriginal) => {
 });
 
 vi.mock("@/features/repertoire/hooks/use-tags", () => ({
-  useTags: vi.fn(() => ({ tags: [], isLoading: false })),
+  useTags: vi.fn(() => ({ tags: [], isLoading: false, error: null })),
 }));
 
 vi.mock("@/features/repertoire/hooks/use-tag-mutations", () => ({
@@ -91,10 +91,16 @@ vi.mock("@/features/repertoire/hooks/use-tag-mutations", () => ({
 
 // Mock child components so we can capture and drive their props
 let capturedFormSheetProps: Partial<ItemFormSheetProps> = {};
+// Records every `open` value the mock has seen. Lets block-on-error tests
+// distinguish "handler-gate prevented open" from "auto-close effect closed
+// after a brief open" — they're indistinguishable from the final `open` prop
+// alone. Reset in afterEach.
+const formSheetOpenHistory: boolean[] = [];
 
 vi.mock("./item-form-sheet", () => ({
   ItemFormSheet: (props: ItemFormSheetProps) => {
     capturedFormSheetProps = props;
+    formSheetOpenHistory.push(props.open);
     return <div data-open={String(props.open)} data-testid="item-form-sheet" />;
   },
 }));
@@ -234,6 +240,7 @@ afterEach(async () => {
   const { useQuery } = await import("@powersync/react");
   const { useItems } = await import("../hooks/use-items");
   const { useItem } = await import("../hooks/use-item");
+  const { useTags } = await import("@/features/repertoire/hooks/use-tags");
 
   vi.mocked(useQuery).mockReturnValue({
     data: [],
@@ -251,12 +258,18 @@ afterEach(async () => {
     error: null,
     isLoading: false,
   });
+  vi.mocked(useTags).mockReturnValue({
+    tags: [],
+    isLoading: false,
+    error: null,
+  });
 
   mockCreateItem.mockResolvedValue("new-item-id");
   mockUpdateItem.mockResolvedValue(undefined);
   mockDeleteItem.mockResolvedValue(undefined);
 
   capturedFormSheetProps = {};
+  formSheetOpenHistory.length = 0;
   capturedDeleteDialogProps = {};
   capturedFiltersProps = {};
 });
@@ -1260,6 +1273,165 @@ describe("CollectView", () => {
         isFetching: false,
         error: undefined,
       };
+    });
+    rerender(<CollectView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #263 — useTags() error swallowing
+  // The picker source for tags. Unlike the item-scoped joins (gate Edit only),
+  // tagError gates BOTH Add and Edit because the picker is rendered in both
+  // flows. Mirrors the availableTricksError contract in #218.
+  // ---------------------------------------------------------------------------
+
+  it("blocks Edit when tags query has errored (issue #263)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useTags } = await import("@/features/repertoire/hooks/use-tags");
+    const itemId = "00000000-0000-4000-8000-000000000263";
+    const item = makeItem(itemId, "Color Change");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+
+    const tagsQueryError = new Error("tags table query failed");
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: tagsQueryError,
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+
+    expect(capturedFormSheetProps.open).toBe(false);
+    // Discriminates handler-gate from auto-close: if the handler-entry guard
+    // were dropped, the sheet would briefly open before the auto-close effect
+    // slammed it shut, leaving `open === false` final but `true` in history.
+    expect(formSheetOpenHistory).not.toContain(true);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("blocks Add when tags query has errored (issue #263)", async () => {
+    const { useTags } = await import("@/features/repertoire/hooks/use-tags");
+
+    const tagsQueryError = new Error("tags table query failed");
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: tagsQueryError,
+    });
+
+    render(<CollectView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+
+    // Add path also blocks because the tag picker source is broken.
+    expect(capturedFormSheetProps.open).toBe(false);
+    // Path-discriminates: confirms the handler-entry guard prevented open,
+    // not just that the auto-close effect closed a briefly-open sheet.
+    expect(formSheetOpenHistory).not.toContain(true);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("auto-closes the Edit sheet when tags errors after open (issue #263)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useItem } = await import("../hooks/use-item");
+    const { useTags } = await import("@/features/repertoire/hooks/use-tags");
+    const itemId = "00000000-0000-4000-8000-000000000263e";
+    const item = makeItem(itemId, "Sponge Balls");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useItem).mockReturnValue({
+      item,
+      error: null,
+      isLoading: false,
+    });
+
+    // Healthy initial state — Edit sheet opens cleanly.
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: null,
+    });
+
+    const { rerender } = render(<CollectView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${itemId}`));
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    // Background sync surfaces a tags-query error — mode-scoped close should
+    // slam the Edit sheet shut.
+    const tagsQueryError = new Error("background tags drift");
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: tagsQueryError,
+    });
+    rerender(<CollectView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "collect.loadError",
+      expect.objectContaining({ id: "collect-load-relations-error" })
+    );
+  });
+
+  it("auto-closes the Add sheet when tags errors after open (issue #263)", async () => {
+    const { useTags } = await import("@/features/repertoire/hooks/use-tags");
+
+    // Healthy initial state — Add sheet opens cleanly.
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: null,
+    });
+
+    const { rerender } = render(<CollectView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_ITEM_PATTERN })
+    );
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    // Background sync surfaces a tags error — Add sheet must close because
+    // tags is a picker source (gates both modes, unlike item-scoped joins).
+    const tagsQueryError = new Error("background tags failure");
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: tagsQueryError,
     });
     rerender(<CollectView />);
 

--- a/src/features/collect/components/collect-view.tsx
+++ b/src/features/collect/components/collect-view.tsx
@@ -141,7 +141,7 @@ export function CollectView(): React.ReactElement {
     error: editingItemError,
     isLoading: editingItemLoading,
   } = useItem(editingItemId);
-  const { tags } = useTags();
+  const { tags, error: tagError } = useTags();
   const { createItem, updateItem, deleteItem } = useItemMutations();
   const { createTag } = useTagMutations();
   const { brands: userBrands, error: brandsError } = useItemBrands();
@@ -225,7 +225,10 @@ export function CollectView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   useEffect(() => {
     if (editingItemId && editingItemError) {
-      console.error("Failed to load item for editing:", editingItemError);
+      console.error(
+        "[CollectView] Failed to load item for editing:",
+        editingItemError
+      );
       // Do NOT pass editingItemError.message as description — PowerSync/SQLite
       // error messages can contain row context, query fragments, or user-supplied
       // values. The full error is already in the console.error above for
@@ -245,21 +248,29 @@ export function CollectView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   useEffect(() => {
     if (itemsError) {
-      console.error("Items query error:", itemsError);
+      console.error("[CollectView] Items query error:", itemsError);
       toast.error(t("loadError"), { id: LOAD_ITEMS_ERROR_TOAST_ID });
     }
   }, [itemsError, t]);
 
   // ---------------------------------------------------------------------------
-  // Critical relation-query failures (issue #218). The empty/stale data they
-  // produce feeds useHydratedSelection's seed, which doesn't observe `error` —
-  // a save against the wrong baseline can silently NOT remove an
-  // existing-but-invisible relation, or hit a UNIQUE/PK violation when the
-  // user re-toggles it. Toast always so the user is informed even before
-  // clicking Edit/Add. Stable id so re-renders dedupe.
+  // Critical relation-query failures (issue #218 + #263). The empty/stale data
+  // they produce feeds useHydratedSelection's seed (and the picker source for
+  // tagError/availableTricksError), which doesn't observe `error` — a save
+  // against the wrong baseline can silently NOT remove an existing-but-invisible
+  // relation, or hit a UNIQUE/PK violation when the user re-toggles it. Toast
+  // always so the user is informed even before clicking Edit/Add. Stable id so
+  // re-renders dedupe.
+  //
+  // Picker-source vs junction distinction:
+  //   - tagError / availableTricksError → no available items to PICK from;
+  //     gates both Add and Edit (the picker is used in both flows).
+  //   - itemTagError / itemTrickError   → can't seed EXISTING relations on the
+  //     item being edited; gates Edit only (Add seeds via seedEmpty()).
   // ---------------------------------------------------------------------------
   useEffect(() => {
-    const error = itemTagError ?? itemTrickError ?? availableTricksError;
+    const error =
+      itemTagError ?? itemTrickError ?? availableTricksError ?? tagError;
     if (!error) {
       return;
     }
@@ -267,9 +278,10 @@ export function CollectView(): React.ReactElement {
       itemTagError,
       itemTrickError,
       availableTricksError,
+      tagError,
     });
     toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
-  }, [itemTagError, itemTrickError, availableTricksError, t]);
+  }, [itemTagError, itemTrickError, availableTricksError, tagError, t]);
 
   // ---------------------------------------------------------------------------
   // Supplementary queries — datalist autocomplete only. Log so we can debug
@@ -278,10 +290,10 @@ export function CollectView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   useEffect(() => {
     if (brandsError) {
-      console.error("Brands query error:", brandsError);
+      console.error("[CollectView] Brands query error:", brandsError);
     }
     if (locationsError) {
-      console.error("Locations query error:", locationsError);
+      console.error("[CollectView] Locations query error:", locationsError);
     }
   }, [brandsError, locationsError]);
 
@@ -289,11 +301,12 @@ export function CollectView(): React.ReactElement {
   // If a critical relation error fires while the sheet is open, close it
   // rather than let the user save against potentially corrupted seed data.
   // Mirrors the editingItemError handler above. Mode-scoped to match the
-  // handler-entry guards (issue #218 matrix):
+  // handler-entry guards (issue #218 + #263 matrix):
   //   - Edit (editingItemId !== null): any of item_tags / item_tricks /
-  //     available_tricks errors → close.
-  //   - Add (editingItemId === null): only available_tricks (picker source)
-  //     matters; the item-scoped joins don't feed the Add path.
+  //     available_tricks / tags errors → close.
+  //   - Add (editingItemId === null): only the picker sources matter —
+  //     available_tricks (trick picker) and tags (tag picker). The
+  //     item-scoped joins (item_tags / item_tricks) don't feed the Add path.
   // ---------------------------------------------------------------------------
   useEffect(() => {
     if (!sheetOpen) {
@@ -302,8 +315,8 @@ export function CollectView(): React.ReactElement {
     const inEditMode = editingItemId !== null;
     const shouldClose = Boolean(
       inEditMode
-        ? itemTagError || itemTrickError || availableTricksError
-        : availableTricksError
+        ? itemTagError || itemTrickError || availableTricksError || tagError
+        : availableTricksError || tagError
     );
     if (shouldClose) {
       setSheetOpen(false);
@@ -317,6 +330,7 @@ export function CollectView(): React.ReactElement {
     itemTagError,
     itemTrickError,
     availableTricksError,
+    tagError,
     tagsSel.reset,
     tricksSel.reset,
   ]);
@@ -352,10 +366,11 @@ export function CollectView(): React.ReactElement {
   // ---------------------------------------------------------------------------
 
   function handleAddItem(): void {
-    // availableTricksError breaks the picker source; without it the user
-    // would create an item with an empty/misleading trick list (issue #218).
-    // The other relation errors are edit-only (item-scoped joins).
-    if (availableTricksError) {
+    // Picker sources (availableTricks + tags) feed both Add and Edit; without
+    // them the user would create an item with an empty/misleading trick list
+    // or no tag picker (issue #218 + #263). The item-scoped junction errors
+    // (itemTagError / itemTrickError) are edit-only and not checked here.
+    if (availableTricksError || tagError) {
       toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
       return;
     }
@@ -368,8 +383,10 @@ export function CollectView(): React.ReactElement {
   function handleEditItem(id: ItemId): void {
     // Block opening the sheet if relation queries are broken — without
     // current relations the seed lock-in would be empty, and the user
-    // can't see what they have or remove what they've toggled. Issue #218.
-    if (itemTagError || itemTrickError || availableTricksError) {
+    // can't see what they have or remove what they've toggled (issue #218).
+    // tagError additionally blocks because the picker has no tags to render
+    // even if the existing-tag seed is intact (issue #263).
+    if (itemTagError || itemTrickError || availableTricksError || tagError) {
       toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
       return;
     }
@@ -444,7 +461,7 @@ export function CollectView(): React.ReactElement {
       tagsSel.reset();
       tricksSel.reset();
     } catch (error) {
-      console.error("Item save failed:", error);
+      console.error("[CollectView] Item save failed:", error);
       const errorKey = getMutationErrorKey(error);
       if (errorKey === "validation.tooManyTricks") {
         toast.error(t(errorKey, { count: MAX_TRICKS_PER_ITEM }));
@@ -474,7 +491,7 @@ export function CollectView(): React.ReactElement {
       await deleteItem(deletingItemId);
       toast.success(t("itemDeleted"));
     } catch (error) {
-      console.error("Item delete failed:", error);
+      console.error("[CollectView] Item delete failed:", error);
       const errorKey = getMutationErrorKey(error);
       if (errorKey) {
         toast.error(t(errorKey));
@@ -500,7 +517,7 @@ export function CollectView(): React.ReactElement {
     } catch (error) {
       // TagPicker owns the user-facing toast; we only log and rethrow so the
       // child component can reset its UI state. Avoid duplicate toasts here.
-      console.error("Tag create failed:", error);
+      console.error("[CollectView] Tag create failed:", error);
       throw error;
     }
   }

--- a/src/features/repertoire/components/repertoire-view.test.tsx
+++ b/src/features/repertoire/components/repertoire-view.test.tsx
@@ -61,7 +61,7 @@ vi.mock("../hooks/use-trick", () => ({
 }));
 
 vi.mock("../hooks/use-tags", () => ({
-  useTags: vi.fn(() => ({ tags: [], isLoading: false })),
+  useTags: vi.fn(() => ({ tags: [], isLoading: false, error: null })),
 }));
 
 const mockCreateTrick = vi.fn().mockResolvedValue("new-trick-id");
@@ -86,19 +86,25 @@ vi.mock("../hooks/use-tag-mutations", () => ({
 }));
 
 vi.mock("../hooks/use-trick-categories", () => ({
-  useTrickCategories: vi.fn(() => []),
+  useTrickCategories: vi.fn(() => ({ categories: [], error: null })),
 }));
 
 vi.mock("../hooks/use-trick-effect-types", () => ({
-  useTrickEffectTypes: vi.fn(() => []),
+  useTrickEffectTypes: vi.fn(() => ({ effectTypes: [], error: null })),
 }));
 
 // TrickFormSheet mock — exposes callbacks for testing
 let capturedFormSheetProps: Partial<TrickFormSheetProps> = {};
+// Records every `open` value the mock has seen. Lets block-on-error tests
+// distinguish "handler-gate prevented open" from "auto-close effect closed
+// after a brief open" — they're indistinguishable from the final `open` prop
+// alone. Reset in afterEach.
+const formSheetOpenHistory: boolean[] = [];
 
 vi.mock("./trick-form-sheet", () => ({
   TrickFormSheet: (props: TrickFormSheetProps) => {
     capturedFormSheetProps = props;
+    formSheetOpenHistory.push(props.open);
     return (
       <div data-open={String(props.open)} data-testid="trick-form-sheet" />
     );
@@ -204,6 +210,11 @@ afterEach(async () => {
   const { useQuery } = await import("@powersync/react");
   const { useTricks } = await import("../hooks/use-tricks");
   const { useTrick } = await import("../hooks/use-trick");
+  const { useTags } = await import("../hooks/use-tags");
+  const { useTrickCategories } = await import("../hooks/use-trick-categories");
+  const { useTrickEffectTypes } = await import(
+    "../hooks/use-trick-effect-types"
+  );
 
   vi.mocked(useQuery).mockReturnValue({
     data: [],
@@ -221,6 +232,19 @@ afterEach(async () => {
     isLoading: false,
     error: null,
   });
+  vi.mocked(useTags).mockReturnValue({
+    tags: [],
+    isLoading: false,
+    error: null,
+  });
+  vi.mocked(useTrickCategories).mockReturnValue({
+    categories: [],
+    error: null,
+  });
+  vi.mocked(useTrickEffectTypes).mockReturnValue({
+    effectTypes: [],
+    error: null,
+  });
 
   // Restore mutation mock defaults (clearAllMocks strips implementations)
   mockCreateTrick.mockResolvedValue("new-trick-id");
@@ -228,6 +252,7 @@ afterEach(async () => {
   mockDeleteTrick.mockResolvedValue(undefined);
 
   capturedFormSheetProps = {};
+  formSheetOpenHistory.length = 0;
   capturedDeleteDialogProps = {};
   capturedFiltersProps = {};
   capturedTrickListTricks = [];
@@ -523,6 +548,25 @@ describe("RepertoireView", () => {
       screen.getByRole("button", { name: ADD_TRICK_PATTERN })
     );
     await capturedFormSheetProps.onCreateTag?.("Beginner");
+    expect(mockCreateTag).toHaveBeenCalledWith("Beginner");
+  });
+
+  it("rethrows when createTag rejects so TagPicker can reset its state", async () => {
+    // The wrapper logs and rethrows rather than swallowing — TagPicker owns
+    // the user-facing toast and needs the rejection to reset its UI.
+    const { useTagMutations } = await import("../hooks/use-tag-mutations");
+    const failure = new Error("create failed");
+    const mockCreateTag = vi.fn().mockRejectedValue(failure);
+    vi.mocked(useTagMutations).mockReturnValue({ createTag: mockCreateTag });
+
+    render(<RepertoireView />);
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_TRICK_PATTERN })
+    );
+
+    await expect(capturedFormSheetProps.onCreateTag?.("Beginner")).rejects.toBe(
+      failure
+    );
     expect(mockCreateTag).toHaveBeenCalledWith("Beginner");
   });
 
@@ -1262,6 +1306,244 @@ describe("RepertoireView", () => {
 
     // Toast fires (page-level effect always toasts), but Add sheet stays open.
     expect(capturedFormSheetProps.open).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #263 sibling — useTricks() list error must surface to the user.
+  // Mirrors collect-view's items-list error toast (LOAD_ITEMS_ERROR_TOAST_ID).
+  // ---------------------------------------------------------------------------
+
+  it("fires a load-error toast with a stable id when tricks query fails", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [],
+      error: new Error("boom"),
+      isLoading: false,
+    });
+
+    render(<RepertoireView />);
+
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "repertoire.loadError",
+        expect.objectContaining({ id: "repertoire-load-tricks-error" })
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #263 — useTags() error swallowing
+  // The picker source for tags. Unlike trickTagError (junction, gates Edit
+  // only — Add doesn't seed from existing relations), tagError gates BOTH Add
+  // and Edit because the tag picker is rendered in both flows.
+  // ---------------------------------------------------------------------------
+
+  it("blocks Edit when tags query has errored (issue #263)", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTags } = await import("../hooks/use-tags");
+    const trickId = "00000000-0000-4000-8000-000000000263";
+    const trick = makeTrick(trickId, "Card Force");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [trick],
+      error: null,
+      isLoading: false,
+    });
+
+    const tagsQueryError = new Error("tags table query failed");
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: tagsQueryError,
+    });
+
+    render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+
+    expect(capturedFormSheetProps.open).toBe(false);
+    // Discriminates handler-gate from auto-close: if the handler-entry guard
+    // were dropped, the sheet would briefly open before the auto-close effect
+    // slammed it shut, leaving `open === false` final but `true` in history.
+    expect(formSheetOpenHistory).not.toContain(true);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
+    );
+  });
+
+  it("blocks Add when tags query has errored (issue #263)", async () => {
+    const { useTags } = await import("../hooks/use-tags");
+
+    const tagsQueryError = new Error("tags table query failed");
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: tagsQueryError,
+    });
+
+    render(<RepertoireView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_TRICK_PATTERN })
+    );
+
+    // Contrast with trickTagError: Add path DOES gate on tagError because
+    // the picker source is shared between Add and Edit.
+    expect(capturedFormSheetProps.open).toBe(false);
+    // Path-discriminates: confirms the handler-entry guard prevented open,
+    // not just that the auto-close effect closed a briefly-open sheet.
+    expect(formSheetOpenHistory).not.toContain(true);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
+    );
+  });
+
+  it("auto-closes the EDIT sheet when tags errors after open (issue #263)", async () => {
+    const { useTricks } = await import("../hooks/use-tricks");
+    const { useTrick } = await import("../hooks/use-trick");
+    const { useTags } = await import("../hooks/use-tags");
+    const trickId = "00000000-0000-4000-8000-000000000263e";
+    const trick = makeTrick(trickId, "Sponge Balls");
+    vi.mocked(useTricks).mockReturnValue({
+      tricks: [trick],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useTrick).mockReturnValue({
+      trick,
+      isLoading: false,
+      error: null,
+    });
+
+    // Healthy initial state — Edit sheet opens cleanly.
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: null,
+    });
+
+    const { rerender } = render(<RepertoireView />);
+
+    await userEvent.click(screen.getByTestId(`edit-${trickId}`));
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    // Background sync surfaces a tags-query error.
+    const tagsQueryError = new Error("background tags drift");
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: tagsQueryError,
+    });
+    rerender(<RepertoireView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
+    );
+  });
+
+  it("auto-closes the ADD sheet when tags errors after open (issue #263)", async () => {
+    const { useTags } = await import("../hooks/use-tags");
+
+    // Healthy initial state — Add sheet opens cleanly.
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: null,
+    });
+
+    const { rerender } = render(<RepertoireView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_TRICK_PATTERN })
+    );
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    // Background tags error fires — Add sheet must close because tags is a
+    // picker source (gates both modes). Contrast with the trickTagError test
+    // immediately above, where Add stays open.
+    const tagsQueryError = new Error("background tags failure");
+    vi.mocked(useTags).mockReturnValue({
+      tags: [],
+      isLoading: false,
+      error: tagsQueryError,
+    });
+    rerender(<RepertoireView />);
+
+    await waitFor(() => {
+      expect(capturedFormSheetProps.open).toBe(false);
+    });
+
+    const { toast } = await import("sonner");
+    expect(toast.error).toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #263 — supplementary autocomplete queries must NOT toast.
+  // categories/effect-types feed combobox suggestions only; the form has
+  // hardcoded SUGGESTED_* fallbacks. Mirrors brandsError/locationsError in
+  // collect-view. Guards against a future "fix" that adds toast.error to the
+  // supplementary effect.
+  // ---------------------------------------------------------------------------
+
+  it("does NOT toast for categoriesError (supplementary autocomplete)", async () => {
+    const { useTrickCategories } = await import(
+      "../hooks/use-trick-categories"
+    );
+    vi.mocked(useTrickCategories).mockReturnValue({
+      categories: [],
+      error: new Error("categories offline"),
+    });
+
+    render(<RepertoireView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_TRICK_PATTERN })
+    );
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
+    );
+  });
+
+  it("does NOT toast for effectTypesError (supplementary autocomplete)", async () => {
+    const { useTrickEffectTypes } = await import(
+      "../hooks/use-trick-effect-types"
+    );
+    vi.mocked(useTrickEffectTypes).mockReturnValue({
+      effectTypes: [],
+      error: new Error("effect types offline"),
+    });
+
+    render(<RepertoireView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: ADD_TRICK_PATTERN })
+    );
+    expect(capturedFormSheetProps.open).toBe(true);
+
+    const { toast } = await import("sonner");
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "repertoire.loadError",
+      expect.objectContaining({ id: "repertoire-load-relations-error" })
+    );
   });
 
   it("uses a stable toast id so re-renders dedupe (idempotency)", async () => {

--- a/src/features/repertoire/components/repertoire-view.tsx
+++ b/src/features/repertoire/components/repertoire-view.tsx
@@ -96,6 +96,8 @@ const LOAD_EDIT_TRICK_ERROR_TOAST_ID = "repertoire-load-edit-trick-error";
  * both — same surfaced message, never want to stack. Issue #218.
  */
 const LOAD_RELATIONS_ERROR_TOAST_ID = "repertoire-load-relations-error";
+/** Stable toast id for the primary tricks-list query error (mirrors collect-view's items-list pattern). */
+const LOAD_TRICKS_ERROR_TOAST_ID = "repertoire-load-tricks-error";
 
 /**
  * Main orchestration component for the repertoire feature.
@@ -141,7 +143,7 @@ export function RepertoireView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   // Data hooks
   // ---------------------------------------------------------------------------
-  const { tricks } = useTricks({
+  const { tricks, error: tricksError } = useTricks({
     search: debouncedSearch,
     status: statusFilter,
     category: categoryFilter,
@@ -153,11 +155,11 @@ export function RepertoireView(): React.ReactElement {
     error: editingTrickError,
     isLoading: editingTrickLoading,
   } = useTrick(editingTrickId);
-  const { tags } = useTags();
+  const { tags, error: tagError } = useTags();
   const { createTrick, updateTrick, deleteTrick } = useTrickMutations();
   const { createTag } = useTagMutations();
-  const categories = useTrickCategories();
-  const effectTypes = useTrickEffectTypes();
+  const { categories, error: categoriesError } = useTrickCategories();
+  const { effectTypes, error: effectTypesError } = useTrickEffectTypes();
 
   // ---------------------------------------------------------------------------
   // Trick-tags join query (build a Map<trickId, ParsedTag[]>)
@@ -197,23 +199,64 @@ export function RepertoireView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   // Toast on any relation-query failure so the user is informed even before
   // clicking Edit/Add. Stable id so re-renders dedupe. Mirrors the unified
-  // shape used in collect-view for consistency. The critical-vs-supplementary
-  // asymmetry between the two errors (trickTagError feeds tagsSel seed
-  // lock-in; trickItemError feeds only the inverse-relation badge) only
-  // matters for auto-close behavior — see the next effect — not for toast
-  // surfacing, where both should equally inform the user (issue #218).
+  // shape used in collect-view for consistency. The asymmetry between these
+  // errors only matters for auto-close behavior (next effect) and handler
+  // gating, not for toast surfacing — all critical errors should inform the
+  // user equally (issue #218 + #263).
+  //
+  // Picker-source vs junction distinction:
+  //   - tagError       → useTags() (the picker source); gates both Add and
+  //                      Edit because the picker is used in both flows.
+  //   - trickTagError  → trick_tags join; gates Edit only (it seeds existing
+  //                      tag selections on the trick; Add uses seedEmpty()).
+  //   - trickItemError → trick_items join; never gates the form at all
+  //                      (feeds only the inverse-relation badge in TrickList).
   // ---------------------------------------------------------------------------
   useEffect(() => {
-    const error = trickTagError ?? trickItemError;
+    const error = trickTagError ?? trickItemError ?? tagError;
     if (!error) {
       return;
     }
     console.error("[RepertoireView] Relation query error", {
       trickTagError,
       trickItemError,
+      tagError,
     });
     toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
-  }, [trickTagError, trickItemError, t]);
+  }, [trickTagError, trickItemError, tagError, t]);
+
+  // ---------------------------------------------------------------------------
+  // Tricks list error — toast on the list page since tricks are the page's data.
+  // Mirrors collect-view's items-list error handling (issue #263 sibling).
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (tricksError) {
+      console.error("[RepertoireView] Tricks query error:", tricksError);
+      toast.error(t("loadError"), { id: LOAD_TRICKS_ERROR_TOAST_ID });
+    }
+  }, [tricksError, t]);
+
+  // ---------------------------------------------------------------------------
+  // Supplementary queries — combobox autocomplete only. Log so we can debug
+  // from session reports; do NOT toast (the form still works without
+  // category/effect-type suggestions; hardcoded SUGGESTED_* constants in the
+  // form provide a fallback). Mirrors the brands/locations precedent in
+  // collect-view (issue #263).
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (categoriesError) {
+      console.error(
+        "[RepertoireView] Categories query error:",
+        categoriesError
+      );
+    }
+    if (effectTypesError) {
+      console.error(
+        "[RepertoireView] Effect types query error:",
+        effectTypesError
+      );
+    }
+  }, [categoriesError, effectTypesError]);
 
   // ---------------------------------------------------------------------------
   // Editing trick load failure — close the sheet rather than render "add new"
@@ -221,7 +264,10 @@ export function RepertoireView(): React.ReactElement {
   // ---------------------------------------------------------------------------
   useEffect(() => {
     if (editingTrickId && editingTrickError) {
-      console.error("Failed to load trick for editing:", editingTrickError);
+      console.error(
+        "[RepertoireView] Failed to load trick for editing:",
+        editingTrickError
+      );
       // Do NOT pass error.message as description — PowerSync/SQLite messages
       // can carry row context or query fragments. Full error already in
       // console.error above for developer diagnostics.
@@ -233,18 +279,30 @@ export function RepertoireView(): React.ReactElement {
   }, [editingTrickId, editingTrickError, t, tagsSel.reset]);
 
   // ---------------------------------------------------------------------------
-  // If trickTagError fires while the EDIT sheet is open, close it rather
-  // than let the user save against an empty seed lock-in. Add path is
-  // unaffected — there are no existing relations to seed (issue #218).
-  // trickItemError is intentionally NOT here — it never feeds the edit form.
+  // If a critical error fires while the sheet is open, close it rather than
+  // let the user save against an empty seed lock-in or an empty tag picker.
+  // Mode-scoped to match the handler-entry guards (issue #218 + #263 matrix):
+  //   - Edit (editingTrickId !== null): trickTagError (existing-tag seed)
+  //     or tagError (picker source) → close.
+  //   - Add  (editingTrickId === null): only tagError matters — the picker
+  //     source is used in both flows; trick_tags doesn't feed Add (seedEmpty).
+  // trickItemError is intentionally NOT in either branch — it feeds only the
+  // inverse-relation badge in TrickList, never the edit form.
   // ---------------------------------------------------------------------------
   useEffect(() => {
-    if (sheetOpen && editingTrickId !== null && trickTagError) {
+    if (!sheetOpen) {
+      return;
+    }
+    const inEditMode = editingTrickId !== null;
+    const shouldClose = Boolean(
+      inEditMode ? trickTagError || tagError : tagError
+    );
+    if (shouldClose) {
       setSheetOpen(false);
       setEditingTrickId(null);
       tagsSel.reset();
     }
-  }, [sheetOpen, editingTrickId, trickTagError, tagsSel.reset]);
+  }, [sheetOpen, editingTrickId, trickTagError, tagError, tagsSel.reset]);
 
   const trickItemMap = buildTrickItemMap(trickItemRows);
 
@@ -272,6 +330,13 @@ export function RepertoireView(): React.ReactElement {
   // ---------------------------------------------------------------------------
 
   function handleAddTrick(): void {
+    // tagError breaks the picker source; without it the user would create a
+    // trick they can't tag (issue #263). The trick-scoped join (trickTagError)
+    // is edit-only and not checked here — Add seeds via seedEmpty().
+    if (tagError) {
+      toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
+      return;
+    }
     setEditingTrickId(null);
     tagsSel.seedEmpty();
     setSheetOpen(true);
@@ -280,8 +345,9 @@ export function RepertoireView(): React.ReactElement {
   function handleEditTrick(id: TrickId): void {
     // Block opening the sheet if trick_tags is broken — without it the seed
     // lock-in would be empty and the user can't see what they have or
-    // remove what they've toggled. Issue #218.
-    if (trickTagError) {
+    // remove what they've toggled (issue #218). tagError additionally blocks
+    // because the picker has no tags to render even with a valid seed (#263).
+    if (trickTagError || tagError) {
       toast.error(t("loadError"), { id: LOAD_RELATIONS_ERROR_TOAST_ID });
       return;
     }
@@ -335,7 +401,7 @@ export function RepertoireView(): React.ReactElement {
       setEditingTrickId(null);
       tagsSel.reset();
     } catch (error) {
-      console.error("Failed to save trick:", error);
+      console.error("[RepertoireView] Failed to save trick:", error);
       const errorKey = getMutationErrorKey(error);
       if (errorKey) {
         toast.error(t(errorKey));
@@ -359,7 +425,7 @@ export function RepertoireView(): React.ReactElement {
       await deleteTrick(deletingTrickId);
       toast.success(t("trickDeleted"));
     } catch (error) {
-      console.error("Failed to delete trick:", error);
+      console.error("[RepertoireView] Failed to delete trick:", error);
       const errorKey = getMutationErrorKey(error);
       if (errorKey) {
         toast.error(t(errorKey));
@@ -379,8 +445,15 @@ export function RepertoireView(): React.ReactElement {
     }
   }
 
-  function handleCreateTag(name: string): Promise<TagId> {
-    return createTag(name);
+  async function handleCreateTag(name: string): Promise<TagId> {
+    try {
+      return await createTag(name);
+    } catch (error) {
+      // TagPicker owns the user-facing toast; we only log and rethrow so the
+      // child component can reset its UI state. Avoid duplicate toasts here.
+      console.error("[RepertoireView] Tag create failed:", error);
+      throw error;
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/features/repertoire/hooks/use-tags.test.ts
+++ b/src/features/repertoire/hooks/use-tags.test.ts
@@ -14,14 +14,15 @@ import { useTags } from "./use-tags";
 
 describe("useTags", () => {
   it("returns empty tags and isLoading false when there are no rows", () => {
-    mockUseQuery.mockReturnValue({ data: [], isLoading: false });
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
     const { result } = renderHook(() => useTags());
     expect(result.current.tags).toEqual([]);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
   it("returns isLoading true while loading", () => {
-    mockUseQuery.mockReturnValue({ data: [], isLoading: true });
+    mockUseQuery.mockReturnValue({ data: [], isLoading: true, error: null });
     const { result } = renderHook(() => useTags());
     expect(result.current.isLoading).toBe(true);
   });
@@ -33,6 +34,7 @@ describe("useTags", () => {
         { id: "tag-2", name: "Coin", color: null },
       ],
       isLoading: false,
+      error: null,
     });
     const { result } = renderHook(() => useTags());
     expect(result.current.tags).toEqual([
@@ -41,8 +43,27 @@ describe("useTags", () => {
     ]);
   });
 
+  it("surfaces useQuery error", () => {
+    const err = new Error("query failed");
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: err });
+    const { result } = renderHook(() => useTags());
+    expect(result.current.error).toBe(err);
+    expect(result.current.tags).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("returns null error when useQuery error is undefined", () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const { result } = renderHook(() => useTags());
+    expect(result.current.error).toBeNull();
+  });
+
   it("calls useQuery with the correct SQL", () => {
-    mockUseQuery.mockReturnValue({ data: [], isLoading: false });
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
     renderHook(() => useTags());
     const calledSql: string = mockUseQuery.mock.calls[0]?.[0];
     expect(calledSql).toContain("SELECT id, name, color FROM tags");

--- a/src/features/repertoire/hooks/use-tags.ts
+++ b/src/features/repertoire/hooks/use-tags.ts
@@ -11,6 +11,7 @@ interface TagRow {
 }
 
 interface UseTagsResult {
+  error: Error | null;
   isLoading: boolean;
   tags: ParsedTag[];
 }
@@ -22,7 +23,7 @@ interface UseTagsResult {
  * Data is re-fetched automatically by PowerSync whenever the `tags` table changes.
  */
 export function useTags(): UseTagsResult {
-  const { data, isLoading } = useQuery<TagRow>(
+  const { data, error, isLoading } = useQuery<TagRow>(
     "SELECT id, name, color FROM tags WHERE deleted_at IS NULL ORDER BY name ASC"
   );
 
@@ -32,5 +33,5 @@ export function useTags(): UseTagsResult {
     color: row.color,
   }));
 
-  return { tags, isLoading };
+  return { tags, isLoading, error: error ?? null };
 }

--- a/src/features/repertoire/hooks/use-trick-categories.test.ts
+++ b/src/features/repertoire/hooks/use-trick-categories.test.ts
@@ -13,23 +13,43 @@ vi.mock("@powersync/react", () => ({
 import { useTrickCategories } from "./use-trick-categories";
 
 describe("useTrickCategories", () => {
-  it("returns an empty array when there are no rows", () => {
-    mockUseQuery.mockReturnValue({ data: [], isLoading: false });
+  it("returns empty categories and null error when there are no rows", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
     const { result } = renderHook(() => useTrickCategories());
-    expect(result.current).toEqual([]);
+    expect(result.current.categories).toEqual([]);
+    expect(result.current.error).toBeNull();
   });
 
   it("returns mapped category strings from rows", () => {
     mockUseQuery.mockReturnValue({
       data: [{ category: "Cards" }, { category: "Coins" }],
       isLoading: false,
+      error: null,
     });
     const { result } = renderHook(() => useTrickCategories());
-    expect(result.current).toEqual(["Cards", "Coins"]);
+    expect(result.current.categories).toEqual(["Cards", "Coins"]);
+  });
+
+  it("surfaces useQuery error", () => {
+    const err = new Error("query failed");
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: err });
+    const { result } = renderHook(() => useTrickCategories());
+    expect(result.current.error).toBe(err);
+    expect(result.current.categories).toEqual([]);
+  });
+
+  it("returns null error when useQuery error is undefined", () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const { result } = renderHook(() => useTrickCategories());
+    expect(result.current.error).toBeNull();
   });
 
   it("calls useQuery with the correct SQL", () => {
-    mockUseQuery.mockReturnValue({ data: [], isLoading: false });
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
     renderHook(() => useTrickCategories());
     const calledSql: string = mockUseQuery.mock.calls[0]?.[0];
     expect(calledSql).toContain("SELECT DISTINCT category FROM tricks");

--- a/src/features/repertoire/hooks/use-trick-categories.ts
+++ b/src/features/repertoire/hooks/use-trick-categories.ts
@@ -6,16 +6,24 @@ interface CategoryRow {
   category: string;
 }
 
+interface UseTrickCategoriesResult {
+  categories: string[];
+  error: Error | null;
+}
+
 /**
  * Returns a reactive list of distinct trick categories from local SQLite,
  * sorted alphabetically. Used for combobox autocomplete in the trick form.
  *
  * Data is re-fetched automatically by PowerSync whenever the `tricks` table changes.
  */
-export function useTrickCategories(): string[] {
-  const { data } = useQuery<CategoryRow>(
+export function useTrickCategories(): UseTrickCategoriesResult {
+  const { data, error } = useQuery<CategoryRow>(
     "SELECT DISTINCT category FROM tricks WHERE deleted_at IS NULL AND category IS NOT NULL AND category != '' ORDER BY category ASC"
   );
 
-  return data.map((row) => row.category);
+  return {
+    categories: data.map((row) => row.category),
+    error: error ?? null,
+  };
 }

--- a/src/features/repertoire/hooks/use-trick-effect-types.test.ts
+++ b/src/features/repertoire/hooks/use-trick-effect-types.test.ts
@@ -13,23 +13,43 @@ vi.mock("@powersync/react", () => ({
 import { useTrickEffectTypes } from "./use-trick-effect-types";
 
 describe("useTrickEffectTypes", () => {
-  it("returns an empty array when there are no rows", () => {
-    mockUseQuery.mockReturnValue({ data: [], isLoading: false });
+  it("returns empty effectTypes and null error when there are no rows", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
     const { result } = renderHook(() => useTrickEffectTypes());
-    expect(result.current).toEqual([]);
+    expect(result.current.effectTypes).toEqual([]);
+    expect(result.current.error).toBeNull();
   });
 
   it("returns mapped effect_type strings from rows", () => {
     mockUseQuery.mockReturnValue({
       data: [{ effect_type: "Production" }, { effect_type: "Vanish" }],
       isLoading: false,
+      error: null,
     });
     const { result } = renderHook(() => useTrickEffectTypes());
-    expect(result.current).toEqual(["Production", "Vanish"]);
+    expect(result.current.effectTypes).toEqual(["Production", "Vanish"]);
+  });
+
+  it("surfaces useQuery error", () => {
+    const err = new Error("query failed");
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: err });
+    const { result } = renderHook(() => useTrickEffectTypes());
+    expect(result.current.error).toBe(err);
+    expect(result.current.effectTypes).toEqual([]);
+  });
+
+  it("returns null error when useQuery error is undefined", () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const { result } = renderHook(() => useTrickEffectTypes());
+    expect(result.current.error).toBeNull();
   });
 
   it("calls useQuery with the correct SQL", () => {
-    mockUseQuery.mockReturnValue({ data: [], isLoading: false });
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
     renderHook(() => useTrickEffectTypes());
     const calledSql: string = mockUseQuery.mock.calls[0]?.[0];
     expect(calledSql).toContain("SELECT DISTINCT effect_type FROM tricks");

--- a/src/features/repertoire/hooks/use-trick-effect-types.ts
+++ b/src/features/repertoire/hooks/use-trick-effect-types.ts
@@ -6,16 +6,24 @@ interface EffectTypeRow {
   effect_type: string;
 }
 
+interface UseTrickEffectTypesResult {
+  effectTypes: string[];
+  error: Error | null;
+}
+
 /**
  * Returns a reactive list of distinct trick effect types from local SQLite,
  * sorted alphabetically. Used for combobox autocomplete in the trick form.
  *
  * Data is re-fetched automatically by PowerSync whenever the `tricks` table changes.
  */
-export function useTrickEffectTypes(): string[] {
-  const { data } = useQuery<EffectTypeRow>(
+export function useTrickEffectTypes(): UseTrickEffectTypesResult {
+  const { data, error } = useQuery<EffectTypeRow>(
     "SELECT DISTINCT effect_type FROM tricks WHERE deleted_at IS NULL AND effect_type IS NOT NULL AND effect_type != '' ORDER BY effect_type ASC"
   );
 
-  return data.map((row) => row.effect_type);
+  return {
+    effectTypes: data.map((row) => row.effect_type),
+    error: error ?? null,
+  };
 }


### PR DESCRIPTION
## Summary

Extends the issue #218 silent-failure pattern from junction joins to picker-source queries.

- `useTags`, `useTrickCategories`, `useTrickEffectTypes` now expose `error: Error | null`.
- `CollectView` and `RepertoireView` wire `tagError` into the handler-entry guards (Add + Edit), the auto-close-on-error effect, and the relations-toast effect.
- `RepertoireView` also gains a tricks-list error toast (`LOAD_TRICKS_ERROR_TOAST_ID`) mirroring `CollectView`'s items-list pattern.
- `categoriesError` / `effectTypesError` are logged but not toasted — the combobox falls back to hardcoded `SUGGESTED_*` constants, matching the existing `brandsError`/`locationsError` precedent.

### Picker-source vs junction matrix

- `tagError` / `availableTricksError` (picker source) → gates **both** Add and Edit.
- `itemTagError` / `itemTrickError` / `trickTagError` (junction) → gates Edit only (Add uses `seedEmpty()`).

## Test plan

- [x] `pnpm typecheck` clean (no consumers of the changed hook shapes outside the two views).
- [x] `pnpm test:run -- src/features/repertoire src/features/collect` → 1844/1844 pass.
- New tests cover:
  - Handler-gate vs auto-close discrimination via a `formSheetOpenHistory` recorder (catches the case where the gate is dropped but the auto-close effect masks it).
  - Tag query error blocks Add and Edit; auto-closes the sheet if it errors after open.
  - Tricks list query error fires a toast with a stable id.
  - Hook error normalization (undefined → null).
  - `createTag` rethrow so `TagPicker` can reset its UI state.

Closes #263