### PR TITLE
feat(collect): per-card relation-error indicators

### DIFF
--- a/src/features/collect/components/collect-view.test.tsx
+++ b/src/features/collect/components/collect-view.test.tsx
@@ -155,12 +155,20 @@ vi.mock("./item-list", () => ({
     items,
     onEdit,
     onDelete,
+    tagsError,
+    tricksError,
   }: {
     items: { id: ItemId; name: string }[];
     onEdit: (id: ItemId) => void;
     onDelete: (id: ItemId) => void;
+    tagsError?: boolean;
+    tricksError?: boolean;
   }) => (
-    <div data-testid="item-list">
+    <div
+      data-tags-error={String(Boolean(tagsError))}
+      data-testid="item-list"
+      data-tricks-error={String(Boolean(tricksError))}
+    >
       {items.map((item) => (
         <div key={item.id}>
           <span>{item.name}</span>
@@ -1400,6 +1408,98 @@ describe("CollectView", () => {
     expect(capturedFormSheetProps.open).toBe(true);
     expect(capturedFormSheetProps.selectedTagIds).toEqual([]);
     expect(capturedFormSheetProps.selectedTrickIds).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #267 — per-card relation-error indicator wiring. collect-view must
+  // forward each join query's error state to ItemList as a boolean so every
+  // card can swap the affected relation for a muted indicator.
+  // ---------------------------------------------------------------------------
+
+  it("passes tagsError to ItemList when the item_tags query has errored (issue #267)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useQuery } = await import("@powersync/react");
+    const item = makeItem("00000000-0000-4000-8000-0000000267a0", "Card Force");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === ITEM_TAGS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: new Error("item_tags schema drift"),
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    const list = screen.getByTestId("item-list");
+    expect(list).toHaveAttribute("data-tags-error", "true");
+    expect(list).toHaveAttribute("data-tricks-error", "false");
+  });
+
+  it("passes tricksError to ItemList when the item_tricks query has errored (issue #267)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const { useQuery } = await import("@powersync/react");
+    const item = makeItem(
+      "00000000-0000-4000-8000-0000000267b0",
+      "Coin Vanish"
+    );
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    vi.mocked(useQuery).mockImplementation((sql) => {
+      if (sql === ITEM_TRICKS_QUERY) {
+        return {
+          data: [],
+          isLoading: false,
+          isFetching: false,
+          error: new Error("item_tricks parse error"),
+        };
+      }
+      return {
+        data: [],
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      };
+    });
+
+    render(<CollectView />);
+
+    const list = screen.getByTestId("item-list");
+    expect(list).toHaveAttribute("data-tricks-error", "true");
+    expect(list).toHaveAttribute("data-tags-error", "false");
+  });
+
+  it("passes neither error flag to ItemList when relation queries are healthy (issue #267)", async () => {
+    const { useItems } = await import("../hooks/use-items");
+    const item = makeItem("00000000-0000-4000-8000-0000000267c0", "Svengali");
+    vi.mocked(useItems).mockReturnValue({
+      items: [item],
+      error: null,
+      isLoading: false,
+    });
+    // useQuery keeps the afterEach default — empty data, no error.
+
+    render(<CollectView />);
+
+    const list = screen.getByTestId("item-list");
+    expect(list).toHaveAttribute("data-tags-error", "false");
+    expect(list).toHaveAttribute("data-tricks-error", "false");
   });
 
   it("does NOT toast for brandsError (supplementary autocomplete)", async () => {

--- a/src/features/collect/components/collect-view.tsx
+++ b/src/features/collect/components/collect-view.tsx
@@ -603,6 +603,8 @@ export function CollectView(): React.ReactElement {
           items={itemsWithRelations}
           onDelete={handleDeleteItem}
           onEdit={handleEditItem}
+          tagsError={Boolean(itemTagError)}
+          tricksError={Boolean(itemTrickError)}
         />
       );
     }

--- a/src/features/collect/components/item-card.test.tsx
+++ b/src/features/collect/components/item-card.test.tsx
@@ -556,3 +556,134 @@ describe("ItemCard condition", () => {
     expect(screen.queryByText(CONDITION_RE)).not.toBeInTheDocument();
   });
 });
+
+describe("ItemCard relation load errors", () => {
+  // Issue #267 — item_tags / item_tricks query failures must surface a
+  // per-card indicator so the user can tell "no relations" from "couldn't
+  // load them". The icon carries role="img" + aria-label so it is reachable
+  // by AT users without spawning a polite live region per card.
+  it("renders a labelled tricks error indicator (not a live region) when tricksError is set", () => {
+    render(
+      <ItemCard
+        item={makeItem({ tricks: [] })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        tricksError
+      />
+    );
+
+    expect(
+      screen.getByRole("img", { name: "collect.tricksLoadError" })
+    ).toBeInTheDocument();
+    // No status/alert live region — the page-level toast announces it once.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    // The linked-tricks count is replaced by the indicator.
+    expect(screen.queryByText(LINKED_TRICKS_RE)).not.toBeInTheDocument();
+  });
+
+  it("shows the tricks error indicator even when linked-trick data is present (error wins)", () => {
+    render(
+      <ItemCard
+        item={makeItem({
+          tricks: [
+            { id: "trick-1" as TrickId, name: "T1" },
+            { id: "trick-2" as TrickId, name: "T2" },
+          ],
+        })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        tricksError
+      />
+    );
+
+    expect(
+      screen.getByRole("img", { name: "collect.tricksLoadError" })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(LINKED_TRICKS_RE)).not.toBeInTheDocument();
+  });
+
+  it("renders a labelled tags error indicator when tagsError is set", () => {
+    render(
+      <ItemCard
+        item={makeItem({ tags: [] })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        tagsError
+      />
+    );
+
+    expect(
+      screen.getByRole("img", { name: "collect.tagsLoadError" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows the tags error indicator in place of the tag list (error wins over data)", () => {
+    const tags = [
+      makeTag({ id: "t1" as TagId, name: "Tag1" }),
+      makeTag({ id: "t2" as TagId, name: "Tag2" }),
+    ];
+    render(
+      <ItemCard
+        item={makeItem({ tags })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        tagsError
+      />
+    );
+
+    expect(
+      screen.getByRole("img", { name: "collect.tagsLoadError" })
+    ).toBeInTheDocument();
+    // The tag <ul> and its badges are replaced by the indicator.
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tag1")).not.toBeInTheDocument();
+  });
+
+  it("renders distinct indicators for each relation when both errors are set", () => {
+    render(
+      <ItemCard
+        item={makeItem()}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        tagsError
+        tricksError
+      />
+    );
+
+    // Distinct accessible names — each relation gets its own labelled icon.
+    expect(
+      screen.getByRole("img", { name: "collect.tagsLoadError" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "collect.tricksLoadError" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders no error indicator when neither error flag is set", () => {
+    render(
+      <ItemCard
+        item={makeItem({
+          tags: [makeTag({ id: "t1" as TagId, name: "Tag1" })],
+          tricks: [{ id: "trick-1" as TrickId, name: "T1" }],
+        })}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole("img", { name: "collect.tagsLoadError" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: "collect.tricksLoadError" })
+    ).not.toBeInTheDocument();
+    // Normal relations still render.
+    expect(screen.getByText("Tag1")).toBeInTheDocument();
+    expect(
+      screen.getByText("collect.linkedTricksCount (count: 1)")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/collect/components/item-card.tsx
+++ b/src/features/collect/components/item-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Edit, Link2, MoreHorizontal, Trash2 } from "lucide-react";
+import { CircleAlert, Edit, Link2, MoreHorizontal, Trash2 } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -20,6 +20,18 @@ interface ItemCardProps {
   item: ItemWithRelations;
   onDelete: (id: ItemId) => void;
   onEdit: (id: ItemId) => void;
+  /**
+   * True when the parent's item_tags query failed. Renders a muted indicator
+   * badge in place of the tag list so the user can distinguish "no tags" from
+   * "failed to load tags" (issue #267).
+   */
+  tagsError?: boolean;
+  /**
+   * True when the parent's item_tricks query failed. Renders a muted indicator
+   * badge in place of the linked-tricks count so the user can distinguish
+   * "no linked tricks" from "failed to load" (issue #267).
+   */
+  tricksError?: boolean;
 }
 
 export const MAX_VISIBLE_TAGS = 3;
@@ -28,6 +40,8 @@ export function ItemCard({
   item,
   onEdit,
   onDelete,
+  tagsError,
+  tricksError,
 }: ItemCardProps): React.ReactElement {
   const t = useTranslations("collect");
   const locale = useLocale();
@@ -135,34 +149,78 @@ export function ItemCard({
           </div>
         )}
 
-        {/* Linked tricks count */}
-        {item.tricks.length > 0 && (
-          <div className="flex items-center gap-1.5 text-muted-foreground text-sm">
-            <Link2 aria-hidden="true" className="size-3.5" />
-            <span>{t("linkedTricksCount", { count: item.tricks.length })}</span>
-          </div>
+        {/* Linked tricks count — a muted indicator replaces the count when the
+            parent's item_tricks query errored, so "no linked tricks" stays
+            distinguishable from "couldn't load" (issue #267). */}
+        {tricksError ? (
+          <RelationLoadErrorIndicator label={t("tricksLoadError")} />
+        ) : (
+          item.tricks.length > 0 && (
+            <div className="flex items-center gap-1.5 text-muted-foreground text-sm">
+              <Link2 aria-hidden="true" className="size-3.5" />
+              <span>
+                {t("linkedTricksCount", { count: item.tricks.length })}
+              </span>
+            </div>
+          )
         )}
 
-        {/* Tags */}
-        {item.tags.length > 0 && (
-          <ul
-            aria-label={t("field.tags")}
-            className="flex flex-wrap items-center gap-1.5"
-          >
-            {visibleTags.map((tag) => (
-              <li key={tag.id}>
-                <TagBadge tag={tag} />
-              </li>
-            ))}
-            {hiddenTagCount > 0 && (
-              <li>
-                <Badge variant="outline">+{hiddenTagCount}</Badge>
-              </li>
-            )}
-          </ul>
+        {/* Tags — a muted indicator replaces the list when the parent's
+            item_tags query errored (issue #267). */}
+        {tagsError ? (
+          <RelationLoadErrorIndicator label={t("tagsLoadError")} />
+        ) : (
+          item.tags.length > 0 && (
+            <ul
+              aria-label={t("field.tags")}
+              className="flex flex-wrap items-center gap-1.5"
+            >
+              {visibleTags.map((tag) => (
+                <li key={tag.id}>
+                  <TagBadge tag={tag} />
+                </li>
+              ))}
+              {hiddenTagCount > 0 && (
+                <li>
+                  <Badge variant="outline">+{hiddenTagCount}</Badge>
+                </li>
+              )}
+            </ul>
+          )
         )}
       </CardContent>
     </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Relation load-error indicator
+// ---------------------------------------------------------------------------
+
+/**
+ * Muted badge shown in place of a relation (tags or linked tricks) when its
+ * PowerSync query errored — lets the user tell "none" from "couldn't load"
+ * (issue #267). Mirrors the repertoire pattern in `trick-card.tsx`.
+ *
+ * The accessible name sits on the icon (`role="img"`), not on a wrapper with
+ * `role="status"`: a list of N cards would otherwise spawn N polite live
+ * regions and queue N announcements. The page-level toast (collect-view)
+ * already announces the failure once.
+ */
+function RelationLoadErrorIndicator({
+  label,
+}: {
+  label: string;
+}): React.ReactElement {
+  return (
+    <div className="flex items-center gap-1.5 text-muted-foreground text-sm">
+      <CircleAlert
+        aria-label={label}
+        className="size-3.5 shrink-0"
+        role="img"
+      />
+      <span aria-hidden="true">—</span>
+    </div>
   );
 }
 

--- a/src/features/collect/components/item-list.test.tsx
+++ b/src/features/collect/components/item-list.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ItemId } from "@/db/types";
+import type { ItemWithRelations } from "../types";
+import { ItemList } from "./item-list";
+
+// Mock ItemCard to avoid rendering its full complexity. The tagsError and
+// tricksError flags are reflected as data-attributes so a single render can
+// assert each prop was forwarded to every card without exposing the real
+// CircleAlert markup. Mirrors the trick-list.test.tsx pattern (issue #267).
+vi.mock("./item-card", () => ({
+  ItemCard: ({
+    item,
+    onEdit,
+    onDelete,
+    tagsError,
+    tricksError,
+  }: {
+    item: ItemWithRelations;
+    onEdit: (id: string) => void;
+    onDelete: (id: string) => void;
+    tagsError?: boolean;
+    tricksError?: boolean;
+  }) => (
+    <div
+      data-tags-error={String(Boolean(tagsError))}
+      data-testid={`item-card-${item.id}`}
+      data-tricks-error={String(Boolean(tricksError))}
+    >
+      <span>{item.name}</span>
+      <button onClick={() => onEdit(item.id)} type="button">
+        Edit
+      </button>
+      <button onClick={() => onDelete(item.id)} type="button">
+        Delete
+      </button>
+    </div>
+  ),
+}));
+
+const ITEM_CARD_PATTERN = /item-card/;
+
+const makeItem = (id: string, name: string): ItemWithRelations => ({
+  id: id as ItemId,
+  name,
+  type: "deck",
+  description: null,
+  brand: null,
+  condition: null,
+  location: null,
+  notes: null,
+  purchaseDate: null,
+  purchasePrice: null,
+  quantity: 1,
+  creator: null,
+  url: null,
+  createdAt: "2025-01-01T00:00:00.000Z",
+  updatedAt: "2025-01-01T00:00:00.000Z",
+  tags: [],
+  tricks: [],
+});
+
+describe("ItemList", () => {
+  it("renders a list with the correct aria-label", () => {
+    render(<ItemList items={[]} onDelete={vi.fn()} onEdit={vi.fn()} />);
+    expect(
+      screen.getByRole("list", { name: "collect.title" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders a card for each item", () => {
+    const items = [
+      makeItem("i1", "Invisible Deck"),
+      makeItem("i2", "Svengali Deck"),
+    ];
+    render(<ItemList items={items} onDelete={vi.fn()} onEdit={vi.fn()} />);
+    expect(screen.getByTestId("item-card-i1")).toBeInTheDocument();
+    expect(screen.getByTestId("item-card-i2")).toBeInTheDocument();
+  });
+
+  it("renders no cards when the items array is empty", () => {
+    render(<ItemList items={[]} onDelete={vi.fn()} onEdit={vi.fn()} />);
+    expect(screen.queryAllByTestId(ITEM_CARD_PATTERN)).toHaveLength(0);
+  });
+
+  // Issue #267 — tagsError / tricksError must reach every rendered card so
+  // each one can swap the affected relation for the muted indicator.
+  it("forwards tagsError to every rendered ItemCard", () => {
+    const items = [makeItem("i1", "A"), makeItem("i2", "B")];
+    render(
+      <ItemList items={items} onDelete={vi.fn()} onEdit={vi.fn()} tagsError />
+    );
+
+    for (const item of items) {
+      expect(screen.getByTestId(`item-card-${item.id}`)).toHaveAttribute(
+        "data-tags-error",
+        "true"
+      );
+    }
+  });
+
+  it("forwards tricksError to every rendered ItemCard", () => {
+    const items = [makeItem("i1", "A"), makeItem("i2", "B")];
+    render(
+      <ItemList items={items} onDelete={vi.fn()} onEdit={vi.fn()} tricksError />
+    );
+
+    for (const item of items) {
+      expect(screen.getByTestId(`item-card-${item.id}`)).toHaveAttribute(
+        "data-tricks-error",
+        "true"
+      );
+    }
+  });
+
+  it("forwards both error flags as false when omitted", () => {
+    const items = [makeItem("i1", "A"), makeItem("i2", "B")];
+    render(<ItemList items={items} onDelete={vi.fn()} onEdit={vi.fn()} />);
+
+    for (const item of items) {
+      const card = screen.getByTestId(`item-card-${item.id}`);
+      expect(card).toHaveAttribute("data-tags-error", "false");
+      expect(card).toHaveAttribute("data-tricks-error", "false");
+    }
+  });
+});

--- a/src/features/collect/components/item-list.tsx
+++ b/src/features/collect/components/item-list.tsx
@@ -9,6 +9,18 @@ interface ItemListProps {
   items: ItemWithRelations[];
   onDelete: (id: ItemId) => void;
   onEdit: (id: ItemId) => void;
+  /**
+   * True when the item_tags join query has errored. Forwarded to every
+   * ItemCard so each shows a muted indicator badge in place of its tag list
+   * (issue #267).
+   */
+  tagsError?: boolean;
+  /**
+   * True when the item_tricks join query has errored. Forwarded to every
+   * ItemCard so each shows a muted indicator in place of its linked-tricks
+   * count (issue #267).
+   */
+  tricksError?: boolean;
 }
 
 /**
@@ -21,6 +33,8 @@ export function ItemList({
   items,
   onEdit,
   onDelete,
+  tagsError,
+  tricksError,
 }: ItemListProps): React.ReactElement {
   const t = useTranslations("collect");
 
@@ -31,7 +45,13 @@ export function ItemList({
     >
       {items.map((item) => (
         <li key={item.id}>
-          <ItemCard item={item} onDelete={onDelete} onEdit={onEdit} />
+          <ItemCard
+            item={item}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            tagsError={tagsError}
+            tricksError={tricksError}
+          />
         </li>
       ))}
     </ul>

--- a/src/features/repertoire/components/trick-card.tsx
+++ b/src/features/repertoire/components/trick-card.tsx
@@ -206,7 +206,7 @@ export function TrickCard({
             announcements; the page-level toast already announces the failure
             once. aria-label reuses the existing `loadError` translation. */}
         {linkedItemsError ? (
-          <div className="flex items-center gap-1.5 text-muted-foreground text-sm opacity-50">
+          <div className="flex items-center gap-1.5 text-muted-foreground text-sm">
             <CircleAlert
               aria-label={t("loadError")}
               className="size-3.5 shrink-0"

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -266,6 +266,8 @@
     "saveFailed": "Objekt konnte nicht gespeichert werden",
     "deleteFailed": "Objekt konnte nicht gelöscht werden",
     "loadError": "Daten konnten nicht geladen werden",
+    "tagsLoadError": "Tags konnten nicht geladen werden",
+    "tricksLoadError": "Verknüpfte Tricks konnten nicht geladen werden",
     "emptyTitle": "Deine Sammlung ist leer",
     "emptyDescription": "Füge dein erstes Objekt hinzu, um deine Sammlung aufzubauen.",
     "searchPlaceholder": "Objekte suchen...",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -266,6 +266,8 @@
     "saveFailed": "Failed to save item",
     "deleteFailed": "Failed to delete item",
     "loadError": "Failed to load data",
+    "tagsLoadError": "Failed to load tags",
+    "tricksLoadError": "Failed to load linked tricks",
     "emptyTitle": "Your collection is empty",
     "emptyDescription": "Add your first item to start building your collection.",
     "searchPlaceholder": "Search items...",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -266,6 +266,8 @@
     "saveFailed": "Error al guardar el objeto",
     "deleteFailed": "Error al eliminar el objeto",
     "loadError": "Error al cargar los datos",
+    "tagsLoadError": "Error al cargar las etiquetas",
+    "tricksLoadError": "Error al cargar los trucos vinculados",
     "emptyTitle": "Tu colección está vacía",
     "emptyDescription": "Agrega tu primer objeto para empezar a construir tu colección.",
     "searchPlaceholder": "Buscar objetos...",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -266,6 +266,8 @@
     "saveFailed": "Échec de l'enregistrement de l'objet",
     "deleteFailed": "Échec de la suppression de l'objet",
     "loadError": "Échec du chargement des données",
+    "tagsLoadError": "Échec du chargement des tags",
+    "tricksLoadError": "Échec du chargement des tours associés",
     "emptyTitle": "Votre collection est vide",
     "emptyDescription": "Ajoutez votre premier objet pour commencer à construire votre collection.",
     "searchPlaceholder": "Rechercher des objets...",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -266,6 +266,8 @@
     "saveFailed": "Impossibile salvare l'oggetto",
     "deleteFailed": "Impossibile eliminare l'oggetto",
     "loadError": "Impossibile caricare i dati",
+    "tagsLoadError": "Impossibile caricare i tag",
+    "tricksLoadError": "Impossibile caricare i trucchi collegati",
     "emptyTitle": "La tua collezione è vuota",
     "emptyDescription": "Aggiungi il tuo primo oggetto per iniziare a costruire la tua collezione.",
     "searchPlaceholder": "Cerca oggetti...",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -266,6 +266,8 @@
     "saveFailed": "Item opslaan mislukt",
     "deleteFailed": "Item verwijderen mislukt",
     "loadError": "Gegevens laden mislukt",
+    "tagsLoadError": "Tags laden mislukt",
+    "tricksLoadError": "Gekoppelde trucs laden mislukt",
     "emptyTitle": "Je collectie is leeg",
     "emptyDescription": "Voeg je eerste item toe om je collectie op te bouwen.",
     "searchPlaceholder": "Items zoeken...",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -266,6 +266,8 @@
     "saveFailed": "Falha ao guardar o objeto",
     "deleteFailed": "Falha ao eliminar o objeto",
     "loadError": "Falha ao carregar os dados",
+    "tagsLoadError": "Falha ao carregar as etiquetas",
+    "tricksLoadError": "Falha ao carregar os truques associados",
     "emptyTitle": "A sua coleção está vazia",
     "emptyDescription": "Adicione o seu primeiro objeto para começar a construir a sua coleção.",
     "searchPlaceholder": "Pesquisar objetos...",


### PR DESCRIPTION
## Summary

- Adds `tagsError` / `tricksError` boolean props to `ItemList` and `ItemCard`, wiring `CollectView`'s `itemTagError` / `itemTrickError` query-error state down to each card
- When a join query fails, cards render a muted `CircleAlert` icon (`role="img"`) in place of the tag list or linked-tricks count — so users can distinguish "none" from "couldn't load" (issue #267)
- Aligns `trick-card.tsx`: removes `opacity-50` from its equivalent error indicator so both modules render at full muted opacity

## Accessibility

The accessible name sits on the icon (`role="img"` + `aria-label`), not on a wrapper with `role="status"`. A list of N cards would otherwise spawn N polite live regions; the page-level toast in `CollectView` already announces the failure once.

## Test plan

- [x] `item-card.test.tsx` — 8 new cases: indicator renders on error, error wins over data, both indicators distinct, healthy state renders normally
- [x] `item-list.test.tsx` (new) — forwards `tagsError`/`tricksError` to every rendered card
- [x] `collect-view.test.tsx` — 3 new cases: wires `itemTagError`, `itemTrickError`, and healthy state to `ItemList` props
- [x] i18n: `tagsLoadError`/`tricksLoadError` added to all 7 locales; `pnpm i18n:check` passes
- [x] All 111 tests pass

Closes #267