### PR TITLE
feat(a11y): extract LoadingAnnouncer for form-sheet live-region (issue #295)

### DIFF
--- a/e2e/repertoire.spec.ts
+++ b/e2e/repertoire.spec.ts
@@ -133,3 +133,68 @@ test.describe("Repertoire — Trick CRUD", () => {
     await expect(page.getByText(name)).not.toBeVisible({ timeout: 10_000 });
   });
 });
+
+// The form-sheet loading announcer (issue #295) is covered at the unit level
+// by src/components/loading-announcer.test.tsx. This browser-level check of the
+// two-tick render — live region inserted empty, then the loading text added as
+// a separate DOM mutation — needs the edit-sheet flow, which is test.fixme
+// above for PowerSync E2E timing instability. It activates with those tests
+// once the PowerSync E2E patterns stabilise.
+test.describe("Repertoire — form-sheet loading announcer (#295)", () => {
+  test.beforeEach(() => {
+    test.skip(!hasAuthSession(), "No authenticated session available");
+  });
+
+  test.fixme("loading text is added to the live region as a mutation, not at mount", async ({
+    page,
+  }) => {
+    const name = `E2E A11y ${Date.now().toString()}`;
+    await page.goto("/repertoire");
+    await waitForAddButton(page, ADD_TRICK_RE);
+    await createTrick(page, name);
+
+    // Before the edit sheet opens, watch for any DOM mutation that targets a
+    // role=status element — text added/changed AFTER the live region span is
+    // already mounted. Content-at-mount would insert the span with its text
+    // inline, so no mutation would ever target the span itself.
+    await page.evaluate(() => {
+      const flag = window as unknown as { __lrMutatedAfterMount: boolean };
+      flag.__lrMutatedAfterMount = false;
+      new MutationObserver((batch) => {
+        for (const record of batch) {
+          let target: Element | null = null;
+          if (record.type === "characterData") {
+            target = record.target.parentElement;
+          } else if (record.target instanceof Element) {
+            target = record.target;
+          }
+          // Count only a status region INSIDE the dialog — a sonner toast is
+          // also role="status" but renders in a body-level portal.
+          if (
+            target?.getAttribute("role") === "status" &&
+            target?.closest('[role="dialog"]')
+          ) {
+            flag.__lrMutatedAfterMount = true;
+          }
+        }
+      }).observe(document.body, {
+        characterData: true,
+        childList: true,
+        subtree: true,
+      });
+    });
+
+    // Open the edit sheet — it mounts in loading mode while the trick row
+    // hydrates from PowerSync, then transitions to the edit form.
+    await page.getByRole("button", { name: new RegExp(name) }).click();
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("status")).toBeAttached();
+
+    const mutatedAfterMount = await page.evaluate(
+      () =>
+        (window as unknown as { __lrMutatedAfterMount: boolean })
+          .__lrMutatedAfterMount
+    );
+    expect(mutatedAfterMount).toBe(true);
+  });
+});

