### PR TITLE
feat: add Ask an AI section to marketing footer

### DIFF
--- a/docs/product-overview.md
+++ b/docs/product-overview.md
@@ -1,0 +1,57 @@
+# The Magic Lab — Product Overview
+
+**Tagline**: Train. Plan. Perform. Elevate your magic.
+
+The Magic Lab (themagiclab.app) is a free, open-source, offline-first workspace built for magicians. It is a single place to organize your repertoire, plan setlists, track practice and performance, and grow your craft over time — not a marketplace, not a social network, not a video platform. Your data stays yours.
+
+## Who it is for
+
+Working magicians, hobbyists, and students of the art — from someone learning their first sleights to a touring professional juggling close-up, parlor, and stage repertoire across multiple venues. If you currently keep your tricks in a notebook, a Notes app, a spreadsheet, or scattered Notion pages, The Magic Lab is purpose-built for what you are doing.
+
+The app is designed mobile-first because rehearsal and reference happen in greenrooms, at tables, on planes — not at a desk. It installs as a Progressive Web App on iOS and Android and works fully offline once loaded.
+
+## What it does today
+
+The current product surface ships two complete modules, plus an activity history. Several other modules are in development and visible as "coming soon" placeholders.
+
+### Available today
+
+- **Repertoire** — Catalog your tricks. Each entry tracks name, description, category (card, coin, mentalism, stage, etc.), effect type (vanish, production, prediction…), difficulty (1–5), status (new / learning / performance-ready / mastered / shelved), props required, music, languages performed in, angle sensitivity, camera-friendliness, source (book, DVD, mentor), video reference, and free-form notes. Tag tricks to slice your library however you think (themes, opener, closer, walkaround, restaurant set, etc.).
+- **Collection** — Inventory of props, books, gimmicks, DVDs, downloads, decks, clothing, consumables, accessories. Track condition, purchase date and price, current location ("close-up case", "stage case"), quantity, and link items back to the tricks that use them — so you can answer "which tricks am I out of supplies for?" or "where did I put the Invisible Deck?".
+- **Activity** — A canonical timeline of everything you've done in the app: trick added / updated / deleted, item added, tag created, settings changed. Useful as a journal and as a "did I really practice this week?" reality check.
+
+### In development (visible but disabled)
+
+- **Improve** — Log practice sessions (what, how long, self-rating), see trends, maintain streaks.
+- **Train** — Goals, drills, structured practice plans.
+- **Plan** — Build show-ready setlists. Order tricks, annotate transitions, estimate timing, keep multiple setlists for different venues and audiences.
+- **Perform** — Performance log: venue, audience, what worked, what to change, feedback.
+- **Enhance** — Insights and suggestions: what to practice next, gaps in repertoire, suggested setlists from your existing tricks.
+
+These appear in the navigation as "coming soon" today; they will activate as they ship.
+
+## How it is different
+
+- **Built for magicians, by a magician.** The data model knows what a "trick" is, what "angle sensitivity" means, why "camera friendly" matters, what tags actually need to do. A general notes app does not.
+- **Offline-first, not cloud-only.** Your data is stored locally on your device in a real database (SQLite via PowerSync) and syncs to the cloud (Neon Postgres) when you are online. Open the app backstage with no signal — every trick, every note, every prop entry is right there. Make changes offline, they sync next time you connect.
+- **Free and open source under the GPL-3.0 license.** No paid tiers, no ads, no upsells, no "pro plan". The code is on [GitHub](https://github.com/julienroussel/tml). You can read it, fork it, self-host it, or contribute.
+- **Privacy stance.** The app collects the minimum needed (email + display name from your OAuth provider, plus the data you choose to put in). Data is encrypted in transit and at rest. We do not sell, share, or use your data for advertising. Anonymous analytics (page views, performance metrics) help us improve the app. No third-party AI providers see your data.
+- **Mobile-first PWA.** Installable on iOS and Android home screens. Works as a native-feeling app — no app store, no auto-updates breaking things, no platform tax.
+- **Internationalized.** Available in English, French, Spanish, Portuguese, Italian, German, and Dutch.
+
+## Compared to alternatives
+
+- **vs. a paper notebook**: searchable, filterable, syncs across devices, never lost, never water-damaged. The notebook is still better for ad-hoc sketches; The Magic Lab is better for everything else.
+- **vs. a Notes app (Apple Notes / Google Keep)**: structured fields per trick, tags that mean something, linkable inventory, practice/performance history. Notes apps are unstructured prose; magic has structure.
+- **vs. Notion / Obsidian / Airtable**: zero setup. You do not build the schema, you do not maintain templates, you do not invent the data model — it already knows what a trick is. Specialized beats general-purpose when the domain has its own shape.
+- **vs. SaaS competitors**: free, open source, offline-first, no lock-in. Export your data any time.
+
+## Project facts
+
+- **License**: GPL-3.0
+- **Source**: https://github.com/julienroussel/tml
+- **Production URL**: https://themagiclab.app
+- **Languages supported**: English, French, Spanish, Portuguese, Italian, German, Dutch
+- **Hosting**: Vercel
+- **Stack**: Next.js 16 (App Router), React 19, Tailwind CSS v4, shadcn/ui, Neon Postgres, PowerSync, Drizzle ORM, next-intl. (See the architecture sections of this document for engineering detail.)
+- **Status**: Active development. Repertoire, Collection, and Activity are production-ready. Improve, Train, Plan, Perform, and Enhance are visible as upcoming modules.

--- a/scripts/generate-llms-txt.test.ts
+++ b/scripts/generate-llms-txt.test.ts
@@ -7,14 +7,34 @@ describe("generateLlmsTxt", () => {
     expect(output.startsWith("# The Magic Lab\n")).toBe(true);
   });
 
-  it("includes a blockquote description", () => {
+  it("includes the tagline as a blockquote", () => {
     const output = generateLlmsTxt();
-    expect(output).toContain("> A free, open-source workspace for magicians");
+    expect(output).toContain("> Train. Plan. Perform. Elevate your magic.");
   });
 
-  it("includes a ## Docs section", () => {
+  it("includes product-summary section headings", () => {
     const output = generateLlmsTxt();
-    expect(output).toContain("## Docs");
+    expect(output).toContain("## Who it is for");
+    expect(output).toContain("## What it does today");
+    expect(output).toContain("## Why it is different");
+    expect(output).toContain("## Links");
+  });
+
+  it("mentions the enabled modules so AI summaries describe the real surface", () => {
+    const output = generateLlmsTxt();
+    expect(output).toContain("Repertoire");
+    expect(output).toContain("Collection");
+    expect(output).toContain("Activity");
+  });
+
+  it("marks upcoming modules as in development so AI summaries do not overstate the product", () => {
+    const output = generateLlmsTxt();
+    expect(output).toContain("Improve");
+    expect(output).toContain("Train");
+    expect(output).toContain("Plan");
+    expect(output).toContain("Perform");
+    expect(output).toContain("Enhance");
+    expect(output).toContain("in development");
   });
 
   it("includes links with the production URL", () => {
@@ -89,6 +109,7 @@ describe("generateLlmsFullTxt", () => {
       "i18n.md",
       "local-development.md",
       "migrations.md",
+      "product-overview.md",
       "pwa-notifications.md",
       "route-structure.md",
       "sync-engine.md",
@@ -99,5 +120,13 @@ describe("generateLlmsFullTxt", () => {
     for (const doc of expectedDocs) {
       expect(output).toContain(`Source: docs/${doc}`);
     }
+  });
+
+  it("places product-overview.md as the first source section", () => {
+    const output = generateLlmsFullTxt();
+    const sources = [...output.matchAll(/^Source: docs\/(.+)$/gm)].map(
+      (m) => m[1]
+    );
+    expect(sources[0]).toBe("product-overview.md");
   });
 });

--- a/scripts/generate-llms-txt.ts
+++ b/scripts/generate-llms-txt.ts
@@ -5,6 +5,8 @@ const DOCS_DIR = join(import.meta.dirname, "..", "docs");
 const PUBLIC_DIR = join(import.meta.dirname, "..", "public");
 const BASE_URL = "https://themagiclab.app";
 
+const PRODUCT_OVERVIEW_FILENAME = "product-overview.md";
+
 function collectMarkdownFiles(dir: string): string[] {
   const files: string[] = [];
   const entries = readdirSync(dir, { withFileTypes: true });
@@ -21,6 +23,14 @@ function collectMarkdownFiles(dir: string): string[] {
   return files.sort();
 }
 
+function orderDocFiles(files: string[]): string[] {
+  const overviewPath = files.find((f) =>
+    f.endsWith(`/${PRODUCT_OVERVIEW_FILENAME}`)
+  );
+  const rest = files.filter((f) => f !== overviewPath);
+  return overviewPath ? [overviewPath, ...rest] : rest;
+}
+
 function readDocFile(filePath: string): string {
   return readFileSync(filePath, "utf-8");
 }
@@ -29,25 +39,56 @@ export function generateLlmsTxt(): string {
   const lines = [
     "# The Magic Lab",
     "",
-    "> A free, open-source workspace for magicians to organize their repertoire,",
-    "> plan setlists, track practice sessions, and refine performances.",
+    "> Train. Plan. Perform. Elevate your magic.",
     "",
-    "## Docs",
+    "The Magic Lab is a free, open-source, offline-first workspace built for",
+    "magicians. It is a single place to organize your repertoire, plan setlists,",
+    "track practice and performance, and grow your craft over time.",
     "",
-    `- [Home](${BASE_URL}/en): Overview and features`,
-    `- [Privacy](${BASE_URL}/en/privacy): Privacy policy`,
+    "## Who it is for",
+    "",
+    "Working magicians, hobbyists, and students — from someone learning their",
+    "first sleights to a touring professional. The app is mobile-first and",
+    "installs as a Progressive Web App that works fully offline.",
+    "",
+    "## What it does today",
+    "",
+    "- **Repertoire** — structured catalog of tricks (category, effect type,",
+    "  difficulty, status, props, music, languages, angle sensitivity, notes,",
+    "  tags).",
+    "- **Collection** — inventory of props, books, gimmicks, DVDs, downloads,",
+    "  decks, etc., linkable to the tricks that use them.",
+    "- **Activity** — canonical timeline of everything you've done in the app.",
+    "",
+    "Improve, Train, Plan, Perform, and Enhance modules are in development and",
+    "appear as upcoming placeholders.",
+    "",
+    "## Why it is different",
+    "",
+    "- Built for magicians, by a magician — a domain-specific data model, not",
+    "  a general notes app.",
+    "- Offline-first via PowerSync + local SQLite; Neon Postgres is downstream.",
+    "- Free and open source under GPL-3.0. No paid tiers, no ads.",
+    "- No user data is sent to third-party AI providers.",
+    "- Available in English, French, Spanish, Portuguese, Italian, German, Dutch.",
+    "",
+    "## Links",
+    "",
+    `- [Home](${BASE_URL}/en): Landing page and feature overview`,
     `- [FAQ](${BASE_URL}/en/faq): Common questions`,
+    `- [Privacy](${BASE_URL}/en/privacy): Privacy policy`,
+    "- [Source](https://github.com/julienroussel/tml): GitHub repository",
     "",
     "## Optional",
     "",
-    `- [Full docs](${BASE_URL}/llms-full.txt): Complete documentation`,
+    `- [Full docs](${BASE_URL}/llms-full.txt): Complete product + technical documentation`,
   ];
 
   return `${lines.join("\n")}\n`;
 }
 
 export function generateLlmsFullTxt(): string {
-  const files = collectMarkdownFiles(DOCS_DIR);
+  const files = orderDocFiles(collectMarkdownFiles(DOCS_DIR));
   const sections: string[] = [
     "# The Magic Lab -- Complete Documentation",
     "",

--- a/src/app/(marketing)/[locale]/layout.tsx
+++ b/src/app/(marketing)/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import {
 import type { ReactElement, ReactNode } from "react";
 import { LocaleToggle } from "@/components/locale-toggle";
 import { Logo } from "@/components/logo";
+import { MarketingAskAi } from "@/components/marketing-ask-ai";
 import { MarketingAuthButtons } from "@/components/marketing-auth-buttons";
 import { Providers } from "@/components/providers";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -75,43 +76,48 @@ export default async function MarketingLayout({
           {children}
         </main>
         <footer className="border-t px-6 py-8">
-          <div className="mx-auto flex max-w-5xl flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-muted-foreground text-sm">
-              {tFooter("copyright", { year: new Date().getFullYear() })}
-            </p>
-            <p className="text-muted-foreground text-sm">{tFooter("madeIn")}</p>
-            <nav aria-label={tCommon("footerLinks")} className="flex gap-4">
-              <Link
-                className="text-muted-foreground text-sm transition-colors hover:text-foreground"
-                href={`/${locale}/privacy`}
-              >
-                {tFooter("privacy")}
-              </Link>
-              <Link
-                className="text-muted-foreground text-sm transition-colors hover:text-foreground"
-                href={`/${locale}/faq`}
-              >
-                {tFooter("faq")}
-              </Link>
-              <a
-                className="text-muted-foreground text-sm transition-colors hover:text-foreground"
-                href="https://memdeck.org"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                {tFooter("memDeck")}
-                <span className="sr-only"> {tFooter("memDeckSrOnly")}</span>
-              </a>
-              <a
-                className="text-muted-foreground text-sm transition-colors hover:text-foreground"
-                href="https://github.com/julienroussel/tml"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                {tFooter("gitHub")}
-                <span className="sr-only"> {tFooter("gitHubSrOnly")}</span>
-              </a>
-            </nav>
+          <div className="mx-auto flex max-w-5xl flex-col gap-6">
+            <MarketingAskAi />
+            <div className="flex flex-col gap-6 border-t pt-6 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-muted-foreground text-sm">
+                {tFooter("copyright", { year: new Date().getFullYear() })}
+              </p>
+              <p className="text-muted-foreground text-sm">
+                {tFooter("madeIn")}
+              </p>
+              <nav aria-label={tCommon("footerLinks")} className="flex gap-4">
+                <Link
+                  className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+                  href={`/${locale}/privacy`}
+                >
+                  {tFooter("privacy")}
+                </Link>
+                <Link
+                  className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+                  href={`/${locale}/faq`}
+                >
+                  {tFooter("faq")}
+                </Link>
+                <a
+                  className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+                  href="https://memdeck.org"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  {tFooter("memDeck")}
+                  <span className="sr-only"> {tFooter("memDeckSrOnly")}</span>
+                </a>
+                <a
+                  className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+                  href="https://github.com/julienroussel/tml"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  {tFooter("gitHub")}
+                  <span className="sr-only"> {tFooter("gitHubSrOnly")}</span>
+                </a>
+              </nav>
+            </div>
           </div>
         </footer>
       </div>

--- a/src/app/(marketing)/[locale]/privacy/page.test.tsx
+++ b/src/app/(marketing)/[locale]/privacy/page.test.tsx
@@ -17,7 +17,7 @@ describe("PrivacyPage", () => {
     render(await PrivacyPage(defaultParams));
 
     const sectionHeadings = screen.getAllByRole("heading", { level: 2 });
-    expect(sectionHeadings).toHaveLength(5);
+    expect(sectionHeadings).toHaveLength(6);
   });
 
   it("renders section titles with correct translation keys", async () => {
@@ -28,6 +28,9 @@ describe("PrivacyPage", () => {
     expect(screen.getByText("privacy.dataStorageTitle")).toBeInTheDocument();
     expect(screen.getByText("privacy.rightsTitle")).toBeInTheDocument();
     expect(screen.getByText("privacy.analyticsTitle")).toBeInTheDocument();
+    expect(
+      screen.getByText("privacy.thirdPartyToolsTitle")
+    ).toBeInTheDocument();
   });
 
   it("renders the intro paragraph", async () => {

--- a/src/app/(marketing)/[locale]/privacy/page.tsx
+++ b/src/app/(marketing)/[locale]/privacy/page.tsx
@@ -70,6 +70,12 @@ export default async function PrivacyPage({
           </h2>
           <p>{t("analyticsDesc")}</p>
         </div>
+        <div>
+          <h2 className="mb-2 font-semibold text-foreground text-lg">
+            {t("thirdPartyToolsTitle")}
+          </h2>
+          <p>{t("thirdPartyToolsDesc")}</p>
+        </div>
       </div>
     </section>
   );

--- a/src/components/marketing-ask-ai.test.tsx
+++ b/src/components/marketing-ask-ai.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useTranslations } from "next-intl";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trackEvent } from "@/lib/analytics";
+import { MarketingAskAi } from "./marketing-ask-ai";
+
+vi.mock("next-intl", () => ({
+  useTranslations: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
+type TranslateFn = (key: string) => string;
+
+const defaultT: TranslateFn = (key: string) => `footer.askAi.${key}`;
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function labelPattern(key: string): RegExp {
+  return new RegExp(escapeRegex(`footer.askAi.${key}`));
+}
+
+function setTranslator(t: TranslateFn): void {
+  vi.mocked(useTranslations).mockReturnValue(
+    t as unknown as ReturnType<typeof useTranslations>
+  );
+}
+
+describe("MarketingAskAi", () => {
+  beforeEach(() => {
+    setTranslator(defaultT);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scopes translations to the footer.askAi namespace", () => {
+    render(<MarketingAskAi />);
+    expect(useTranslations).toHaveBeenCalledWith("footer.askAi");
+  });
+
+  it("renders one link per provider with the correct hostname and ?q= prompt", () => {
+    render(<MarketingAskAi />);
+
+    const expected: Array<{ key: string; hostname: string; path: string }> = [
+      { key: "chatGpt", hostname: "chatgpt.com", path: "/" },
+      { key: "claude", hostname: "claude.ai", path: "/new" },
+      {
+        key: "perplexity",
+        hostname: "www.perplexity.ai",
+        path: "/search/new",
+      },
+    ];
+
+    for (const { key, hostname, path } of expected) {
+      const link = screen.getByRole("link", { name: labelPattern(key) });
+      const href = link.getAttribute("href");
+      expect(href, `href for ${key}`).toBeTruthy();
+      const url = new URL(href ?? "");
+      expect(url.hostname).toBe(hostname);
+      expect(url.pathname).toBe(path);
+      expect(url.searchParams.get("q")).toBe("footer.askAi.prompt");
+    }
+  });
+
+  it("opens each link in a new tab with safe rel attributes", () => {
+    render(<MarketingAskAi />);
+
+    for (const key of ["chatGpt", "claude", "perplexity"]) {
+      const link = screen.getByRole("link", { name: labelPattern(key) });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+
+  it("composes the link's accessible name from provider label and 'opens in new tab'", () => {
+    render(<MarketingAskAi />);
+
+    for (const key of ["chatGpt", "claude", "perplexity"]) {
+      const pattern = new RegExp(
+        `${escapeRegex(`footer.askAi.${key}`)}.*${escapeRegex("footer.askAi.opensInNewTab")}`
+      );
+      expect(screen.getByRole("link", { name: pattern })).toBeInTheDocument();
+    }
+  });
+
+  it("URL-encodes special characters in the prompt within the href", () => {
+    setTranslator((key) =>
+      key === "prompt" ? "hello & world?" : `footer.askAi.${key}`
+    );
+
+    render(<MarketingAskAi />);
+
+    const link = screen.getByRole("link", { name: labelPattern("chatGpt") });
+    const href = link.getAttribute("href") ?? "";
+
+    expect(href).toContain("hello%20%26%20world%3F");
+    expect(href).not.toContain("hello & world?");
+  });
+
+  it("fires marketing_ask_ai_clicked with the right provider on click", async () => {
+    const user = userEvent.setup();
+    render(<MarketingAskAi />);
+
+    const cases: Array<{ key: string; provider: string }> = [
+      { key: "chatGpt", provider: "chatgpt" },
+      { key: "claude", provider: "claude" },
+      { key: "perplexity", provider: "perplexity" },
+    ];
+
+    for (const { key, provider } of cases) {
+      await user.click(screen.getByRole("link", { name: labelPattern(key) }));
+      expect(trackEvent).toHaveBeenCalledWith("marketing_ask_ai_clicked", {
+        provider,
+      });
+    }
+    expect(trackEvent).toHaveBeenCalledTimes(3);
+  });
+
+  it("renders the link group as a list of three items labelled by the section heading", () => {
+    render(<MarketingAskAi />);
+
+    const list = screen.getByRole("list");
+    expect(list).toBeInTheDocument();
+    expect(within(list).getAllByRole("listitem")).toHaveLength(3);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "footer.askAi.groupLabel",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the visible third-party disclosure", () => {
+    render(<MarketingAskAi />);
+
+    expect(screen.getByText("footer.askAi.disclosure")).toBeInTheDocument();
+  });
+});

--- a/src/components/marketing-ask-ai.tsx
+++ b/src/components/marketing-ask-ai.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { ReactElement } from "react";
+import { type MarketingAiProviderId, trackEvent } from "@/lib/analytics";
+
+type Provider = {
+  id: MarketingAiProviderId;
+  labelKey: "chatGpt" | "claude" | "perplexity";
+  urlFor: (encodedPrompt: string) => string;
+};
+
+const PROVIDERS: readonly Provider[] = [
+  {
+    id: "chatgpt",
+    labelKey: "chatGpt",
+    urlFor: (q) => `https://chatgpt.com/?q=${q}`,
+  },
+  {
+    id: "claude",
+    labelKey: "claude",
+    urlFor: (q) => `https://claude.ai/new?q=${q}`,
+  },
+  {
+    id: "perplexity",
+    labelKey: "perplexity",
+    urlFor: (q) => `https://www.perplexity.ai/search/new?q=${q}`,
+  },
+];
+
+export function MarketingAskAi(): ReactElement {
+  const t = useTranslations("footer.askAi");
+  const encodedPrompt = encodeURIComponent(t("prompt"));
+
+  return (
+    <div className="flex flex-col items-center gap-3 text-center">
+      <h2 className="sr-only">{t("groupLabel")}</h2>
+      <div className="flex flex-col items-center gap-3 sm:flex-row sm:flex-wrap sm:justify-center sm:gap-x-4 sm:gap-y-2">
+        <p className="text-muted-foreground text-sm">{t("heading")}</p>
+        <ul
+          className="m-0 flex list-none flex-wrap items-center justify-center gap-2 p-0"
+          // biome-ignore lint/a11y/noRedundantRoles: Safari + VoiceOver strip the implicit list role when list-style: none is applied; explicit role="list" restores it.
+          role="list"
+        >
+          {PROVIDERS.map((provider) => (
+            <li key={provider.id}>
+              <a
+                aria-label={`${t(provider.labelKey)} ${t("opensInNewTab")}`}
+                className="inline-flex min-h-11 items-center rounded-full border border-border bg-background px-4 py-1.5 text-foreground text-sm hover:bg-accent hover:text-accent-foreground focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2 motion-safe:transition-colors"
+                href={provider.urlFor(encodedPrompt)}
+                onClick={() =>
+                  trackEvent("marketing_ask_ai_clicked", {
+                    provider: provider.id,
+                  })
+                }
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {t(provider.labelKey)}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <p className="max-w-md text-muted-foreground text-xs">
+        {t("disclosure")}
+      </p>
+    </div>
+  );
+}

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -446,7 +446,9 @@
     "rightsTitle": "Your rights",
     "rightsDesc": "You can export your data at any time from the Settings page. You can delete your account and all associated data. For questions, reach out via the GitHub repository.",
     "analyticsTitle": "Analytics",
-    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services."
+    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services.",
+    "thirdPartyToolsTitle": "Externe KI-Assistenten",
+    "thirdPartyToolsDesc": "Die Marketingseiten enthalten optionale Links, die ChatGPT, Claude oder Perplexity in einem neuen Tab mit einer vorausgefüllten Anfrage zu The Magic Lab öffnen. Die Anfrage ist eine allgemeine Marketing-Zusammenfassung — The Magic Lab fügt der URL beim Klick keine Konto-, Profil- oder Gerätedaten hinzu. Der Anbieter sieht trotzdem deine IP-Adresse und deinen User-Agent, wie bei jedem externen Link, und Konversationen mit diesen Assistenten unterliegen der Datenschutzrichtlinie des jeweiligen Anbieters. Die Anwendung selbst übermittelt keine Nutzerdaten an externe KI-Anbieter."
   },
   "sync": {
     "online": "Online",
@@ -500,7 +502,17 @@
     "memDeckSrOnly": "(öffnet in einem neuen Tab)",
     "gitHub": "GitHub",
     "gitHubSrOnly": "(öffnet in einem neuen Tab)",
-    "madeIn": "Made with ❤ in Paris 🇫🇷"
+    "madeIn": "Made with ❤ in Paris 🇫🇷",
+    "askAi": {
+      "heading": "Neugierig? Frag eine KI über The Magic Lab —",
+      "groupLabel": "Einen KI-Assistenten zu The Magic Lab befragen",
+      "opensInNewTab": "(öffnet in einem neuen Tab)",
+      "disclosure": "Öffnet einen externen KI-Assistenten — deine Unterhaltung geht an diesen Anbieter, nicht an uns.",
+      "chatGpt": "ChatGPT",
+      "claude": "Claude",
+      "perplexity": "Perplexity",
+      "prompt": "Ich bin Zauberkünstler und suche ein Tool, um mein Repertoire und meine Übungen zu organisieren. The Magic Lab (https://themagiclab.app) ist ein kostenloser, offline-fähiger Open-Source-Arbeitsbereich für Zauberkünstler: Trick-Repertoire, Übungstagebuch, Auftrittsprotokoll. Bitte lies https://themagiclab.app/llms-full.txt und gib mir eine knappe Zusammenfassung: was es bietet, für wen es gedacht ist und wie es sich im Vergleich zu handschriftlichen Notizen oder allgemeinen Apps wie Notion verhält."
+    }
   },
   "auth": {
     "SIGN_IN": "Anmelden",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -446,7 +446,9 @@
     "rightsTitle": "Your rights",
     "rightsDesc": "You can export your data at any time from the Settings page. You can delete your account and all associated data. For questions, reach out via the GitHub repository.",
     "analyticsTitle": "Analytics",
-    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services."
+    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services.",
+    "thirdPartyToolsTitle": "Third-party AI assistants",
+    "thirdPartyToolsDesc": "The marketing pages include optional links that open ChatGPT, Claude, or Perplexity in a new tab with a pre-filled prompt about The Magic Lab. The prompt is a generic marketing summary — The Magic Lab does not add any account, profile, or device data to the URL when you click. The provider will still see your IP address and User-Agent as with any external link, and conversations with these assistants are governed by each provider's own privacy policy. The app itself does not transmit user data to any third-party AI provider."
   },
   "sync": {
     "online": "Online",
@@ -500,7 +502,17 @@
     "memDeckSrOnly": "(opens in a new tab)",
     "gitHub": "GitHub",
     "gitHubSrOnly": "(opens in a new tab)",
-    "madeIn": "Made with ❤ in Paris 🇫🇷"
+    "madeIn": "Made with ❤ in Paris 🇫🇷",
+    "askAi": {
+      "heading": "Curious? Ask an AI assistant about The Magic Lab —",
+      "groupLabel": "Ask an AI assistant about The Magic Lab",
+      "opensInNewTab": "(opens in a new tab)",
+      "disclosure": "Opens a third-party AI assistant — your conversation goes to them, not us.",
+      "chatGpt": "ChatGPT",
+      "claude": "Claude",
+      "perplexity": "Perplexity",
+      "prompt": "I'm a magician evaluating practice and repertoire tools. The Magic Lab (https://themagiclab.app) is a free, open-source, offline-first workspace for magicians: trick repertoire, practice logging, performance tracking. Please read https://themagiclab.app/llms-full.txt and give me a concise summary of what it offers, who it's for, and how it compares to keeping notes in a notebook or general-purpose apps like Notion."
+    }
   },
   "auth": {
     "SIGN_IN": "Sign In",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -446,7 +446,9 @@
     "rightsTitle": "Your rights",
     "rightsDesc": "You can export your data at any time from the Settings page. You can delete your account and all associated data. For questions, reach out via the GitHub repository.",
     "analyticsTitle": "Analytics",
-    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services."
+    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services.",
+    "thirdPartyToolsTitle": "Asistentes de IA externos",
+    "thirdPartyToolsDesc": "Las páginas de marketing incluyen enlaces opcionales que abren ChatGPT, Claude o Perplexity en una pestaña nueva con una pregunta predefinida sobre The Magic Lab. La pregunta es un resumen genérico de marketing — The Magic Lab no añade a la URL ningún dato de cuenta, perfil o dispositivo cuando haces clic. El proveedor recibirá igualmente tu dirección IP y User-Agent, como con cualquier enlace externo, y las conversaciones con estos asistentes se rigen por la política de privacidad de cada proveedor. La aplicación en sí no transmite datos de los usuarios a ningún proveedor de IA externo."
   },
   "sync": {
     "online": "En línea",
@@ -500,7 +502,17 @@
     "memDeckSrOnly": "(se abre en una pestaña nueva)",
     "gitHub": "GitHub",
     "gitHubSrOnly": "(se abre en una pestaña nueva)",
-    "madeIn": "Hecho con ❤ en París 🇫🇷"
+    "madeIn": "Hecho con ❤ en París 🇫🇷",
+    "askAi": {
+      "heading": "¿Curiosidad? Pregunta a una IA sobre The Magic Lab —",
+      "groupLabel": "Preguntar a un asistente de IA sobre The Magic Lab",
+      "opensInNewTab": "(se abre en una pestaña nueva)",
+      "disclosure": "Abre un asistente de IA externo — tu conversación se envía a ese proveedor, no a nosotros.",
+      "chatGpt": "ChatGPT",
+      "claude": "Claude",
+      "perplexity": "Perplexity",
+      "prompt": "Soy mago y estoy evaluando herramientas para organizar mi repertorio y mi práctica. The Magic Lab (https://themagiclab.app) es un espacio de trabajo gratuito, de código abierto y que funciona sin conexión, pensado para magos: repertorio de trucos, registro de práctica, seguimiento de actuaciones. Por favor, consulta https://themagiclab.app/llms-full.txt y dame un resumen conciso de qué ofrece, a quién va dirigido y cómo se compara con tomar notas en un cuaderno o con aplicaciones genéricas como Notion."
+    }
   },
   "auth": {
     "SIGN_IN": "Iniciar sesión",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -446,7 +446,9 @@
     "rightsTitle": "Your rights",
     "rightsDesc": "You can export your data at any time from the Settings page. You can delete your account and all associated data. For questions, reach out via the GitHub repository.",
     "analyticsTitle": "Analytics",
-    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services."
+    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services.",
+    "thirdPartyToolsTitle": "Assistants IA tiers",
+    "thirdPartyToolsDesc": "Les pages marketing proposent des liens optionnels qui ouvrent ChatGPT, Claude ou Perplexity dans un nouvel onglet avec une question préremplie au sujet de The Magic Lab. La question est un résumé marketing générique — The Magic Lab n'ajoute à l'URL aucune donnée de compte, de profil ou d'appareil lorsque vous cliquez. Le fournisseur reçoit néanmoins votre adresse IP et votre User-Agent, comme avec tout lien externe, et les conversations avec ces assistants sont régies par la politique de confidentialité de chaque fournisseur. L'application elle-même ne transmet aucune donnée utilisateur à un fournisseur d'IA tiers."
   },
   "sync": {
     "online": "En ligne",
@@ -500,7 +502,17 @@
     "memDeckSrOnly": "(s'ouvre dans un nouvel onglet)",
     "gitHub": "GitHub",
     "gitHubSrOnly": "(s'ouvre dans un nouvel onglet)",
-    "madeIn": "Fait avec ❤ à Paris 🇫🇷"
+    "madeIn": "Fait avec ❤ à Paris 🇫🇷",
+    "askAi": {
+      "heading": "Curieux ? Demandez à une IA ce qu'est The Magic Lab —",
+      "groupLabel": "Demander à un assistant IA de présenter The Magic Lab",
+      "opensInNewTab": "(s'ouvre dans un nouvel onglet)",
+      "disclosure": "Ouvre un assistant IA tiers — votre conversation lui est envoyée, pas à nous.",
+      "chatGpt": "ChatGPT",
+      "claude": "Claude",
+      "perplexity": "Perplexity",
+      "prompt": "Je suis magicien et j'évalue des outils pour organiser mon répertoire et ma pratique. The Magic Lab (https://themagiclab.app) est un espace de travail gratuit, open source et hors ligne, dédié aux magiciens : répertoire de tours, journal de pratique, suivi des performances. Merci de consulter https://themagiclab.app/llms-full.txt et de me résumer brièvement ce qu'il propose, à qui il s'adresse, et comment il se situe par rapport à un simple carnet ou à des applications généralistes comme Notion."
+    }
   },
   "auth": {
     "SIGN_IN": "Connexion",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -446,7 +446,9 @@
     "rightsTitle": "Your rights",
     "rightsDesc": "You can export your data at any time from the Settings page. You can delete your account and all associated data. For questions, reach out via the GitHub repository.",
     "analyticsTitle": "Analytics",
-    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services."
+    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services.",
+    "thirdPartyToolsTitle": "Assistenti IA di terze parti",
+    "thirdPartyToolsDesc": "Le pagine marketing includono link opzionali che aprono ChatGPT, Claude o Perplexity in una nuova scheda con una domanda precompilata su The Magic Lab. La domanda è un riassunto generico di marketing — The Magic Lab non aggiunge all'URL alcun dato di account, profilo o dispositivo quando clicchi. Il fornitore riceve comunque il tuo indirizzo IP e User-Agent, come con qualsiasi link esterno, e le conversazioni con questi assistenti sono disciplinate dall'informativa sulla privacy di ciascun fornitore. L'applicazione vera e propria non trasmette dati degli utenti ad alcun fornitore IA di terze parti."
   },
   "sync": {
     "online": "Online",
@@ -500,7 +502,17 @@
     "memDeckSrOnly": "(si apre in una nuova scheda)",
     "gitHub": "GitHub",
     "gitHubSrOnly": "(si apre in una nuova scheda)",
-    "madeIn": "Fatto con ❤ a Parigi 🇫🇷"
+    "madeIn": "Fatto con ❤ a Parigi 🇫🇷",
+    "askAi": {
+      "heading": "Curioso? Chiedi a un'IA cos'è The Magic Lab —",
+      "groupLabel": "Chiedi a un assistente IA cos'è The Magic Lab",
+      "opensInNewTab": "(si apre in una nuova scheda)",
+      "disclosure": "Apre un assistente IA di terze parti — la conversazione va a loro, non a The Magic Lab.",
+      "chatGpt": "ChatGPT",
+      "claude": "Claude",
+      "perplexity": "Perplexity",
+      "prompt": "Sono un mago e sto valutando strumenti per organizzare il mio repertorio e le mie sessioni di pratica. The Magic Lab (https://themagiclab.app) è uno spazio di lavoro gratuito, open source e pensato per funzionare offline, dedicato ai maghi: repertorio di trucchi, registro della pratica, monitoraggio delle esibizioni. Per favore consulta https://themagiclab.app/llms-full.txt e dammi un riassunto conciso di cosa offre, a chi è rivolto e in cosa si differenzia dal prendere appunti su un quaderno o dall'usare app generiche come Notion."
+    }
   },
   "auth": {
     "SIGN_IN": "Accedi",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -446,7 +446,9 @@
     "rightsTitle": "Your rights",
     "rightsDesc": "You can export your data at any time from the Settings page. You can delete your account and all associated data. For questions, reach out via the GitHub repository.",
     "analyticsTitle": "Analytics",
-    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services."
+    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services.",
+    "thirdPartyToolsTitle": "Externe AI-assistenten",
+    "thirdPartyToolsDesc": "De marketingpagina's bevatten optionele links die ChatGPT, Claude of Perplexity in een nieuw tabblad openen met een vooringevulde vraag over The Magic Lab. De vraag is een algemene marketingbeschrijving — The Magic Lab voegt bij het klikken geen account-, profiel- of apparaatgegevens toe aan de URL. De aanbieder ziet desondanks je IP-adres en User-Agent, zoals bij elke externe link, en gesprekken met deze assistenten vallen onder het privacybeleid van de respectieve aanbieder. De applicatie zelf verzendt geen gebruikersgegevens naar externe AI-aanbieders."
   },
   "sync": {
     "online": "Online",
@@ -500,7 +502,17 @@
     "memDeckSrOnly": "(opent in een nieuw tabblad)",
     "gitHub": "GitHub",
     "gitHubSrOnly": "(opent in een nieuw tabblad)",
-    "madeIn": "Gemaakt met ❤ in Parijs 🇫🇷"
+    "madeIn": "Gemaakt met ❤ in Parijs 🇫🇷",
+    "askAi": {
+      "heading": "Nieuwsgierig? Vraag een AI-assistent naar The Magic Lab —",
+      "groupLabel": "Een AI-assistent naar The Magic Lab vragen",
+      "opensInNewTab": "(opent in een nieuw tabblad)",
+      "disclosure": "Opent een externe AI-assistent — je gesprek gaat naar hen, niet naar ons.",
+      "chatGpt": "ChatGPT",
+      "claude": "Claude",
+      "perplexity": "Perplexity",
+      "prompt": "Ik ben goochelaar en zoek tools om mijn repertoire te organiseren en mijn oefenroutine bij te houden. The Magic Lab (https://themagiclab.app) is een gratis, open-source, offline-first werkruimte voor goochelaars: trucrepertoire, oefenlogboek, optredens bijhouden. Lees https://themagiclab.app/llms-full.txt en geef me een beknopt overzicht: wat het biedt, voor wie het bedoeld is en hoe het zich verhoudt tot notities in een notitieboekje of algemene apps zoals Notion."
+    }
   },
   "auth": {
     "SIGN_IN": "Inloggen",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -446,7 +446,9 @@
     "rightsTitle": "Your rights",
     "rightsDesc": "You can export your data at any time from the Settings page. You can delete your account and all associated data. For questions, reach out via the GitHub repository.",
     "analyticsTitle": "Analytics",
-    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services."
+    "analyticsDesc": "We use Vercel Analytics for anonymous page-view tracking and Vercel Speed Insights for performance monitoring. No personal information is shared with these services.",
+    "thirdPartyToolsTitle": "Assistentes de IA externos",
+    "thirdPartyToolsDesc": "As páginas de marketing incluem ligações opcionais que abrem o ChatGPT, o Claude ou o Perplexity num novo separador com uma pergunta predefinida sobre o The Magic Lab. A pergunta é um resumo genérico de marketing — o The Magic Lab não adiciona ao URL quaisquer dados de conta, perfil ou dispositivo quando clicas. O fornecedor recebe igualmente o teu endereço IP e User-Agent, como em qualquer ligação externa, e as conversas com estes assistentes regem-se pela política de privacidade de cada fornecedor. A aplicação propriamente dita não transmite dados de utilizador a qualquer fornecedor de IA externo."
   },
   "sync": {
     "online": "Online",
@@ -500,7 +502,17 @@
     "memDeckSrOnly": "(abre num novo separador)",
     "gitHub": "GitHub",
     "gitHubSrOnly": "(abre num novo separador)",
-    "madeIn": "Feito com ❤ em Paris 🇫🇷"
+    "madeIn": "Feito com ❤ em Paris 🇫🇷",
+    "askAi": {
+      "heading": "Curioso? Pergunta a uma IA sobre The Magic Lab —",
+      "groupLabel": "Perguntar a um assistente de IA sobre The Magic Lab",
+      "opensInNewTab": "(abre num novo separador)",
+      "disclosure": "Abre um assistente de IA externo — a conversa fica com eles, não connosco.",
+      "chatGpt": "ChatGPT",
+      "claude": "Claude",
+      "perplexity": "Perplexity",
+      "prompt": "Sou mágico e estou a avaliar ferramentas para organizar o meu repertório e a minha prática. The Magic Lab (https://themagiclab.app) é um espaço de trabalho gratuito, de código aberto e que funciona offline, pensado para mágicos: repertório de truques, registo de prática e acompanhamento de atuações. Consulta https://themagiclab.app/llms-full.txt e dá-me um resumo conciso do que oferece, a quem se destina e como se compara a tirar apontamentos num caderno ou a usar aplicações generalistas como o Notion."
+    }
   },
   "auth": {
     "SIGN_IN": "Iniciar sessão",

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -2,6 +2,8 @@ import { track } from "@vercel/analytics";
 import type { ItemType } from "@/features/collect/constants";
 import type { Locale } from "@/i18n/config";
 
+export type MarketingAiProviderId = "chatgpt" | "claude" | "perplexity";
+
 /**
  * All tracked event names and their expected properties.
  * Centralised here so every call site is type-checked.
@@ -11,6 +13,7 @@ interface AnalyticsEventMap {
   item_deleted: Record<string, never>;
   item_updated: Record<string, never>;
   locale_changed: { locale: Locale };
+  marketing_ask_ai_clicked: { provider: MarketingAiProviderId };
   push_notifications_disabled: Record<string, never>;
   push_notifications_enabled: Record<string, never>;
   tag_created: Record<string, never>;


### PR DESCRIPTION
## Summary

- Adds `MarketingAskAi` component to the marketing footer: three pill-style links (ChatGPT, Claude, Perplexity) that open pre-filled with a prompt about The Magic Lab
- Visible third-party disclosure text; sr-only `<h2>` for screen-reader navigation; `rel="noopener noreferrer"`, `min-h-11` touch targets, `motion-safe:` transition
- `MarketingAiProviderId` type lives in `analytics.ts` (eliminates the reverse import cycle); `marketing_ask_ai_clicked` event added
- Privacy page gets a new "Third-party AI assistants" section explaining what data leaves the app (none beyond IP/UA); all 7 locales updated
- `docs/product-overview.md` added; `llms.txt` rewritten with richer product summary; `llms-full.txt` now leads with `product-overview.md`

## Test plan

- [ ] `pnpm vitest run src/components/marketing-ask-ai.test.tsx` — 8 tests pass
- [ ] `pnpm vitest run scripts/generate-llms-txt.test.ts` — all tests pass
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm i18n:check` — all 7 locales complete
- [ ] Visually verify footer on `/en`, `/fr`, `/de` — pill links, disclosure, border-top separator
- [ ] Click each pill — opens correct AI assistant in new tab with pre-filled prompt
- [ ] Screen reader: heading "Ask an AI assistant about The Magic Lab" announced; list items each announce "(opens in a new tab)"
- [ ] Privacy page `/en/privacy` — new "Third-party AI assistants" section visible