### PR TITLE
test: tighten event_log invariant coverage + decouple pool cleanup

### DIFF
--- a/src/app/api/powersync/batch/route.test.ts
+++ b/src/app/api/powersync/batch/route.test.ts
@@ -36,13 +36,14 @@ beforeEach(() => {
   mockIsUserBanned.mockResolvedValue(false);
 });
 
-afterEach(() => {
+afterEach(async () => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
-  // Reset the module-level pool singleton between tests
+  // Reset the module's pool singleton before clearing the module cache so the
+  // helper operates on the same module copy the test just used.
+  const { __resetPoolForTest } = await import("./route");
+  __resetPoolForTest();
   vi.resetModules();
-  // Coupled to the production pool singleton name — if renamed, this cleanup silently breaks.
-  globalThis.__batchPool = undefined;
 });
 
 function createRequest(body: unknown): NextRequest {
@@ -349,6 +350,12 @@ describe("POST /api/powersync/batch", () => {
       ["payload", { payload: { x: 1 } }],
       ["event_type", { event_type: "trick.created" }],
       ["entity_type", { entity_type: "trick" }],
+      // entity_id is the most direct audit-trail attack — it would silently
+      // rewrite which entity an event references. Pin its rejection.
+      ["entity_id", { entity_id: "different-trick-id" }],
+      ["created_at", { created_at: "1970-01-01T00:00:00.000Z" }],
+      ["user_id", { user_id: "another-user-id" }],
+      ["id", { id: "different-event-id" }],
     ])("rejects PATCH on event_log mutating disallowed column %s", async (_label, opData) => {
       authenticatedSession();
       vi.stubEnv("DATABASE_URL", "postgres://localhost/test");

--- a/src/app/api/powersync/batch/route.ts
+++ b/src/app/api/powersync/batch/route.ts
@@ -197,6 +197,18 @@ function getPool(): Pool {
   return globalThis.__batchPool;
 }
 
+/**
+ * Test-only helper: clear the module's pool singleton. The pool is attached to
+ * `globalThis` to survive HMR in dev (see getPool above), so `vi.resetModules()`
+ * does not clear it — and the MockPool used in tests has no `.end()`, so leaving
+ * a stale reference would TypeError on the next cache-miss path. Decouples tests
+ * from the `__batchPool` variable name.
+ */
+export function __resetPoolForTest(): void {
+  globalThis.__batchPool = undefined;
+  __poolUrl = undefined;
+}
+
 /** Try to rollback a savepoint; return false if the connection itself is broken. */
 async function rollbackSavepoint(
   client: QueryClient,


### PR DESCRIPTION
## Summary

- Extends the PATCH-allowlist `it.each` (4 new cases) to pin rejection of `entity_id`, `created_at`, `user_id`, and `id` — completing coverage of all 8 disallowed `event_log` columns. `entity_id` is the most direct audit-trail attack vector (rewrites which entity an event references).
- Exports `__resetPoolForTest()` from `route.ts`, following the existing `__resetWarnedTypesForTest` convention at `src/features/activity/lib/format-event.ts:191-193`. Replaces the brittle `globalThis.__batchPool = undefined` line in `afterEach` with a rename-safe helper, decoupling tests from the singleton's variable name.

Closes #255

## Why the pool cleanup is load-bearing

`globalThis.__batchPool` survives `vi.resetModules()` by design (the pool is globalThis-attached to outlive HMR). The MockPool used in tests has no `.end()` method, so a stale truthy reference causes a `TypeError` on the next cache-miss path in `getPool()`. The new export centralises the reset logic and prevents silent test-bleed if the variable is renamed.

## Test plan

- [x] `pnpm vitest run src/app/api/powersync/batch/route.test.ts` → 55 tests pass (up from 51 — 4 new parameterised cases)
- [x] `pnpm typecheck` → clean
- [x] `pnpm test:run` → 131 files, 1914 tests pass
- [x] `pnpm sync:check`, `pnpm sync:check:grants`, `pnpm i18n:check` → all green
- [x] Two-dimensional `/review` (testing + security) → no findings