### PR TITLE
feat: responsive two-column dashboard layout

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -51,9 +51,13 @@ export default async function DashboardPage(): Promise<ReactElement> {
             : t("welcome")}
         </p>
       </div>
-      <RepertoireCard trickCount={trickCount} />
-      <CollectionCard itemCount={itemCount} />
-      <RecentActivityCard />
+      <div className="grid items-start gap-4 sm:grid-cols-2">
+        <div className="flex flex-col gap-4">
+          <RepertoireCard trickCount={trickCount} />
+          <CollectionCard itemCount={itemCount} />
+        </div>
+        <RecentActivityCard />
+      </div>
       <DashboardGrid />
     </div>
   );


### PR DESCRIPTION
## Summary

- On screens ≥ 640 px, the **My Repertoire** and **My Collection** teaser cards now stack in a left column beside the **Recent activity** feed in a right column
- On phones (< 640 px) everything stays full-width and stacked — identical to before
- Uses `grid items-start gap-4 sm:grid-cols-2` (matches the `DashboardGrid` sibling card grid) with an inner `flex flex-col gap-4` to group the two teaser cards as one column
- `items-start` keeps each column at its natural height — the left column ends after **My Collection** rather than stretching to match the taller activity feed

## Test plan

- [ ] `pnpm typecheck` — passes (no type changes)
- [ ] `pnpm test:run src/app/(app)/dashboard/page.test.tsx` — 10/10 green (wrapper divs are DOM-depth-transparent)
- [ ] `ultracite check src/app/(app)/dashboard/page.tsx` — clean (no fixes applied)
- [ ] Manual: `/dashboard` at ~375 px (stacked), ~700 px (2-col, no sidebar), ~900 px (2-col + sidebar), ~1440 px (desktop)
- [ ] Accessibility: DOM reading order and keyboard tab order unchanged (Repertoire → Collection → Recent activity)