### PR TITLE
fix(a11y): remove role=status from SyncStatus pill

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -35,7 +35,7 @@ export async function waitForSync(
   timeout = 30_000
 ): Promise<void> {
   await expect(
-    page.locator(`[role="status"][data-sync-state="${expectedState}"]`).first()
+    page.locator(`[data-sync-state="${expectedState}"]`).first()
   ).toBeVisible({ timeout });
 }
 
@@ -53,7 +53,7 @@ export async function waitForSyncReady(
 ): Promise<void> {
   await expect(
     page
-      .locator(`[role="status"]:not([data-sync-state="uninitialized"])`)
+      .locator(`[data-sync-state]:not([data-sync-state="uninitialized"])`)
       .first()
   ).toBeVisible({ timeout });
 }
@@ -78,9 +78,9 @@ export async function waitForSynced(
   page: Page,
   timeout = 30_000
 ): Promise<void> {
-  await expect(
-    page.locator('[role="status"][data-has-synced="true"]').first()
-  ).toBeVisible({ timeout });
+  await expect(page.locator('[data-has-synced="true"]').first()).toBeVisible({
+    timeout,
+  });
 }
 
 /** Check if a real authenticated session exists (written by auth.setup.ts). */

--- a/src/components/sync-status.test.tsx
+++ b/src/components/sync-status.test.tsx
@@ -49,6 +49,20 @@ function resetStatus(): void {
   useStatusShouldThrow = false;
 }
 
