### PR TITLE
fix: deterministic E2E sync gating via data-* attributes on SyncStatus

### DIFF
--- a/e2e/activity.spec.ts
+++ b/e2e/activity.spec.ts
@@ -6,6 +6,8 @@ import {
   createTrick,
   hasAuthSession,
   waitForAddButton,
+  waitForSync,
+  waitForSynced,
 } from "./helpers";
 
 /**
@@ -97,16 +99,28 @@ test.describe("Activity feed", () => {
     context,
     page,
   }) => {
+    // Offline ↔ online transitions add real wall-clock time on top of every
+    // already-30s wait; without test.slow() the suite hits Playwright's default
+    // 30s per-test budget mid-reconnect (issue #297).
+    test.slow();
     const name = `E2E Activity Offline ${Date.now().toString()}`;
 
     // Boot the app + PowerSync online so the local SQLite is initialised.
     await page.goto("/repertoire");
     await waitForAddButton(page, ADD_TRICK_RE);
+    // Initial sync must complete BEFORE going offline — otherwise the
+    // offline-write asserts what PowerSync never had a chance to bootstrap.
+    await waitForSynced(page);
 
     // Drop the network — the trick + event_log row should still write to
     // local SQLite via PowerSync's writeTransaction. The form should close
     // and the card appear without any network round-trip.
     await context.setOffline(true);
+    // The offline transition itself destabilizes the page (WebSocket drop +
+    // SyncStatus re-render). Wait for the pill to settle into "offline" before
+    // clicking — otherwise the Add-trick click can't pin a stable target
+    // within the 10s actionTimeout (issue #297 confirmed failure mode).
+    await waitForSync(page, "offline");
     try {
       await createTrick(page, name);
 

--- a/e2e/activity.spec.ts
+++ b/e2e/activity.spec.ts
@@ -7,7 +7,7 @@ import {
   hasAuthSession,
   waitForAddButton,
   waitForSync,
-  waitForSynced,
+  waitForSyncReady,
 } from "./helpers";
 
 /**
@@ -110,7 +110,7 @@ test.describe("Activity feed", () => {
     await waitForAddButton(page, ADD_TRICK_RE);
     // Initial sync must complete BEFORE going offline — otherwise the
     // offline-write asserts what PowerSync never had a chance to bootstrap.
-    await waitForSynced(page);
+    await waitForSyncReady(page);
 
     // Drop the network — the trick + event_log row should still write to
     // local SQLite via PowerSync's writeTransaction. The form should close

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { expect, test as setup } from "@playwright/test";
-import { AUTH_STATE_PATH } from "./helpers";
+import { AUTH_STATE_PATH, waitForSynced } from "./helpers";
 
 /**
  * Playwright auth setup — creates an authenticated session via Better Auth's
@@ -95,6 +95,24 @@ setup("authenticate", async ({ page }) => {
   // Navigate to the app to ensure cookies are properly set in the browser context
   await page.goto("/dashboard");
   await page.waitForURL("**/dashboard**");
+
+  // Smoke gate: PowerSync's initial sync must complete on /dashboard once per
+  // session before saving state. If a preview deployment has a broken sync
+  // boot, this fails fast here with a clear, domain-meaningful error rather
+  // than as a downstream click timeout 20 minutes into the run (issue #297).
+  try {
+    await waitForSynced(page, 60_000);
+  } catch (err) {
+    // `cause` preserves the original Playwright locator-timeout stack so
+    // triage points to the actual assertion site, not this rethrow.
+    throw new Error(
+      "auth.setup smoke gate failed: PowerSync did not complete its initial " +
+        "sync on /dashboard within 60s. Likely causes: broken worker bundle " +
+        "fetch (see global-setup.ts pre-warm logs), blocked WebSocket to the " +
+        "PowerSync service, or Vercel Deployment Protection misconfig.",
+      { cause: err }
+    );
+  }
 
   // Save the authenticated browser state
   await page.context().storageState({ path: AUTH_STATE_PATH });

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { expect, test as setup } from "@playwright/test";
-import { AUTH_STATE_PATH, waitForSynced } from "./helpers";
+import { AUTH_STATE_PATH } from "./helpers";
 
 /**
  * Playwright auth setup — creates an authenticated session via Better Auth's
@@ -23,9 +23,6 @@ const BASE_URL =
   (process.env.CI ? "http://localhost:3000" : "https://localhost:3000");
 
 setup("authenticate", async ({ page }) => {
-  // Extend timeout: auth + navigation + 60s sync gate exceeds the 30s default.
-  setup.setTimeout(120_000);
-
   if (!(TEST_EMAIL && TEST_PASSWORD)) {
     if (process.env.CI) {
       throw new Error("E2E_TEST_EMAIL and E2E_TEST_PASSWORD must be set in CI");
@@ -98,24 +95,6 @@ setup("authenticate", async ({ page }) => {
   // Navigate to the app to ensure cookies are properly set in the browser context
   await page.goto("/dashboard");
   await page.waitForURL("**/dashboard**");
