### PR TITLE
docs: fix stale documentation across README, CLAUDE.md, and docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Full script list: `pnpm run`. Project-specific gotchas:
 pnpm sync:generate    # REQUIRED after any src/db/schema/** change — regenerates PowerSync artifacts
 pnpm sync:check       # Fail if sync artifacts drift (pre-commit + CI gate)
 pnpm i18n:check       # Validate all 7 locales share the same keys
-pnpm docs:generate    # Regenerate public/llms{,-full}.txt + docs/diagrams/
+pnpm docs:generate    # Regenerate public/llms{,-full}.txt + docs/diagrams/route-map.md
 ```
 
 Requires Node 24.x and pnpm ≥ 10.
@@ -121,7 +121,7 @@ Client mutations always wrap the event-log write in `safeLogEvent()` (`src/lib/e
 
 ### DB grants & roles
 
-Two Postgres roles exist on Neon. Today, **all server-side code paths use `neondb_owner`** — Drizzle (`src/db/index.ts`), server actions, route handlers including the PowerSync upload route (`Pool({ databaseUrl })` at `src/app/api/powersync/batch/route.ts:180`), `logEventServer()`, and `auth/ensure-user.ts`. `neondb_owner` has full DB access and bypasses RLS, so **anything sensitive must be guarded at the application layer**.
+Two Postgres roles exist on Neon. Today, **all server-side code paths use `neondb_owner`** — Drizzle (`src/db/index.ts`), server actions, route handlers including the PowerSync upload route (`Pool({ databaseUrl })` at `src/app/api/powersync/batch/route.ts:190`), `logEventServer()`, and `auth/ensure-user.ts`. `neondb_owner` has full DB access and bypasses RLS, so **anything sensitive must be guarded at the application layer**.
 
 The `authenticated` role is currently exercised only by the JWT-aware client paths the codebase does not yet use directly (Neon Data API, JWT-forwarded PowerSync sync — both anticipated, not active). Migration `0020_lockdown_authenticated_grants.sql` (issue #245) hardens what `authenticated` CAN see/do **before** any code path actually authenticates as that role:
 
@@ -273,7 +273,7 @@ Detailed reference material lives in `.claude/rules/` and auto-loads when matchi
 - **Empty states**: Icon + title + description + primary CTA. Use `ModuleComingSoon` pattern.
 - **Loading states**: skeleton for cold start only — offline-first means data is usually instant.
 - **Error states**: Error boundary with retry.
-- **Mobile nav**: bottom tab bar (<768px) — Dashboard, Repertoire, Plan, Perform, More.
+- **Mobile nav**: the shadcn `Sidebar` (`app-sidebar.tsx`) renders as an off-canvas `Sheet` drawer below the `md` breakpoint, opened via `SidebarTrigger` in the header.
 - **Desktop nav**: sidebar.
 - **Accent color**: Violet (oklch hue 280). **Always use theme tokens** from `globals.css`, never arbitrary colors.
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,21 @@
 
 ## Features
 
+### Available today
+
+- **Repertoire** -- Catalog your tricks with categories, effect types, difficulty, status, props, and tags — your whole library in one searchable place.
+- **Collection** -- Register and organize your props, books, gimmicks, and other items, and link them to the tricks that use them.
+- **Activity** -- Browse a timeline of every change you've made (offline-friendly).
+
+### In development
+
+Visible in the app as "coming soon" — these modules activate as they ship:
+
 - **Improve** -- Log practice sessions and track your progress on individual sleights, moves, and techniques.
 - **Train** -- Set goals, build drills, and stay consistent with structured practice.
 - **Plan** -- Assemble and fine-tune your setlists, from a quick close-up set to a full stage show.
 - **Perform** -- Keep notes on your performances, track audience reactions, and learn from every show.
 - **Enhance** -- Discover insights, revisit what works, and continuously raise the bar.
-- **Collect** -- Register and organize your props, books, gimmicks, and other items.
-- **Activity** -- Browse a timeline of every change you've made (offline-friendly).
 
 ## Tech Stack
 
@@ -103,7 +111,7 @@ pnpm sync:deploy      # Deploy sync-config.yaml to PowerSync Cloud (requires POW
 
 # i18n & docs
 pnpm i18n:check       # Validate all locales have matching keys
-pnpm docs:generate    # Regenerate llms.txt files from docs/
+pnpm docs:generate    # Regenerate llms.txt files and the route-map diagram
 
 # Other
 pnpm email:dev        # Start email template dev server

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -80,8 +80,8 @@ Join table linking tags to tricks (many-to-many).
 |---|---|---|
 | id | UUID (PK) | |
 | user_id | UUID (FK -> users) | NOT NULL, cascade delete |
-| trick_id | UUID (FK -> tricks) | NOT NULL, cascade delete |
-| tag_id | UUID (FK -> tags) | NOT NULL, cascade delete |
+| trick_id | UUID (FK -> tricks) | NOT NULL, no action |
+| tag_id | UUID (FK -> tags) | NOT NULL, no action |
 | created_at | timestamptz | NOT NULL, default now() |
 | updated_at | timestamptz | NOT NULL, default now() |
 | deleted_at | timestamptz | Soft-delete |
@@ -130,8 +130,9 @@ Join table linking tricks to setlists with ordering.
 | Column | Type | Notes |
 |---|---|---|
 | id | UUID (PK) | |
-| setlist_id | UUID (FK -> setlists) | NOT NULL, cascade delete |
-| trick_id | UUID (FK -> tricks) | NOT NULL, cascade delete |
+| user_id | UUID (FK -> users) | NOT NULL, cascade delete |
+| setlist_id | UUID (FK -> setlists) | NOT NULL, no action |
+| trick_id | UUID (FK -> tricks) | NOT NULL, no action |
 | position | integer | NOT NULL, display order (unique per setlist) |
 | transition_notes | text | Notes on transitioning into this trick |
 | created_at | timestamptz | NOT NULL, default now() |
@@ -161,8 +162,9 @@ Tricks practiced within a session, with per-trick feedback.
 | Column | Type | Notes |
 |---|---|---|
 | id | UUID (PK) | |
-| practice_session_id | UUID (FK -> practice_sessions) | NOT NULL, cascade delete |
-| trick_id | UUID (FK -> tricks) | NOT NULL, cascade delete |
+| user_id | UUID (FK -> users) | NOT NULL, cascade delete |
+| practice_session_id | UUID (FK -> practice_sessions) | NOT NULL, no action |
+| trick_id | UUID (FK -> tricks) | NOT NULL, no action |
 | repetitions | integer | Number of reps |
 | rating | integer | 1-5 self-assessment |
 | notes | text | |
@@ -238,13 +240,14 @@ Join table linking items (props) to tricks that use them.
 | Column | Type | Notes |
 |---|---|---|
 | id | UUID (PK) | |
-| item_id | UUID (FK -> items) | NOT NULL, cascade delete |
-| trick_id | UUID (FK -> tricks) | NOT NULL, cascade delete |
+| user_id | UUID (FK -> users) | NOT NULL, cascade delete |
+| item_id | UUID (FK -> items) | NOT NULL, no action |
+| trick_id | UUID (FK -> tricks) | NOT NULL, no action |
 | created_at | timestamptz | NOT NULL, default now() |
 | updated_at | timestamptz | NOT NULL, default now() |
 | deleted_at | timestamptz | Soft-delete |
 
-Unique constraint on `(item_id, trick_id)`.
+Unique constraint on `(item_id, trick_id)` where `deleted_at IS NULL`.
 
 ### goals
 
@@ -265,6 +268,25 @@ Practice goals and training objectives.
 | created_at | timestamptz | NOT NULL, default now() |
 | updated_at | timestamptz | NOT NULL, default now() |
 | deleted_at | timestamptz | Soft-delete |
+
+### event_log
+
+Append-only activity history — the canonical per-user record powering the Activity timeline (`/activity`) and the dashboard recent-activity card. One row per domain mutation.
+
+| Column | Type | Notes |
+|---|---|---|
+| id | UUID (PK) | |
+| user_id | UUID (FK -> users) | NOT NULL, cascade delete |
+| event_type | text | NOT NULL, dotted event identifier (e.g. `notifications.subscribed`); taxonomy in `src/lib/events/types.ts` |
+| entity_type | text | Entity kind the event refers to — nullable (see paired-NULL check below) |
+| entity_id | UUID | Referenced entity — nullable (see paired-NULL check below) |
+| payload | jsonb | NOT NULL, default `{}` |
+| source | text | `"client"` or `"server"`, NOT NULL, default `"client"` |
+| created_at | timestamptz | NOT NULL, default now() |
+| updated_at | timestamptz | NOT NULL, default now() |
+| deleted_at | timestamptz | Soft-delete |
+
+CHECK constraints: `event_log_source_check` (`source` must be `'client'` or `'server'`) and `event_log_entity_pair_check` (`entity_type` and `entity_id` must both be NULL or both NOT NULL). See [features/activity.md](./features/activity.md) for the full event-log reference.
 
 ### push_subscriptions
 
@@ -306,13 +328,15 @@ Not all tables are synced to the client via PowerSync:
 | tags | Yes | Filtered by `user_id` |
 | trick_tags | Yes | Filtered by `user_id` |
 | setlists | Yes | Filtered by `user_id` |
-| setlist_tricks | Yes | Global bucket (no `user_id`) |
+| setlist_tricks | Yes | Filtered by `user_id` |
 | practice_sessions | Yes | Filtered by `user_id` |
-| practice_session_tricks | Yes | Global bucket (no `user_id`) |
+| practice_session_tricks | Yes | Filtered by `user_id` |
 | performances | Yes | Filtered by `user_id` |
 | items | Yes | Filtered by `user_id` |
-| item_tricks | Yes | Global bucket (no `user_id`) |
+| item_tags | Yes | Filtered by `user_id` |
+| item_tricks | Yes | Filtered by `user_id` |
 | goals | Yes | Filtered by `user_id` |
+| event_log | Yes | Filtered by `user_id` |
 | users | No | Server-only, managed by Neon Auth |
 | user_preferences | No | Server-only |
 | push_subscriptions | No | Server-only |

--- a/docs/diagrams/notification-flow.md
+++ b/docs/diagrams/notification-flow.md
@@ -10,7 +10,7 @@ sequenceDiagram
     participant App as React App
     participant SW as Service Worker
     participant Action as Server Action
-    participant Memory as In-Memory Store
+    participant DB as Neon Postgres<br/>(push_subscriptions)
     participant WebPush as web-push lib
     participant PushSvc as Push Service<br/>(FCM/APNs/Mozilla)
 
@@ -19,14 +19,13 @@ sequenceDiagram
     User->>App: Grant notification permission
     App->>SW: pushManager.subscribe()
     SW-->>App: PushSubscription
-    App->>Action: subscribeToPush()
-    Action->>Memory: Store subscription (per-user map)
-    Note over Memory: WARNING: In-memory only,<br/>lost on cold start.<br/>TODO: migrate to push_subscriptions table
+    App->>Action: subscribeUser()
+    Action->>DB: Upsert subscription (keyed on endpoint)
 
     Note over Action,PushSvc: Sending
 
-    Action->>Memory: Fetch user subscription
-    Memory-->>Action: Subscription data
+    Action->>DB: Fetch user subscriptions
+    DB-->>Action: Subscription rows
     Action->>WebPush: sendNotification()
     WebPush->>PushSvc: Encrypted push message
     PushSvc->>SW: push event

--- a/docs/diagrams/schema-er.md
+++ b/docs/diagrams/schema-er.md
@@ -78,6 +78,7 @@ erDiagram
 
     setlist_tricks {
         uuid id PK "default random"
+        uuid user_id FK
         uuid setlist_id FK
         uuid trick_id FK
         integer position
@@ -101,6 +102,7 @@ erDiagram
 
     practice_session_tricks {
         uuid id PK "default random"
+        uuid user_id FK
         uuid practice_session_id FK
         uuid trick_id FK
         integer repetitions
@@ -184,6 +186,19 @@ erDiagram
         timestamptz deleted_at
     }
 
+    event_log {
+        uuid id PK "default random"
+        uuid user_id FK
+        text event_type
+        text entity_type "nullable"
+        uuid entity_id "nullable"
+        jsonb payload
+        text source "client, server"
+        timestamptz created_at
+        timestamptz updated_at
+        timestamptz deleted_at
+    }
+
     push_subscriptions {
         uuid id PK "default random"
         uuid user_id FK
@@ -213,6 +228,7 @@ erDiagram
     users ||--o{ performances : "owns"
     users ||--o{ items : "owns"
     users ||--o{ goals : "owns"
+    users ||--o{ event_log : "owns"
     users ||--o{ push_subscriptions : "has"
     users ||--o| user_preferences : "has"
 

--- a/docs/pwa-notifications.md
+++ b/docs/pwa-notifications.md
@@ -64,7 +64,7 @@ Push notifications use VAPID (Voluntary Application Server Identification):
 1. User grants notification permission (browser prompt)
 2. Client calls `pushManager.subscribe()` with the VAPID public key
 3. Subscription data (endpoint, p256dh, auth) sent to the server via a server action
-4. Server currently stores subscriptions in an **in-memory map** (per-instance, lost on cold start). A persistent storage migration to the `push_subscriptions` table is planned for production use.
+4. Server persists the subscription to the `push_subscriptions` table — an upsert keyed on the `endpoint` URL (`subscribeUser` in `src/app/actions.ts`). Subscriptions the push service later reports as gone (HTTP 410) are pruned automatically on the next send.
 
 ### push_subscriptions Table
 

--- a/docs/route-structure.md
+++ b/docs/route-structure.md
@@ -41,10 +41,13 @@ Marketing pages use URL-based locale routing for SEO. Each page is statically ge
 | `/train` | Train | Train (Lab) | Goal setting, drills, streaks |
 | `/plan` | Plan | Plan (Lab) | Setlist builder |
 | `/perform` | Perform | Perform (Lab) | Performance logging and review |
+| `/activity` | Activity | Activity (Insights) | Timeline of every change you've made |
 | `/enhance` | Enhance | Enhance (Insights) | Insights, suggestions, analytics |
 | `/settings` | Settings | -- | User preferences, account |
 | `/admin` | Admin | Admin (Admin) | Application administration |
 | `/account/[path]` | Account | -- | Neon Auth account management (sign-in, sign-up, etc.) |
+
+> **Module gating:** `/repertoire`, `/collect`, and `/activity` are live. The Lab routes (`/improve`, `/train`, `/plan`, `/perform`), `/enhance`, and `/admin` exist as route directories but their modules are `enabled: false` in `src/lib/modules.ts` — they render a "coming soon" placeholder until launch.
 
 ### Auth Routes
 
@@ -57,7 +60,9 @@ Marketing pages use URL-based locale routing for SEO. Each page is statically ge
 | Path | Method | Description |
 |---|---|---|
 | `/api/auth/[...path]` | Various | Neon Auth (Better Auth) endpoints |
-| `/api/email/unsubscribe` | GET | Email unsubscribe handler |
+| `/api/powersync/batch` | POST | PowerSync upload — applies the client write queue to Neon |
+| `/api/email/unsubscribe` | GET, POST | Email unsubscribe handler |
+| `/api/cron/cleanup` | GET | Scheduled cleanup — hard-deletes soft-deleted rows past retention |
 
 ## Proxy Behavior
 

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -35,10 +35,10 @@ Design principles and component conventions for The Magic Lab.
 
 ### Mobile Navigation
 
-- **Bottom tab bar** for primary module navigation (Dashboard, Repertoire, Plan, Perform, More)
-- Fixed to bottom of viewport
-- 44px minimum touch targets
-- Active state indicated by violet accent
+- The shadcn `Sidebar` (`app-sidebar.tsx`) renders as an **off-canvas `Sheet` drawer** below the `md` breakpoint
+- Opened via the `SidebarTrigger` button in the header
+- Same navigation content as desktop — Dashboard, the module groups, and Settings
+- 44px minimum touch targets; active state indicated by violet accent
 
 ### Desktop Navigation
 
@@ -57,8 +57,6 @@ Design principles and component conventions for The Magic Lab.
 |          Page Content                    |  <- Scrollable content area
 |          (p-4)                           |
 |                                          |
-+------------------------------------------+
-| [Dashboard] [Repertoire] [Plan] [Perform] [More] |  <- Bottom tabs (mobile only)
 +------------------------------------------+
 ```
 


### PR DESCRIPTION
## Summary

Documentation accuracy pass: audited README.md, CLAUDE.md, and all 21 docs/ files against the live schema, route handlers, module registry, and generator scripts.

Three changes shipped without doc updates caused the drift:
- Junction-table `user_id` backfill (migration `0019_backfill_user_id_junctions.sql`)
- The Activity/`event_log` feature reaching production
- Push-subscription persistence migrated from in-memory to the `push_subscriptions` table

**Changes by file:**

| File | What changed |
|---|---|
| `README.md` | Added missing Repertoire to Features; split into "Available today" / "In development" |
| `CLAUDE.md` | `route.ts:180`→`:190`; `docs:generate` scope; mobile-nav (Sheet drawer, not tab bar) |
| `docs/data-model.md` | Added `event_log` table; `user_id` on 3 junctions; FK cascade→no action; Sync Scope fixed |
| `docs/diagrams/schema-er.md` | Added `event_log` entity + edge; `user_id` on 2 junction blocks |
| `docs/pwa-notifications.md` | In-memory storage claim → DB persistence |
| `docs/diagrams/notification-flow.md` | `Memory` participant → `DB (push_subscriptions)` |
| `docs/ui-conventions.md` | Bottom tab bar → sidebar/Sheet drawer pattern |
| `docs/route-structure.md` | Added `/activity`, `/api/powersync/batch`, `/api/cron/cleanup`; module-gating note |

**Verified accurate (no change):** all version pins, scripts, 13-synced-tables / 7-locales / 21-pages counts, module enable/disable states, migrations 0020-0022, the 422-gate range, skills/commands/rules lists; and `sync-engine.md`, `architecture.md`, `migrations.md`, `product-overview.md`, `features/activity.md` (spot-checked directly against the schema drift).

## Test plan

- [ ] Review each changed file against the cited source (schema files, route handlers, module registry)
- [ ] `pnpm docs:generate` regenerates cleanly (route-map unchanged, llms files gitignored)
- [ ] No code, schema, or i18n changes — CI validation gates are not triggered