### PR TITLE
test: stabilize next-intl mock t ref and tighten idempotency assertions

### DIFF
--- a/src/features/collect/components/collect-view.test.tsx
+++ b/src/features/collect/components/collect-view.test.tsx
@@ -1777,19 +1777,19 @@ describe("CollectView", () => {
       }).length;
     }
 
-    // Capture the call count after the initial render settles, then assert
-    // bounded additive growth per rerender — each rerender may invoke the
-    // effect at most once more (next-intl's `t` is not referentially stable
-    // across renders, so deps change). Tighter than the prior bare `<= 4`:
-    // growth is bounded relative to the baseline, so a regression that fires
-    // multiple toasts per rerender fails here even though sonner dedups by id.
+    // The relations-error effect's deps are the stable query-error refs plus
+    // `t`. `t` is memoized per namespace in the next-intl test mock (issue
+    // #290), so it is referentially stable across rerenders — every effect dep
+    // is stable, the effect fires exactly once (on mount), and the toast count
+    // must not grow on a no-op rerender. A per-rerender effect refire — or a
+    // revert of the mock memoization — breaks this strict-equality assertion.
     const initialCount = countRelationsCalls();
 
     rerender(<CollectView />);
-    expect(countRelationsCalls()).toBeLessThanOrEqual(initialCount + 1);
+    expect(countRelationsCalls()).toBe(initialCount);
 
     rerender(<CollectView />);
-    expect(countRelationsCalls()).toBeLessThanOrEqual(initialCount + 2);
+    expect(countRelationsCalls()).toBe(initialCount);
 
     // Every relations toast call must carry the stable id and message.
     const allRelationsCalls = vi

--- a/src/features/repertoire/components/repertoire-view.test.tsx
+++ b/src/features/repertoire/components/repertoire-view.test.tsx
@@ -1900,14 +1900,12 @@ describe("RepertoireView", () => {
       );
     });
 
