### PR TITLE
docs: document preview sync limitation and add E2E smoke gate

### DIFF
--- a/.claude/rules/sync-engine.md
+++ b/.claude/rules/sync-engine.md
@@ -46,3 +46,13 @@ Deployed via the PowerSync CLI from GitHub Actions.
   - `POWERSYNC_ORG_ID` — only if the PAT spans multiple orgs.
 - **Rollback**: revert the commit and re-run. No native CLI rollback.
 - **Dashboard is view-only** — never edit sync rules there. Changes must flow through PR.
+
+## Preview Deployment Sync Coverage
+
+Vercel preview deployments (`tml-*-jaro-labs.vercel.app` — `e2e.yml` selects them by the `jaro-labs` team slug in the deployment URL) **cannot** validate server-side sync. Preview Vercel environments point `NEON_AUTH_BASE_URL` at a different Neon Auth instance than production; the production PowerSync Cloud instance trusts only production's JWKS + audience, so preview-issued JWTs are rejected at the WebSocket handshake (`PSYNC_S2105`). The sync stream never connects — and because PowerSync only calls `uploadData()` while the sync stream is connected, the upload queue never drains either.
+
+- **Preview E2E (`e2e.yml`) validates**: local-first SQLite reads/writes, offline behavior, auth, and that the PowerSync client boots. (PWA / service-worker specs are localhost-only — `playwright.config.ts` excludes the `pwa` project whenever `BASE_URL` is set.)
+- **It does NOT validate**: server→client sync or the client→server write round-trip — those are verified only against production (`themagiclab.app`).
+- **E2E gate**: use `waitForSyncReady` (WASM/workers up — survives the rejected sync stream). `waitForSynced` (full server sync) hangs on previews; see `e2e/helpers.ts`.
+
+Resolved as a documented limitation in #302 (Option D). Real preview sync coverage — a dedicated preview PowerSync instance — is tracked in #312.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ These complement Biome — they cover what the linter cannot enforce.
 
 Detailed reference material lives in `.claude/rules/` and auto-loads when matching files are read:
 
-- **Sync engine** (`.claude/rules/sync-engine.md`) — generated artifacts, write/read paths, codegen + deployment. Loads on edits to `src/sync/**`, `powersync/**`, `src/db/schema/**`. Or invoke `/sync-engine`.
+- **Sync engine** (`.claude/rules/sync-engine.md`) — generated artifacts, write/read paths, codegen + deployment, preview-deployment sync coverage. Loads on edits to `src/sync/**`, `powersync/**`, `src/db/schema/**`. Or invoke `/sync-engine`.
 - **Migrations** (`.claude/rules/migrations.md`) — single-file + monotonic-timestamp safety rules. Loads on `src/db/schema/**`, `src/db/migrations/**`. Or invoke `/migrations`.
 - **i18n** (`.claude/rules/i18n.md`) — locale list, namespace conventions, completeness check. Loads on `src/i18n/**` and components. Or invoke `/i18n`.
 - **CSP** (`.claude/rules/csp.md`) — builder + test-against-real-build rule. Loads on `src/lib/csp.ts`, `public/sw.js`. Or invoke `/real-build-check`.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { expect, test as setup } from "@playwright/test";
-import { AUTH_STATE_PATH } from "./helpers";
+import { AUTH_STATE_PATH, waitForSyncReady } from "./helpers";
 
 /**
  * Playwright auth setup — creates an authenticated session via Better Auth's
@@ -95,6 +95,15 @@ setup("authenticate", async ({ page }) => {
   // Navigate to the app to ensure cookies are properly set in the browser context
   await page.goto("/dashboard");
   await page.waitForURL("**/dashboard**");
+
+  // Smoke gate: confirm PowerSync's client boots on the authenticated shell
+  // before saving auth state, so a broken PowerSync provider surfaces as one
+  // clear `setup` failure rather than ambiguous failures across the
+  // authenticated suite. WASM/workers only (waitForSyncReady), NOT a full
+  // server sync: preview deployments can't complete a server sync at all —
+  // see `waitForSynced` in helpers.ts and the "Preview Deployment Sync
+  // Coverage" section in .claude/rules/sync-engine.md.
+  await waitForSyncReady(page, 60_000);
 
   // Save the authenticated browser state
   await page.context().storageState({ path: AUTH_STATE_PATH });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -66,6 +66,13 @@ export async function waitForSyncReady(
  * before proceeding — on environments where PowerSync can't reach its sync
  * service, this will hang indefinitely. For most write-path tests, prefer
  * `waitForSyncReady`.
+ *
+ * Vercel preview deployments are currently exactly such an environment:
+ * preview-issued JWTs are rejected by the production PowerSync instance, so
+ * the sync stream never connects. This helper therefore has no caller and is
+ * effectively production-only. See the "Preview Deployment Sync Coverage"
+ * section in `.claude/rules/sync-engine.md` (issue #302); a dedicated preview
+ * PowerSync instance is tracked in #312.
  */
 export async function waitForSynced(
   page: Page,


### PR DESCRIPTION
## Summary

- Documents in `.claude/rules/sync-engine.md` that Vercel preview deployments cannot validate server-side PowerSync sync — preview-issued JWTs are rejected by the production PowerSync instance, so the sync stream never connects and `uploadData()` never drains (resolves #302, Option D)
- Adds a `waitForSyncReady` smoke gate to `auth.setup.ts` so a broken PowerSync provider surfaces as one clear `setup` failure instead of ambiguous failures across all authenticated specs
- Updates `CLAUDE.md` description of the sync-engine rule to mention preview-deployment sync coverage
- Adds a doc comment to `waitForSynced` in `helpers.ts` explaining it has no caller on preview environments (production-only)

## Test plan

- [ ] E2E auth setup passes on localhost with the 60s `waitForSyncReady` gate
- [ ] E2E auth setup passes on Vercel preview (smoke gate survives rejected sync stream — `waitForSyncReady` only requires WASM/workers up, not a connected sync stream)
- [ ] `waitForSynced` remains unused on previews (by design — it would hang)

Closes #302