### PR TITLE
fix: add missing deleted_at partial indexes for tags and trick_tags

### DIFF
--- a/src/db/migrations/0023_tags_deleted_at_partial_indexes.sql
+++ b/src/db/migrations/0023_tags_deleted_at_partial_indexes.sql
@@ -1,0 +1,7 @@
+-- Partial indexes on deleted_at for the cron cleanup job.
+-- Mirrors 0010 / 0011 / 0017 — closes the gap left by 0015 for tags and trick_tags.
+-- These avoid full table scans on cleanupSyncedTables and the NOT EXISTS subqueries
+-- in cleanupUsers (src/app/api/cron/cleanup/route.ts:134, 166).
+
+CREATE INDEX IF NOT EXISTS "idx_tags_deleted_at" ON "tags" ("deleted_at") WHERE "deleted_at" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_trick_tags_deleted_at" ON "trick_tags" ("deleted_at") WHERE "deleted_at" IS NOT NULL;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1777823096312,
       "tag": "0022_revoke_public_function_execute",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1779225760983,
+      "tag": "0023_tags_deleted_at_partial_indexes",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Migration 0015 added `tags` and `trick_tags` tables (Mar 2026) but omitted the `idx_<table>_deleted_at` partial indexes that every other synced soft-delete table has (added in migration 0010 / 0011 / 0017).
- The daily cleanup cron at `src/app/api/cron/cleanup/route.ts` queries `WHERE deleted_at IS NOT NULL` on both tables in two code paths — `cleanupSyncedTables` (full hard-delete sweep) and `cleanupUsers` (NOT EXISTS child-check before hard-deleting a user). Both paths do full table scans today.
- Adds migration 0023 with `IF NOT EXISTS` guards (idempotent, replay-safe). No Drizzle schema changes, no GRANT changes, no PowerSync sync-engine regen required.

## Verification

Verified on dev/julien via EXPLAIN ANALYZE — both cleanup-cron query shapes switch from `Seq Scan` to `Bitmap Index Scan on idx_tags_deleted_at / idx_trick_tags_deleted_at` after the migration is applied.

## Test plan

- [x] `pnpm db:migrate` applied 0023 cleanly on dev/julien
- [x] `pg_indexes` confirms both indexes exist with `WHERE (deleted_at IS NOT NULL)` predicate
- [x] `EXPLAIN ANALYZE` on cleanup-cron query shape shows Bitmap Index Scan for both tables
- [x] `pnpm sync:check` — pass (no schema delta)
- [x] `pnpm sync:check:grants` — pass (no CREATE TABLE / GRANT statements)
- [x] `pnpm typecheck` — pass
- [x] `pnpm test:run` — 131 files / 1909 tests pass

Closes #201