+/**
+ * Locate the SyncStatus pill by its `data-sync-state` public-contract
+ * attribute. The pill is intentionally not a live region (no `role="status"`,
+ * see #298), so there is no semantic role to query — `data-sync-state` is the
+ * same handle the E2E helpers select on.
+ */
+function getPill(): HTMLElement {
+  const pill = document.body.querySelector<HTMLElement>("[data-sync-state]");
+  if (!pill) {
+    throw new Error("SyncStatus pill not found");
+  }
+  return pill;
+}
+
 describe("SyncStatus", () => {
   beforeEach(() => {
     resetStatus();
@@ -57,12 +71,9 @@ describe("SyncStatus", () => {
   it("renders offline status when disconnected", () => {
     render(<SyncStatus />);
 
-    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(getPill()).toBeInTheDocument();
     expect(screen.getByText("sync.offline")).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-sync-state",
-      "offline"
-    );
+    expect(getPill()).toHaveAttribute("data-sync-state", "offline");
   });
 
   it("renders online status when connected with no activity", () => {
@@ -70,10 +81,7 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.online")).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-sync-state",
-      "online"
-    );
+    expect(getPill()).toHaveAttribute("data-sync-state", "online");
   });
 
   it("renders syncing status when connected and downloading", () => {
@@ -82,10 +90,7 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.syncing")).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-sync-state",
-      "syncing"
-    );
+    expect(getPill()).toHaveAttribute("data-sync-state", "syncing");
   });
 
   it("renders pendingChanges status when connected and uploading", () => {
@@ -94,10 +99,7 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.pendingChanges")).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-sync-state",
-      "pendingChanges"
-    );
+    expect(getPill()).toHaveAttribute("data-sync-state", "pendingChanges");
   });
 
   it("renders error status when there is a download error", () => {
@@ -106,10 +108,7 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.error")).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-sync-state",
-      "error"
-    );
+    expect(getPill()).toHaveAttribute("data-sync-state", "error");
   });
 
   it("renders error status when there is an upload error", () => {
@@ -117,10 +116,7 @@ describe("SyncStatus", () => {
     render(<SyncStatus />);
 
     expect(screen.getByText("sync.error")).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-sync-state",
-      "error"
-    );
+    expect(getPill()).toHaveAttribute("data-sync-state", "error");
   });
 
   it("prioritizes error over syncing status", () => {
@@ -137,10 +133,7 @@ describe("SyncStatus", () => {
     mockStatus.lastSyncedAt = new Date();
     render(<SyncStatus />);
 
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-has-synced",
-      "true"
-    );
+    expect(getPill()).toHaveAttribute("data-has-synced", "true");
   });
 
   it("emits data-has-synced='false' when lastSyncedAt is undefined", () => {
@@ -148,10 +141,7 @@ describe("SyncStatus", () => {
     mockStatus.lastSyncedAt = undefined;
     render(<SyncStatus />);
 
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-has-synced",
-      "false"
-    );
+    expect(getPill()).toHaveAttribute("data-has-synced", "false");
   });
 
   it("keeps data-has-synced='true' after disconnect (lastSyncedAt sticky)", () => {
@@ -162,14 +152,8 @@ describe("SyncStatus", () => {
     mockStatus.lastSyncedAt = new Date();
     render(<SyncStatus />);
 
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-has-synced",
-      "true"
-    );
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "data-sync-state",
-      "offline"
-    );
+    expect(getPill()).toHaveAttribute("data-has-synced", "true");
+    expect(getPill()).toHaveAttribute("data-sync-state", "offline");
   });
 
   it("renders fallback with uninitialized state when useStatus throws", () => {
@@ -182,17 +166,24 @@ describe("SyncStatus", () => {
 
       render(<SyncStatus />);
 
-      expect(screen.getByRole("status")).toBeInTheDocument();
-      expect(screen.getByRole("status")).toHaveAttribute(
-        "data-sync-state",
-        "uninitialized"
-      );
-      expect(screen.getByRole("status")).toHaveAttribute(
-        "data-has-synced",
-        "false"
-      );
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(getPill()).toBeInTheDocument();
+      expect(getPill()).toHaveAttribute("data-sync-state", "uninitialized");
+      expect(getPill()).toHaveAttribute("data-has-synced", "false");
     } finally {
       errorSpy.mockRestore();
     }
+  });
+
+  it("renders the pill as a presentational badge, not a live region", () => {
+    // PowerSync flaps online/syncing/pendingChanges constantly; a live region
+    // would announce every transition to AT users. Regression guard for #298.
+    mockStatus.connected = true;
+    render(<SyncStatus />);
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    const pill = getPill();
+    expect(pill).not.toHaveAttribute("role");
+    expect(pill).not.toHaveAttribute("aria-live");
   });
 });

--- a/src/components/sync-status.tsx
+++ b/src/components/sync-status.tsx
@@ -61,7 +61,6 @@ function SyncStatusFallback(): ReactElement {
       className="flex items-center gap-1.5"
       data-has-synced="false"
       data-sync-state={FALLBACK_SYNC_STATE}
-      role="status"
     />
   );
 }
@@ -100,12 +99,16 @@ function SyncStatusInner(): ReactElement {
 
   // `lastSyncedAt` (sticky), not `hasSynced` (cleared on every disconnect by
   // @powersync/common's `updateSyncStatus` merge — see issue #297).
+  //
+  // Intentionally no `role="status"`: PowerSync flaps online/syncing/
+  // pendingChanges on every round trip and local write, so a live region
+  // would announce each transition to AT users. The pill is an ambient
+  // indicator, read on demand like a sighted user glancing at it (#298).
   return (
     <span
       className="flex items-center gap-1.5"
       data-has-synced={status.lastSyncedAt === undefined ? "false" : "true"}
       data-sync-state={key}
-      role="status"
     >
       <span className={cn("inline-flex size-2 rounded-full", color)} />
       <span className="text-muted-foreground text-xs">{t(key)}</span>


### PR DESCRIPTION
## Summary

- Removes \`role=\"status\"\` from the \`SyncStatus\` pill (\`SyncStatusInner\` + \`SyncStatusFallback\`) so the pill becomes a presentational badge instead of a polite live region
- PowerSync flips online/syncing/pendingChanges on every network round-trip and local write; the previous \`role=\"status\"\` (implicit \`aria-live=\"polite\"\`) announced each transition to screen readers — continuous interruptions during routine use
- Visible text stays in the accessible tree and readable on navigation, giving screen-reader users the same ambient-glance experience as sighted users

## Test plan

- \`pnpm test:run src/components/sync-status.test.tsx\` — 12/12 pass (14 locators migrated from \`getByRole(\"status\")\` to \`getPill()\` via \`data-sync-state\`; regression test added pinning no \`role\` or \`aria-live\` on the pill)
- \`pnpm typecheck\` — clean
- \`pnpm exec ultracite check\` (3 changed files) — clean
- E2E \`activity.spec.ts\`: auth setup gate (\`waitForSyncReady\`) passed; \`waitForSync(page, \"offline\")\` confirmed working in the offline test; 2 unrelated dev-mode flakes (cold-compile nav timeout + form-submit) did not involve the changed helpers

Closes #298