-    // Capture the call count after the initial effect has settled, then
-    // assert linear-bounded growth across rerenders. Each rerender refires
-    // the effect once (the `t` translator identity changes per render in
-    // the next-intl test mock, which is on the effect's dep list), so the
-    // count must grow by at most 1 per rerender — never more. A regression
-    // that, say, drops the stable error reference inside the effect would
-    // compound (every state-change triggers another render which fires the
-    // effect again, which sets a fresh ref…), breaching this bound.
+    // The relations-error effect's deps are the stable query-error refs plus
+    // `t`. `t` is memoized per namespace in the next-intl test mock (issue
+    // #290), so it is referentially stable across rerenders — every effect dep
+    // is stable, the effect fires exactly once (on mount), and the toast count
+    // must not grow on a no-op rerender. A per-rerender effect refire — or a
+    // revert of the mock memoization — breaks this strict-equality assertion.
     const relationsErrorCount = () =>
       vi.mocked(toast.error).mock.calls.filter(([, opts]) => {
         if (!opts || typeof opts !== "object") {
@@ -1921,10 +1919,10 @@ describe("RepertoireView", () => {
     const initialCount = relationsErrorCount();
 
     rerender(<RepertoireView />);
-    expect(relationsErrorCount()).toBeLessThanOrEqual(initialCount + 1);
+    expect(relationsErrorCount()).toBe(initialCount);
 
     rerender(<RepertoireView />);
-    expect(relationsErrorCount()).toBeLessThanOrEqual(initialCount + 2);
+    expect(relationsErrorCount()).toBe(initialCount);
 
     // Every relations-toast call must carry the stable message + id.
     const relationsCalls = vi

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,25 +2,68 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
 
+// next-intl test mock — `t` returns "namespace.key" so tests catch
+// wrong-namespace usage; interpolated values are appended in parentheses.
+//
+// The per-namespace `t` is MEMOIZED (issue #290) so useTranslations("collect")
+// returns a referentially-stable `t` across rerenders. Effects that depend on
+// `t` (the relations-error toast in collect-view / repertoire-view) must not
+// refire on a no-op rerender — the idempotency tests assert that with strict
+// equality, and a fresh-`t`-per-call mock silently breaks them. The caches are
+// cleared after every test (below) to avoid cross-test reference bleed.
+const { tClientCache, tServerCache, getClientT, getServerT } = vi.hoisted(
+  () => {
+    const makeT = (namespace?: string) => {
+      const t = (key: string, values?: Record<string, string | number>) => {
+        const fullKey = namespace ? `${namespace}.${key}` : key;
+        if (values) {
+          const parts = Object.entries(values).map(
+            ([k, v]) => `${k}: ${String(v)}`
+          );
+          return `${fullKey} (${parts.join(", ")})`;
+        }
+        return fullKey;
+      };
+      return Object.assign(t, { rich: t, raw: t, markup: t });
+    };
+
+    type CachedTranslator = ReturnType<typeof makeT>;
+    const tClientCache = new Map<string, CachedTranslator>();
+    const tServerCache = new Map<string, CachedTranslator>();
+
+    const cached = (
+      cache: Map<string, CachedTranslator>,
+      namespace?: string
+    ): CachedTranslator => {
+      const key = namespace ?? "";
+      const existing = cache.get(key);
+      if (existing) {
+        return existing;
+      }
+      const created = makeT(namespace);
+      cache.set(key, created);
+      return created;
+    };
+
+    return {
+      tClientCache,
+      tServerCache,
+      getClientT: (namespace?: string) => cached(tClientCache, namespace),
+      getServerT: (namespace?: string) => cached(tServerCache, namespace),
+    };
+  }
+);
+
 afterEach(cleanup);
 
-// Global mock for next-intl — returns "namespace.key" so tests catch
-// wrong-namespace usage (e.g. getTranslations("settings") vs "dashboard").
-// Interpolated values are appended in parentheses.
+// Drop memoized translators so each test starts with fresh `t` references.
+afterEach(() => {
+  tClientCache.clear();
+  tServerCache.clear();
+});
+
 vi.mock("next-intl", () => ({
-  useTranslations: (namespace?: string) => {
-    const t = (key: string, values?: Record<string, string | number>) => {
-      const fullKey = namespace ? `${namespace}.${key}` : key;
-      if (values) {
-        const parts = Object.entries(values).map(
-          ([k, v]) => `${k}: ${String(v)}`
-        );
-        return `${fullKey} (${parts.join(", ")})`;
-      }
-      return fullKey;
-    };
-    return Object.assign(t, { rich: t, raw: t, markup: t });
-  },
+  useTranslations: (namespace?: string) => getClientT(namespace),
   useLocale: () => "en",
   useMessages: () => ({}),
   NextIntlClientProvider: ({ children }: { children: unknown }) => children,
@@ -35,17 +78,7 @@ vi.mock("next-intl/server", () => ({
       typeof namespaceOrOpts === "string"
         ? namespaceOrOpts
         : namespaceOrOpts?.namespace;
-    const t = (key: string, values?: Record<string, string | number>) => {
-      const fullKey = namespace ? `${namespace}.${key}` : key;
-      if (values) {
-        const parts = Object.entries(values).map(
-          ([k, v]) => `${k}: ${String(v)}`
-        );
-        return `${fullKey} (${parts.join(", ")})`;
-      }
-      return fullKey;
-    };
-    return Promise.resolve(Object.assign(t, { rich: t, raw: t, markup: t }));
+    return Promise.resolve(getServerT(namespace));
   },
   getLocale: () => Promise.resolve("en"),
   getMessages: () => Promise.resolve({}),


### PR DESCRIPTION
## Summary

- Memoizes the \`next-intl\` test mock's per-namespace \`t\` function via \`vi.hoisted\` so \`useTranslations("collect")\` returns the **same \`t\` reference** across rerenders. Applied to both the client mock (\`useTranslations\`) and server mock (\`getTranslations\`) for consistency.
- Adds \`afterEach(() => { tClientCache.clear(); tServerCache.clear(); })\` to prevent cross-test reference bleed.
- Tightens two "relations-query idempotency" tests from loose \`toBeLessThanOrEqual(initialCount + N)\` bounds to strict \`toBe(initialCount)\`.

**Root cause:** The relations-error toast effect in \`collect-view\` / \`repertoire-view\` lists \`t\` in its dependency array (\`[...errors, t]\`). With an unstable \`t\`, the effect refired once per rerender even when no error state changed — so the tests couldn't use strict equality.

**With the fix:** All five effect deps (four error refs + \`t\`) are referentially stable across no-op rerenders → the effect fires exactly once (on mount) → \`toBe(initialCount)\` holds.

**Load-bearing check:** Reverting the memoization produces \`expected 2 to be 1\` in both idempotency tests (verified during implementation), confirming the strict assertion catches per-rerender refires.

## Test plan

- [x] Full suite: 1929/1929 pass (`pnpm test:run`)
- [x] Load-bearing: reverted mock breaks both idempotency tests (`expected 2 to be 1`)
- [x] Lint (scoped to 3 changed files): clean
- [x] Typecheck: `tsc -b` clean

Closes #290