-
-  // Smoke gate: PowerSync's initial sync must complete on /dashboard once per
-  // session before saving state. If a preview deployment has a broken sync
-  // boot, this fails fast here with a clear, domain-meaningful error rather
-  // than as a downstream click timeout 20 minutes into the run (issue #297).
-  try {
-    await waitForSynced(page, 60_000);
-  } catch (err) {
-    // `cause` preserves the original Playwright locator-timeout stack so
-    // triage points to the actual assertion site, not this rethrow.
-    throw new Error(
-      "auth.setup smoke gate failed: PowerSync did not complete its initial " +
-        "sync on /dashboard within 60s. Likely causes: broken worker bundle " +
-        "fetch (see global-setup.ts pre-warm logs), blocked WebSocket to the " +
-        "PowerSync service, or Vercel Deployment Protection misconfig.",
-      { cause: err }
-    );
-  }
 
   // Save the authenticated browser state
   await page.context().storageState({ path: AUTH_STATE_PATH });

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -23,6 +23,9 @@ const BASE_URL =
   (process.env.CI ? "http://localhost:3000" : "https://localhost:3000");
 
 setup("authenticate", async ({ page }) => {
+  // Extend timeout: auth + navigation + 60s sync gate exceeds the 30s default.
+  setup.setTimeout(120_000);
+
   if (!(TEST_EMAIL && TEST_PASSWORD)) {
     if (process.env.CI) {
       throw new Error("E2E_TEST_EMAIL and E2E_TEST_PASSWORD must be set in CI");

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,6 +1,27 @@
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-import { chromium } from "@playwright/test";
+import { type APIRequestContext, chromium } from "@playwright/test";
+
+/**
+ * Pre-warm a single asset URL and surface degraded states. Returns nothing —
+ * failures are non-fatal so the test run can still proceed (workers will be
+ * fetched on demand), but any non-2xx response or thrown error is logged so
+ * a silently broken pre-warm (e.g., worker URL drift after a PowerSync bump)
+ * is visible in CI output instead of disappearing into `.catch(() => undefined)`.
+ */
+async function prewarm(request: APIRequestContext, url: string): Promise<void> {
+  try {
+    const res = await request.get(url);
+    if (!res.ok()) {
+      console.warn(
+        `[global-setup] pre-warm ${url} returned ${res.status()} — worker URL may have drifted`
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[global-setup] pre-warm ${url} threw: ${message}`);
+  }
+}
 
 /**
  * Playwright global setup — runs once before all tests.
@@ -37,6 +58,18 @@ export default async function globalSetup() {
   // Save the cookie state for reuse by all test projects
   mkdirSync(dirname(BYPASS_STATE_PATH), { recursive: true });
   await context.storageState({ path: BYPASS_STATE_PATH });
+
+  // Pre-warm Vercel's edge CDN for PowerSync's large worker bundles so the
+  // first authenticated context doesn't pay the cold-fetch cost. Errors are
+  // non-fatal but logged by `prewarm()` so a silently-broken pre-warm
+  // (e.g., worker URL drift after a version bump) is visible in CI output.
+  await Promise.all([
+    prewarm(page.request, `${baseURL}/powersync/worker/WASQLiteDB.umd.js`),
+    prewarm(
+      page.request,
+      `${baseURL}/powersync/worker/SharedSyncImplementation.umd.js`
+    ),
+  ]);
 
   await browser.close();
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -40,11 +40,32 @@ export async function waitForSync(
 }
 
 /**
+ * Wait for PowerSync context to be fully initialized — WASM loaded, workers
+ * up, and the status hook mounted — without requiring a server-to-client sync.
+ * Once `data-sync-state` is anything other than "uninitialized", `db` is ready
+ * to accept `writeTransaction` calls (schema is set up from the JS definition,
+ * not the first sync). Use this before going offline in E2E tests; prefer
+ * `waitForSynced` only when you actually need a completed server sync.
+ */
+export async function waitForSyncReady(
+  page: Page,
+  timeout = 30_000
+): Promise<void> {
+  await expect(
+    page
+      .locator(`[role="status"]:not([data-sync-state="uninitialized"])`)
+      .first()
+  ).toBeVisible({ timeout });
+}
+
+/**
  * Wait for PowerSync to have completed at least one full initial sync
- * (`status.lastSyncedAt != null`). E2E writes that race ahead of this can hang
- * `db.writeTransaction`, leaving the form sheet stuck open (issue #297). The
- * underlying primitive is `lastSyncedAt` (sticky across disconnects), not
- * `hasSynced` (reset on every disconnect by PowerSync's status merge).
+ * (`status.lastSyncedAt != null`). The underlying primitive is `lastSyncedAt`
+ * (sticky across disconnects), not `hasSynced` (reset on every disconnect by
+ * PowerSync's status merge). Only use this when server data must be present
+ * before proceeding — on environments where PowerSync can't reach its sync
+ * service, this will hang indefinitely. For most write-path tests, prefer
+ * `waitForSyncReady`.
  */
 export async function waitForSynced(
   page: Page,

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { expect, type Page } from "@playwright/test";
+import type {
+  FALLBACK_SYNC_STATE,
+  SyncKey,
+} from "../src/components/sync-status";
 
 export const AUTH_STATE_PATH = resolve(
   import.meta.dirname,
@@ -11,6 +15,45 @@ export const AUTH_STATE_PATH = resolve(
 export const ADD_TRICK_RE = /add trick/i;
 export const ADD_ITEM_RE = /add item/i;
 export const NAME_RE = /^name$/i;
+
+/**
+ * Union of all `data-sync-state` values the `<SyncStatus>` pill can emit:
+ * the canonical `SyncKey` set plus the `FALLBACK_SYNC_STATE` sentinel from
+ * `SyncStatusFallback`. Both sides are imported (not duplicated) so the
+ * union and the rendered attribute can't drift.
+ */
+export type SyncState = SyncKey | typeof FALLBACK_SYNC_STATE;
+
+/**
+ * Wait for the `<SyncStatus>` pill (rendered in the app shell) to reach a
+ * specific transport state. Reads the `data-sync-state` attribute set by
+ * `SyncStatusInner` — see `src/components/sync-status.tsx`.
+ */
+export async function waitForSync(
+  page: Page,
+  expectedState: SyncState = "online",
+  timeout = 30_000
+): Promise<void> {
+  await expect(
+    page.locator(`[role="status"][data-sync-state="${expectedState}"]`).first()
+  ).toBeVisible({ timeout });
+}
+
+/**
+ * Wait for PowerSync to have completed at least one full initial sync
+ * (`status.lastSyncedAt != null`). E2E writes that race ahead of this can hang
+ * `db.writeTransaction`, leaving the form sheet stuck open (issue #297). The
+ * underlying primitive is `lastSyncedAt` (sticky across disconnects), not
+ * `hasSynced` (reset on every disconnect by PowerSync's status merge).
+ */
+export async function waitForSynced(
+  page: Page,
+  timeout = 30_000
+): Promise<void> {
+  await expect(
+    page.locator('[role="status"][data-has-synced="true"]').first()
+  ).toBeVisible({ timeout });
+}
 
 /** Check if a real authenticated session exists (written by auth.setup.ts). */
 export function hasAuthSession(): boolean {
@@ -73,6 +116,12 @@ async function createEntity(
   page: Page,
   args: { addButtonRe: RegExp; formId: string; name: string }
 ): Promise<void> {
+  // Defensive gate against PowerSync's initial-sync race: `waitForAddButton`
+  // only checks visibility, so the click can land before WASM + workers + the
+  // first server-to-client sync are all ready, leaving `db.writeTransaction`
+  // hanging and the sheet stuck open (issue #297). In offline mode this is a
+  // fast no-op — `lastSyncedAt` is a sticky latch from the initial connect.
+  await waitForSynced(page);
   await page.getByRole("button", { name: args.addButtonRe }).first().click();
   await expect(page.getByRole("dialog")).toBeVisible({ timeout: 5000 });
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -116,12 +116,6 @@ async function createEntity(
   page: Page,
   args: { addButtonRe: RegExp; formId: string; name: string }
 ): Promise<void> {
-  // Defensive gate against PowerSync's initial-sync race: `waitForAddButton`
-  // only checks visibility, so the click can land before WASM + workers + the
-  // first server-to-client sync are all ready, leaving `db.writeTransaction`
-  // hanging and the sheet stuck open (issue #297). In offline mode this is a
-  // fast no-op — `lastSyncedAt` is a sticky latch from the initial connect.
-  await waitForSynced(page);
   await page.getByRole("button", { name: args.addButtonRe }).first().click();
   await expect(page.getByRole("dialog")).toBeVisible({ timeout: 5000 });
 

--- a/src/components/sync-status.test.tsx
+++ b/src/components/sync-status.test.tsx
@@ -1,27 +1,52 @@
+import type { useStatus } from "@powersync/react";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SyncStatus } from "./sync-status";
 
-const mockStatus = {
+// Derive the mock shape from the real `useStatus()` return type so the test
+// breaks at compile time if @powersync/react renames or retypes a field —
+// rather than silently passing against a stale fictional shape. The mapped
+// `-readonly` modifier strips SyncStatus's readonly getters so tests can
+// mutate fields between cases.
+type MockStatus = {
+  -readonly [K in "connected" | "dataFlowStatus" | "lastSyncedAt"]: ReturnType<
+    typeof useStatus
+  >[K];
+};
+
+const mockStatus: MockStatus = {
   connected: false,
+  lastSyncedAt: undefined,
   dataFlowStatus: {
     uploading: false,
     downloading: false,
-    downloadError: undefined as Error | undefined,
-    uploadError: undefined as Error | undefined,
+    downloadError: undefined,
+    uploadError: undefined,
   },
 };
 
+// Module-level latch: when true, the next `useStatus()` call throws (simulating
+// rendering outside a PowerSyncContext) so SyncStatusBoundary catches it and
+// SyncStatusFallback renders. Reset by `resetStatus()` between tests.
+let useStatusShouldThrow = false;
+
 vi.mock("@powersync/react", () => ({
-  useStatus: () => mockStatus,
+  useStatus: () => {
+    if (useStatusShouldThrow) {
+      throw new Error("useStatus called outside PowerSyncContext");
+    }
+    return mockStatus;
+  },
 }));
 
 function resetStatus(): void {
   mockStatus.connected = false;
+  mockStatus.lastSyncedAt = undefined;
   mockStatus.dataFlowStatus.uploading = false;
   mockStatus.dataFlowStatus.downloading = false;
   mockStatus.dataFlowStatus.downloadError = undefined;
   mockStatus.dataFlowStatus.uploadError = undefined;
+  useStatusShouldThrow = false;
 }
 
 describe("SyncStatus", () => {
@@ -34,6 +59,10 @@ describe("SyncStatus", () => {
 
     expect(screen.getByRole("status")).toBeInTheDocument();
     expect(screen.getByText("sync.offline")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-sync-state",
+      "offline"
+    );
   });
 
   it("renders online status when connected with no activity", () => {
@@ -41,6 +70,10 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.online")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-sync-state",
+      "online"
+    );
   });
 
   it("renders syncing status when connected and downloading", () => {
@@ -49,6 +82,10 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.syncing")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-sync-state",
+      "syncing"
+    );
   });
 
   it("renders pendingChanges status when connected and uploading", () => {
@@ -57,6 +94,10 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.pendingChanges")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-sync-state",
+      "pendingChanges"
+    );
   });
 
   it("renders error status when there is a download error", () => {
@@ -65,6 +106,10 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.error")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-sync-state",
+      "error"
+    );
   });
 
   it("renders error status when there is an upload error", () => {
@@ -72,6 +117,10 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.error")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-sync-state",
+      "error"
+    );
   });
 
   it("prioritizes error over syncing status", () => {
@@ -81,5 +130,69 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.error")).toBeInTheDocument();
+  });
+
+  it("reflects lastSyncedAt set via data-has-synced='true'", () => {
+    mockStatus.connected = true;
+    mockStatus.lastSyncedAt = new Date();
+    render(<SyncStatus />);
+
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-has-synced",
+      "true"
+    );
+  });
+
+  it("emits data-has-synced='false' when lastSyncedAt is undefined", () => {
+    mockStatus.connected = true;
+    mockStatus.lastSyncedAt = undefined;
+    render(<SyncStatus />);
+
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-has-synced",
+      "false"
+    );
+  });
+
+  it("keeps data-has-synced='true' after disconnect (lastSyncedAt sticky)", () => {
+    // Regression guard for issue #297: PowerSync's updateSyncStatus drops
+    // `hasSynced` on disconnect but preserves `lastSyncedAt`. Using
+    // lastSyncedAt as the underlying signal keeps the durable latch.
+    mockStatus.connected = false;
+    mockStatus.lastSyncedAt = new Date();
+    render(<SyncStatus />);
+
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-has-synced",
+      "true"
+    );
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-sync-state",
+      "offline"
+    );
+  });
+
+  it("renders fallback with uninitialized state when useStatus throws", () => {
+    // Silence React's expected error log for the caught-by-boundary throw.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // intentionally empty
+    });
+    try {
+      useStatusShouldThrow = true;
+
+      render(<SyncStatus />);
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toHaveAttribute(
+        "data-sync-state",
+        "uninitialized"
+      );
+      expect(screen.getByRole("status")).toHaveAttribute(
+        "data-has-synced",
+        "false"
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/src/components/sync-status.tsx
+++ b/src/components/sync-status.tsx
@@ -5,7 +5,23 @@ import { useTranslations } from "next-intl";
 import { Component, type ReactElement, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
-type SyncKey = "offline" | "syncing" | "pendingChanges" | "online" | "error";
+/**
+ * Public contract for `data-sync-state` values. Consumed by E2E helpers in
+ * `e2e/helpers.ts` (composed with `FALLBACK_SYNC_STATE` into `SyncState`) —
+ * keep this union and the rendered attribute in sync.
+ */
+export type SyncKey =
+  | "offline"
+  | "syncing"
+  | "pendingChanges"
+  | "online"
+  | "error";
+
+/**
+ * Sentinel value emitted on the fallback span. Intentionally not a member of
+ * `SyncKey` so locator queries for it never collide with a real state.
+ */
+export const FALLBACK_SYNC_STATE = "uninitialized";
 
 /** Maps every SyncKey to its dot color — adding a new key without a color is a type error. */
 const syncColors: Record<SyncKey, string> = {
@@ -40,7 +56,14 @@ function deriveSyncKey(status: ReturnType<typeof useStatus>): SyncKey {
 
 /** Renders an empty placeholder matching the SyncStatus layout dimensions. */
 function SyncStatusFallback(): ReactElement {
-  return <span className="flex items-center gap-1.5" role="status" />;
+  return (
+    <span
+      className="flex items-center gap-1.5"
+      data-has-synced="false"
+      data-sync-state={FALLBACK_SYNC_STATE}
+      role="status"
+    />
+  );
 }
 
 // Error boundary is required here because useStatus() throws if rendered
@@ -75,8 +98,15 @@ function SyncStatusInner(): ReactElement {
   const key = deriveSyncKey(status);
   const color = syncColors[key];
 
+  // `lastSyncedAt` (sticky), not `hasSynced` (cleared on every disconnect by
+  // @powersync/common's `updateSyncStatus` merge — see issue #297).
   return (
-    <span className="flex items-center gap-1.5" role="status">
+    <span
+      className="flex items-center gap-1.5"
+      data-has-synced={status.lastSyncedAt === undefined ? "false" : "true"}
+      data-sync-state={key}
+      role="status"
+    >
       <span className={cn("inline-flex size-2 rounded-full", color)} />
       <span className="text-muted-foreground text-xs">{t(key)}</span>
     </span>


### PR DESCRIPTION
## Summary

- Exposes \`data-sync-state\` and \`data-has-synced\` DOM attributes on the \`<SyncStatus>\` pill so Playwright tests can gate on PowerSync state without arbitrary timeouts
- Uses \`lastSyncedAt\` (sticky across disconnects) instead of \`hasSynced\` (reset on every disconnect by \`@powersync/common\`'s \`updateSyncStatus\`) as the underlying signal for \`data-has-synced\`
- Adds three E2E helpers backed by the new attributes:
  - \`waitForSync(page, state)\` — waits for a specific \`data-sync-state\` value
  - \`waitForSyncReady(page)\` — waits for PowerSync context to initialize (WASM + workers ready; does NOT require server connectivity)
  - \`waitForSynced(page)\` — waits for a completed server-to-client sync (\`lastSyncedAt\` set); only use when server data must be present
- Exports \`SyncKey\` and \`FALLBACK_SYNC_STATE\` from \`sync-status.tsx\` as the canonical public contract consumed by E2E helpers to keep locators drift-free
- Prewarms PowerSync worker bundles in \`global-setup.ts\` with logged non-fatal fallback (replaces silent \`.catch(() => undefined)\`)
- Adds \`test.slow()\` and \`waitForSyncReady\` + \`waitForSync(page, "offline")\` gates to the offline E2E test (issue #297 confirmed failure mode)

## Test plan

- [x] Unit tests: \`data-has-synced\` assertions, \`lastSyncedAt\` sticky tests, and fallback boundary test all pass
- [x] E2E: all 33 tests pass on Vercel preview
- [x] E2E: offline test no longer flakes — \`waitForSyncReady\` gates on WASM/worker init, \`waitForSync(page, "offline")\` gates on stable pill state before the click

## Notes

- On Vercel preview deployments, PowerSync's WebSocket to the sync service does not complete (likely a domain allowlist or WSS policy issue on the preview URLs). Tests pass because all writes are local-first. Tracked separately in issue #298.

Refs #297