### PR TITLE
diag: widen PowerSync token logging for issue #300

### DIFF
--- a/e2e/diag-300.spec.ts
+++ b/e2e/diag-300.spec.ts
@@ -37,6 +37,16 @@ test.describe("DIAG #300 — PowerSync token diagnostics", () => {
       () =>
         document.documentElement.getAttribute("data-diag-token-ok") ?? "not-set"
     );
+    const tokenIss = await page.evaluate(
+      () =>
+        document.documentElement.getAttribute("data-diag-token-iss") ??
+        "not-set"
+    );
+    const tokenAud = await page.evaluate(
+      () =>
+        document.documentElement.getAttribute("data-diag-token-aud") ??
+        "not-set"
+    );
     const hasSynced = await page.evaluate(
       () =>
         document.querySelector("[role='status'][data-has-synced='true']") !==
@@ -52,6 +62,7 @@ test.describe("DIAG #300 — PowerSync token diagnostics", () => {
     // Log everything so the CI output tells us which branch (B1/B2/B3) applies.
     console.log(
       `[DIAG #300] token-status=${tokenStatus} token-ok=${tokenOk} ` +
+        `iss=${tokenIss} aud=${tokenAud} ` +
         `has-synced=${hasSynced} sync-state=${syncState}`
     );
 

--- a/e2e/diag-300.spec.ts
+++ b/e2e/diag-300.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * DIAG #300 — REMOVE BEFORE MERGE.
+ *
+ * Reads `data-diag-token-*` attributes stamped by provider.tsx's diagnostic
+ * getToken() wrapper to determine WHY PowerSync doesn't sync on previews.
+ *
+ * Results surface in CI logs under "Activity feed" without needing Vercel
+ * log access. Run only in the authenticated project (session required so the
+ * token endpoint is actually hit with a real session).
+ */
+import { expect, test } from "@playwright/test";
+import { hasAuthSession } from "./helpers";
+
+test.describe("DIAG #300 — PowerSync token diagnostics", () => {
+  test.beforeEach(() => {
+    test.skip(!hasAuthSession(), "No authenticated session — skipping diag");
+  });
+
+  test("reports /api/auth/token status and token shape from preview", async ({
+    page,
+  }) => {
+    // Navigate to a page that mounts PowerSyncProvider (any (app) route).
+    await page.goto("/dashboard");
+    // Give getToken() up to 15s to fire after page load.
+    await page.waitForFunction(
+      () => document.documentElement.hasAttribute("data-diag-token-status"),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    const tokenStatus = await page.evaluate(
+      () =>
+        document.documentElement.getAttribute("data-diag-token-status") ??
+        "not-set"
+    );
+    const tokenOk = await page.evaluate(
+      () =>
+        document.documentElement.getAttribute("data-diag-token-ok") ?? "not-set"
+    );
+    const hasSynced = await page.evaluate(
+      () =>
+        document.querySelector("[role='status'][data-has-synced='true']") !==
+        null
+    );
+    const syncState = await page.evaluate(
+      () =>
+        document
+          .querySelector("[role='status']")
+          ?.getAttribute("data-sync-state") ?? "not-found"
+    );
+
+    // Log everything so the CI output tells us which branch (B1/B2/B3) applies.
+    console.log(
+      `[DIAG #300] token-status=${tokenStatus} token-ok=${tokenOk} ` +
+        `has-synced=${hasSynced} sync-state=${syncState}`
+    );
+
+    // The test itself always passes — we're collecting data, not asserting.
+    // The console.log above is the diagnostic output.
+    expect(tokenStatus).not.toBe("not-set");
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -71,7 +71,7 @@ export default defineConfig({
         storageState: AUTH_STATE_PATH,
       },
       testMatch:
-        /settings-.*\.spec\.ts|repertoire\.spec\.ts|activity\.spec\.ts/,
+        /settings-.*\.spec\.ts|repertoire\.spec\.ts|activity\.spec\.ts|diag-300\.spec\.ts/,
       dependencies: ["setup"],
     },
     // PWA tests — SW registration, activation, cache verification.

--- a/src/app/api/auth/[...path]/route.ts
+++ b/src/app/api/auth/[...path]/route.ts
@@ -12,12 +12,30 @@ export async function GET(
 
   if (path[0] === "token") {
     const { data: session } = await auth.getSession();
+    // DIAG #300 — REVERT BEFORE MERGE. Log token-endpoint context so we can
+    // see on Vercel preview logs whether the session is reaching the handler.
+    console.info("[DIAG #300] /api/auth/token GET", {
+      hasSession: session !== null,
+      userId: session?.user?.id ?? null,
+      host: request.headers.get("host"),
+      origin: request.headers.get("origin"),
+      cookieHeaderLen: request.headers.get("cookie")?.length ?? 0,
+      vercelEnv: process.env.VERCEL_ENV ?? null,
+    });
     if (session?.user?.id && (await isUserBanned(session.user.id))) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
   }
 
-  return handler.GET(request, context);
+  const response = await handler.GET(request, context);
+  if (path[0] === "token") {
+    // DIAG #300 — log the response status the upstream Neon Auth handler gave us.
+    console.info("[DIAG #300] /api/auth/token response status", {
+      status: response.status,
+      ok: response.ok,
+    });
+  }
+  return response;
 }
 
 // POST does not need a ban check: the token endpoint is GET-only (Neon Auth

--- a/src/sync/provider.tsx
+++ b/src/sync/provider.tsx
@@ -20,18 +20,36 @@ function hasStringToken(value: unknown): value is { token: string } {
   );
 }
 
+// DIAG #300 — REVERT BEFORE MERGE. Widened logging to surface why
+// /api/auth/token doesn't yield a usable token on Vercel previews.
 async function getToken(): Promise<string | null> {
   try {
     const response = await fetch("/api/auth/token");
+    console.info("[DIAG #300] /api/auth/token response", {
+      status: response.status,
+      contentType: response.headers.get("content-type"),
+      url: response.url,
+      cookieSent: document.cookie.length > 0,
+    });
     if (!response.ok) {
       if (response.status !== 401) {
         console.warn(`[PowerSync] Token fetch failed: ${response.status}`);
       }
+      console.warn(
+        "[DIAG #300] returning null — non-OK status",
+        response.status
+      );
       return null;
     }
     const data: unknown = await response.json();
-    return hasStringToken(data) ? data.token : null;
-  } catch {
+    const tokenOk = hasStringToken(data);
+    console.info("[DIAG #300] token body shape", {
+      tokenOk,
+      keys: data && typeof data === "object" ? Object.keys(data) : null,
+    });
+    return tokenOk ? data.token : null;
+  } catch (err) {
+    console.error("[DIAG #300] getToken threw", err);
     return null;
   }
 }
@@ -59,15 +77,28 @@ export function PowerSyncProvider({
 
     const connectAsync = async (): Promise<void> => {
       try {
-        const connector = createNeonConnector(getToken);
+        // DIAG #300 — wrap getToken so we can see whether fetchCredentials
+        // is even being invoked on previews.
+        const wrappedGetToken = async (): Promise<string | null> => {
+          console.info("[DIAG #300] fetchCredentials -> getToken invoked");
+          const t = await getToken();
+          console.info("[DIAG #300] getToken resolved", {
+            hasToken: t !== null,
+          });
+          return t;
+        };
+        const connector = createNeonConnector(wrappedGetToken);
         if (cancelled) {
           return;
         }
+        console.info("[DIAG #300] powerSyncDb.connect() starting");
         await powerSyncDb.connect(connector);
+        console.info("[DIAG #300] powerSyncDb.connect() resolved");
       } catch (error: unknown) {
         if (!cancelled) {
           connecting = false;
           console.error("PowerSync connection failed:", error);
+          console.error("[DIAG #300] connect threw", error);
         }
       }
     };

--- a/src/sync/provider.tsx
+++ b/src/sync/provider.tsx
@@ -34,11 +34,11 @@ async function getToken(): Promise<string | null> {
     if (!response.ok) {
       if (response.status !== 401) {
         console.warn(`[PowerSync] Token fetch failed: ${response.status}`);
+        console.warn(
+          "[DIAG #300] returning null — non-OK status",
+          response.status
+        );
       }
-      console.warn(
-        "[DIAG #300] returning null — non-OK status",
-        response.status
-      );
       return null;
     }
     const data: unknown = await response.json();

--- a/src/sync/provider.tsx
+++ b/src/sync/provider.tsx
@@ -54,6 +54,33 @@ async function getToken(): Promise<string | null> {
       "data-diag-token-ok",
       tokenOk ? "true" : "false-bad-shape"
     );
+    if (tokenOk) {
+      try {
+        const payloadB64 = data.token.split(".")[1] ?? "";
+        const padded = payloadB64
+          .replace(/-/g, "+")
+          .replace(/_/g, "/")
+          .padEnd(payloadB64.length + ((4 - (payloadB64.length % 4)) % 4), "=");
+        const payload = JSON.parse(atob(padded)) as Record<string, unknown>;
+        const issStr = typeof payload.iss === "string" ? payload.iss : "n/a";
+        const audVal = payload.aud;
+        let audStr = "n/a";
+        if (Array.isArray(audVal)) {
+          audStr = audVal.join(",");
+        } else if (typeof audVal === "string") {
+          audStr = audVal;
+        }
+        document.documentElement.setAttribute("data-diag-token-iss", issStr);
+        document.documentElement.setAttribute("data-diag-token-aud", audStr);
+        console.info("[DIAG #300] JWT claims", { iss: issStr, aud: audStr });
+      } catch (err) {
+        document.documentElement.setAttribute(
+          "data-diag-token-iss",
+          "decode-error"
+        );
+        console.error("[DIAG #300] JWT decode failed", err);
+      }
+    }
     console.info("[DIAG #300] token body shape", {
       tokenOk,
       keys: data && typeof data === "object" ? Object.keys(data) : null,

--- a/src/sync/provider.tsx
+++ b/src/sync/provider.tsx
@@ -25,6 +25,12 @@ function hasStringToken(value: unknown): value is { token: string } {
 async function getToken(): Promise<string | null> {
   try {
     const response = await fetch("/api/auth/token");
+    // DIAG #300: stamp the token response status onto <html> so Playwright
+    // can read it without needing Vercel log access.
+    document.documentElement.setAttribute(
+      "data-diag-token-status",
+      String(response.status)
+    );
     console.info("[DIAG #300] /api/auth/token response", {
       status: response.status,
       contentType: response.headers.get("content-type"),
@@ -39,10 +45,15 @@ async function getToken(): Promise<string | null> {
           response.status
         );
       }
+      document.documentElement.setAttribute("data-diag-token-ok", "false");
       return null;
     }
     const data: unknown = await response.json();
     const tokenOk = hasStringToken(data);
+    document.documentElement.setAttribute(
+      "data-diag-token-ok",
+      tokenOk ? "true" : "false-bad-shape"
+    );
     console.info("[DIAG #300] token body shape", {
       tokenOk,
       keys: data && typeof data === "object" ? Object.keys(data) : null,


### PR DESCRIPTION
## ⚠️ DIAGNOSTIC BRANCH — REVERT BEFORE MERGE

Do not merge. This branch exists to capture runtime evidence for issue #300 (PowerSync WebSocket never completing on Vercel preview deployments).

## What this adds

**Server-side** (visible in `vercel logs <preview-url>`):
- `[DIAG #300] /api/auth/token GET` — logs `hasSession`, `userId`, `host`, `origin`, cookie header length, `VERCEL_ENV`
- `[DIAG #300] /api/auth/token response status` — logs the status Neon Auth's handler returned

**Client-side** (visible in browser DevTools → Console → filter `DIAG #300`):
- `/api/auth/token` response status, content-type, body keys
- Whether `fetchCredentials` is invoked at all
- Whether `connect()` resolves or throws

## How to read the results

After the preview deploys, run:
```
vercel logs <preview-url> --since 1h | grep "DIAG #300"
```

Or sign in to the preview in a browser and check the console.

Decision matrix (from the issue #300 plan):
| Server log shows | Root cause | Fix |
|---|---|---|
| `hasSession: false` | Auth session not honoured on preview host | B1 — Neon Auth trusted origins |
| `hasSession: true`, token 401 | Token endpoint rejecting preview session | B1 |
| `hasSession: true`, token 200, client shows `tokenOk: false` | Response body shape mismatch | B2 |
| `hasSession: true`, token 200, client shows `tokenOk: true`, no WSS | PowerSync Cloud rejects JWT/origin | B3 |

Refs #300