--- a/src/components/loading-announcer.test.tsx
+++ b/src/components/loading-announcer.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LoadingAnnouncer } from "./loading-announcer";
+
+describe("LoadingAnnouncer", () => {
+  it("renders a polite, atomic status live region", () => {
+    render(<LoadingAnnouncer message="Loading…" />);
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAttribute("aria-atomic", "true");
+    expect(region).toHaveClass("sr-only");
+  });
+
+  it("announces the provided message", () => {
+    render(<LoadingAnnouncer message="Loading trick…" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading trick…");
+  });
+
+  it("renders the region empty for an empty message", () => {
+    render(<LoadingAnnouncer message="" />);
+
+    expect(screen.getByRole("status").textContent).toBe("");
+  });
+
+  it("preserves the live-region node when the message changes", () => {
+    const { rerender } = render(<LoadingAnnouncer message="Loading trick…" />);
+    const initial = screen.getByRole("status");
+
+    // A content change must mutate the same node, never remount it — a remount
+    // would risk re-announcing stale text or being skipped by some readers.
+    rerender(<LoadingAnnouncer message="Trick ready to edit." />);
+    expect(screen.getByRole("status")).toBe(initial);
+    expect(initial).toHaveTextContent("Trick ready to edit.");
+
+    rerender(<LoadingAnnouncer message="" />);
+    expect(screen.getByRole("status")).toBe(initial);
+  });
+
+  it("delivers the message as a mutation on the mounted region, not as content at mount", () => {
+    // Two-tick render (issue #295 caveat 1): the <span> mounts empty and the
+    // text arrives on a later commit. Proof = a DOM mutation that targets the
+    // live region itself (or a text node inside it) — i.e. the text was added
+    // AFTER the span was in the DOM. Content-at-mount would instead insert the
+    // span with its text already inline, producing no span-targeted mutation.
+    const records: MutationRecord[] = [];
+    const observer = new MutationObserver((batch) => {
+      records.push(...batch);
+    });
+    observer.observe(document.body, {
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+
+    render(<LoadingAnnouncer message="Loading trick…" />);
+
+    records.push(...observer.takeRecords());
+    observer.disconnect();
+
+    const region = screen.getByRole("status");
+    const textArrivedAfterMount = records.some((record) => {
+      if (record.type === "characterData") {
+        return record.target.parentNode === region;
+      }
+      return record.type === "childList" && record.target === region;
+    });
+    expect(textArrivedAfterMount).toBe(true);
+  });
+});

--- a/src/components/loading-announcer.tsx
+++ b/src/components/loading-announcer.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { type ReactElement, useEffect, useState } from "react";
+
+interface LoadingAnnouncerProps {
+  /**
+   * Text to announce, pre-resolved by the caller (e.g. via next-intl). An
+   * empty string renders the region silent.
+   */
+  message: string;
+}
+
+/**
+ * Polite live-region announcer for a form sheet's loading→ready transition
+ * (WCAG 2.2 SC 4.1.3 "Status Messages"; issue #288 F3).
+ *
+ * Two-tick render: the region mounts with empty content, then `message` is
+ * applied on the next commit via an effect. Every announcement — including the
+ * first "Loading…" — therefore lands as a DOM mutation on an already-present
+ * live region, never as content present at the region's mount. This is the
+ * canonically-correct live-region pattern and mitigates issue #295 caveat 1
+ * (VoiceOver iOS can swallow content present when a live region is inserted).
+ * Mechanism only — confirming VoiceOver iOS actually narrates it still needs a
+ * manual screen-reader pass.
+ *
+ * Render this as a STABLE, unconditionally-mounted sibling of any keyed or
+ * conditionally-rendered subtree, so a sibling's remount cannot disturb the
+ * region.
+ *
+ * Remaining known caveats (accepted; issue #295):
+ * - Fast hydration: the polite queue may collapse the loading announcement
+ *   behind Radix Dialog's `SheetTitle` read. Accepted — hydration is typically
+ *   perceptible, and an assertive escape valve would interrupt the title read.
+ * - An empty `message` empties the region; most screen readers treat empty
+ *   atomic content as silence, a few announce blank. Accepted.
+ */
+export function LoadingAnnouncer({
+  message,
+}: LoadingAnnouncerProps): ReactElement {
+  const [announced, setAnnounced] = useState("");
+
+  // Two-tick: apply the message only after the empty region has committed, so
+  // it registers as a mutation rather than initial content (see the component
+  // doc). `requestAnimationFrame` is the escalation knob if a VoiceOver iOS
+  // pass shows a single commit is not enough.
+  useEffect(() => {
+    setAnnounced(message);
+  }, [message]);
+
+  return (
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      className="sr-only"
+      role="status"
+    >
+      {announced}
+    </span>
+  );
+}

--- a/src/features/collect/components/item-form-sheet.tsx
+++ b/src/features/collect/components/item-form-sheet.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
+import { LoadingAnnouncer } from "@/components/loading-announcer";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -84,6 +85,20 @@ function toFormDefaults(item: ParsedItem): Partial<ItemFormValues> {
     type: item.type,
     url: item.url ?? "",
   };
+}
+
+/** Resolve the loading→ready live-region announcement for the current mode. */
+function loadingAnnouncement(
+  mode: ItemFormSheetMode,
+  t: (key: "itemReady" | "loadingItem") => string
+): string {
+  if (mode.mode === "loading") {
+    return t("loadingItem");
+  }
+  if (mode.mode === "edit") {
+    return t("itemReady");
+  }
+  return "";
 }
 
 function ItemFormSheet({
@@ -183,34 +198,12 @@ function ItemFormSheet({
 
           <ScrollArea className="flex-1 overflow-y-auto">
             <div className="p-4">
-              {/* Persistent aria-live region — owns the loading→ready
-                  announcement so screen readers don't fall silent when the
-                  skeleton unmounts (WCAG 2.2 SC 4.1.3, issue #288 F3).
-                  Sibling of the conditional so the form's `key` remount
-                  cannot disturb it.
-
-                  Known platform caveats (not blockers):
-                  - VoiceOver iOS may swallow the initial "Loading…" content
-                    announced at mount; the loading→ready transition (a
-                    mutation, not initial content) is reliable across SR/browser
-                    combos and is what the SC requires.
-                  - On fast hydration, the polite queue may collapse the
-                    loading announcement behind Radix Dialog's SheetTitle
-                    read. Acceptable for the common case (hydration is
-                    typically perceptible).
-                  - The edit→create transition empties the region; most SRs
-                    treat empty atomic content as silence, but a few will
-                    announce blank. Acceptable — no meaningful content to
-                    convey on a sheet that's about to close anyway. */}
-              <span
-                aria-atomic="true"
-                aria-live="polite"
-                className="sr-only"
-                role="status"
-              >
-                {mode.mode === "loading" && t("loadingItem")}
-                {mode.mode === "edit" && t("itemReady")}
-              </span>
+              {/* Loading→ready announcer — the two-tick rationale and the
+                  remaining screen-reader caveats live in LoadingAnnouncer
+                  (issues #288 F3, #295). Unconditional sibling of the
+                  conditional below so the form's `key` remount can't reach
+                  it. */}
+              <LoadingAnnouncer message={loadingAnnouncement(mode, t)} />
               {mode.mode === "loading" ? (
                 // aria-busy directly on the skeleton container — NOT on its
                 // parent — so AT walking the tree treats the skeletons as

--- a/src/features/repertoire/components/trick-form-sheet.tsx
+++ b/src/features/repertoire/components/trick-form-sheet.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
+import { LoadingAnnouncer } from "@/components/loading-announcer";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -84,6 +85,20 @@ function toFormDefaults(trick: ParsedTrick): Partial<TrickFormValues> {
     status: trick.status,
     videoUrl: trick.videoUrl ?? "",
   };
+}
+
+/** Resolve the loading→ready live-region announcement for the current mode. */
+function loadingAnnouncement(
+  mode: TrickFormSheetMode,
+  t: (key: "loadingTrick" | "trickReady") => string
+): string {
+  if (mode.mode === "loading") {
+    return t("loadingTrick");
+  }
+  if (mode.mode === "edit") {
+    return t("trickReady");
+  }
+  return "";
 }
 
 function TrickFormSheet({
@@ -186,34 +201,12 @@ function TrickFormSheet({
 
           <ScrollArea className="flex-1 overflow-y-auto">
             <div className="p-4">
-              {/* Persistent aria-live region — owns the loading→ready
-                  announcement so screen readers don't fall silent when the
-                  skeleton unmounts (WCAG 2.2 SC 4.1.3, issue #288 F3).
-                  Sibling of the conditional so the form's `key` remount
-                  cannot disturb it.
-
-                  Known platform caveats (not blockers):
-                  - VoiceOver iOS may swallow the initial "Loading…" content
-                    announced at mount; the loading→ready transition (a
-                    mutation, not initial content) is reliable across SR/browser
-                    combos and is what the SC requires.
-                  - On fast hydration, the polite queue may collapse the
-                    loading announcement behind Radix Dialog's SheetTitle
-                    read. Acceptable for the common case (hydration is
-                    typically perceptible).
-                  - The edit→create transition empties the region; most SRs
-                    treat empty atomic content as silence, but a few will
-                    announce blank. Acceptable — no meaningful content to
-                    convey on a sheet that's about to close anyway. */}
-              <span
-                aria-atomic="true"
-                aria-live="polite"
-                className="sr-only"
-                role="status"
-              >
-                {mode.mode === "loading" && t("loadingTrick")}
-                {mode.mode === "edit" && t("trickReady")}
-              </span>
+              {/* Loading→ready announcer — the two-tick rationale and the
+                  remaining screen-reader caveats live in LoadingAnnouncer
+                  (issues #288 F3, #295). Unconditional sibling of the
+                  conditional below so the form's `key` remount can't reach
+                  it. */}
+              <LoadingAnnouncer message={loadingAnnouncement(mode, t)} />
               {mode.mode === "loading" ? (
                 // aria-busy directly on the skeleton container — NOT on its
                 // parent — so AT walking the tree treats the skeletons as


### PR DESCRIPTION
## Summary

- Extracts a shared `LoadingAnnouncer` component (`src/components/loading-announcer.tsx`) from the duplicated inline `aria-live` span in both form sheets.
- Implements the **two-tick render**: the region mounts empty, then `useEffect` applies the message as a DOM mutation — so every announcement (including the first "Loading…") lands as a mutation on an already-present live region. Mitigates VoiceOver iOS swallowing content present at live-region mount (issue #295 caveat 1).
- Moves the screen-reader caveats and two-tick rationale into the component doc, keeping the call sites lean.
- Adds a `loadingAnnouncement` helper to each form sheet to resolve the message string before passing to `LoadingAnnouncer`.

## Test plan

- [x] 5 new unit tests in `loading-announcer.test.tsx` — ARIA attributes, message delivery, node identity on message change, and the two-tick mutation proof.
- [x] Existing form-sheet unit tests unchanged (59 tests pass).
- [x] TypeScript and Biome lint clean.
- [ ] Fixme'd Playwright E2E test added (`e2e/repertoire.spec.ts` — activates once PowerSync E2E patterns stabilise).
- [ ] Manual screen-reader pass on VoiceOver iOS still needed to confirm the two-tick mitigation works in practice (documented as a known remaining caveat).

Refs #295, #288