### PR TITLE
feat(dashboard): migrate counts to PowerSync, fix card title truncation

### DIFF
--- a/src/app/(app)/dashboard/page.test.tsx
+++ b/src/app/(app)/dashboard/page.test.tsx
@@ -7,15 +7,15 @@ vi.mock("@/components/dashboard-grid", () => ({
 }));
 
 vi.mock("@/components/collection-card", () => ({
-  CollectionCard: ({ itemCount }: { itemCount: number }) => (
-    <div data-count={itemCount} data-testid="collection-card" />
-  ),
+  CollectionCard: () => <div data-testid="collection-card" />,
 }));
 
 vi.mock("@/components/repertoire-card", () => ({
-  RepertoireCard: ({ trickCount }: { trickCount: number }) => (
-    <div data-count={trickCount} data-testid="repertoire-card" />
-  ),
+  RepertoireCard: () => <div data-testid="repertoire-card" />,
+}));
+
+vi.mock("@/features/activity/components/recent-activity-card", () => ({
+  RecentActivityCard: () => <div data-testid="recent-activity-card" />,
 }));
 
 interface MockSession {
@@ -34,47 +34,6 @@ vi.mock("@/auth/server", () => ({
   },
 }));
 
-const mockWhere = vi.fn(() => Promise.resolve([{ count: 3 }]));
-const mockFrom = vi.fn(() => ({ where: mockWhere }));
-const mockSelect = vi.fn(() => ({ from: mockFrom }));
-
-// The dashboard page calls select().from(tricks).where() then select().from(items).where()
-// Both return the same mock chain — the mockWhere default returns [{ count: 3 }] for both.
-
-vi.mock("@/db", () => ({
-  getDb: vi.fn(() => ({
-    select: mockSelect,
-  })),
-}));
-
-const mockAnd = vi.fn((...args: unknown[]) => args);
-const mockCount = vi.fn(() => "count()");
-const mockEq = vi.fn(
-  (col: unknown, val: unknown) => `eq(${String(col)},${String(val)})`
-);
-const mockIsNull = vi.fn((col: unknown) => `isNull(${String(col)})`);
-
-vi.mock("drizzle-orm", () => ({
-  and: (...args: unknown[]) => mockAnd(...args),
-  count: () => mockCount(),
-  eq: (col: unknown, val: unknown) => mockEq(col, val),
-  isNull: (col: unknown) => mockIsNull(col),
-}));
-
-vi.mock("@/db/schema/items", () => ({
-  items: {
-    userId: "items.userId",
-    deletedAt: "items.deletedAt",
-  },
-}));
-
-vi.mock("@/db/schema/tricks", () => ({
-  tricks: {
-    userId: "tricks.userId",
-    deletedAt: "tricks.deletedAt",
-  },
-}));
-
 describe("DashboardPage", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -83,31 +42,36 @@ describe("DashboardPage", () => {
         data: { user: { id: "user-1", name: "Test Magician" } },
       })
     );
-    mockWhere.mockImplementation(() => Promise.resolve([{ count: 3 }]));
-    mockFrom.mockImplementation(() => ({ where: mockWhere }));
-    mockSelect.mockImplementation(() => ({ from: mockFrom }));
   });
 
-  it("renders the CollectionCard with the correct itemCount", async () => {
-    mockWhere
-      .mockResolvedValueOnce([{ count: 3 }]) // tricks query (first)
-      .mockResolvedValueOnce([{ count: 7 }]); // items query (second)
+  it("renders the CollectionCard", async () => {
     render(await DashboardPage());
+    expect(screen.getByTestId("collection-card")).toBeInTheDocument();
+  });
 
-    const card = screen.getByTestId("collection-card");
-    expect(card).toBeInTheDocument();
-    expect(card).toHaveAttribute("data-count", "7");
+  it("renders the RepertoireCard", async () => {
+    render(await DashboardPage());
+    expect(screen.getByTestId("repertoire-card")).toBeInTheDocument();
+  });
+
+  it("renders the RecentActivityCard", async () => {
+    render(await DashboardPage());
+    expect(screen.getByTestId("recent-activity-card")).toBeInTheDocument();
+  });
+
+  it("renders the DashboardGrid", async () => {
+    render(await DashboardPage());
+    expect(screen.getByTestId("dashboard-grid")).toBeInTheDocument();
   });
 
   it("renders the Dashboard heading", async () => {
     render(await DashboardPage());
-
     expect(
       screen.getByRole("heading", { name: "dashboard.title" })
     ).toBeInTheDocument();
   });
 
-  it("renders a personalized welcome message", async () => {
+  it("renders a personalized welcome message when the user has a name", async () => {
     render(await DashboardPage());
 
     const welcomeSection = screen.getByRole("heading", {
@@ -121,40 +85,8 @@ describe("DashboardPage", () => {
     expect(paragraph?.textContent).not.toBe("dashboard.welcome");
   });
 
-  it("renders the DashboardGrid component", async () => {
-    render(await DashboardPage());
-
-    expect(screen.getByTestId("dashboard-grid")).toBeInTheDocument();
-  });
-
-  it("renders the RepertoireCard with the correct trickCount", async () => {
-    mockWhere
-      .mockResolvedValueOnce([{ count: 3 }]) // tricks query (first)
-      .mockResolvedValueOnce([{ count: 7 }]); // items query (second)
-    render(await DashboardPage());
-
-    const card = screen.getByTestId("repertoire-card");
-    expect(card).toBeInTheDocument();
-    expect(card).toHaveAttribute("data-count", "3");
-  });
-
-  it("queries the database with correct parameters", async () => {
-    render(await DashboardPage());
-
-    expect(mockSelect).toHaveBeenCalled();
-    expect(mockFrom).toHaveBeenCalled();
-    expect(mockEq).toHaveBeenCalledWith("tricks.userId", "user-1");
-    expect(mockIsNull).toHaveBeenCalledWith("tricks.deletedAt");
-    expect(mockEq).toHaveBeenCalledWith("items.userId", "user-1");
-    expect(mockIsNull).toHaveBeenCalledWith("items.deletedAt");
-    expect(mockAnd).toHaveBeenCalled();
-    expect(mockWhere).toHaveBeenCalled();
-  });
-
-  it("shows generic welcome when session.user is falsy", async () => {
-    mockGetSession.mockResolvedValueOnce({
-      data: { user: null },
-    });
+  it("shows the generic welcome when session.user is falsy", async () => {
+    mockGetSession.mockResolvedValueOnce({ data: { user: null } });
 
     render(await DashboardPage());
 
@@ -164,40 +96,10 @@ describe("DashboardPage", () => {
     const paragraph = welcomeSection?.querySelector("p");
     expect(paragraph).toBeInTheDocument();
     expect(paragraph?.textContent).toBeTruthy();
-  });
-
-  it("throws when DB query fails", async () => {
-    mockWhere.mockRejectedValueOnce(new Error("DB connection failed"));
-
-    await expect(DashboardPage()).rejects.toThrow("DB connection failed");
   });
 
   it("throws when getSession rejects", async () => {
     mockGetSession.mockRejectedValueOnce(new Error("Auth service down"));
-
     await expect(DashboardPage()).rejects.toThrow("Auth service down");
-  });
-
-  it("skips DB query when userId is empty", async () => {
-    mockGetSession.mockResolvedValueOnce({
-      data: { user: { id: "", name: "No ID User" } },
-    });
-
-    mockSelect.mockClear();
-    mockFrom.mockClear();
-    mockWhere.mockClear();
-
-    render(await DashboardPage());
-
-    const welcomeSection = screen.getByRole("heading", {
-      name: "dashboard.title",
-    }).parentElement;
-    const paragraph = welcomeSection?.querySelector("p");
-    expect(paragraph).toBeInTheDocument();
-    expect(paragraph?.textContent).toBeTruthy();
-
-    expect(mockSelect).not.toHaveBeenCalled();
-    expect(mockFrom).not.toHaveBeenCalled();
-    expect(mockWhere).not.toHaveBeenCalled();
   });
 });

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,3 @@
-import { and, count, eq, isNull } from "drizzle-orm";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import type { ReactElement } from "react";
@@ -6,9 +5,6 @@ import { auth } from "@/auth/server";
 import { CollectionCard } from "@/components/collection-card";
 import { DashboardGrid } from "@/components/dashboard-grid";
 import { RepertoireCard } from "@/components/repertoire-card";
-import { getDb } from "@/db";
-import { items } from "@/db/schema/items";
-import { tricks } from "@/db/schema/tricks";
 import { RecentActivityCard } from "@/features/activity/components/recent-activity-card";
 
 export const metadata: Metadata = {
@@ -19,25 +15,6 @@ export const metadata: Metadata = {
 export default async function DashboardPage(): Promise<ReactElement> {
   const t = await getTranslations("dashboard");
   const { data: session } = await auth.getSession();
-  const userId = session?.user?.id;
-  let trickCount = 0;
-  let itemCount = 0;
-
-  if (userId) {
-    const db = getDb();
-    const [trickRows, itemRows] = await Promise.all([
-      db
-        .select({ count: count() })
-        .from(tricks)
-        .where(and(eq(tricks.userId, userId), isNull(tricks.deletedAt))),
-      db
-        .select({ count: count() })
-        .from(items)
-        .where(and(eq(items.userId, userId), isNull(items.deletedAt))),
-    ]);
-    trickCount = trickRows[0]?.count ?? 0;
-    itemCount = itemRows[0]?.count ?? 0;
-  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -53,8 +30,8 @@ export default async function DashboardPage(): Promise<ReactElement> {
       </div>
       <div className="grid items-start gap-4 sm:grid-cols-2">
         <div className="flex flex-col gap-4">
-          <RepertoireCard trickCount={trickCount} />
-          <CollectionCard itemCount={itemCount} />
+          <RepertoireCard />
+          <CollectionCard />
         </div>
         <RecentActivityCard />
       </div>

--- a/src/components/collection-card.test.tsx
+++ b/src/components/collection-card.test.tsx
@@ -2,12 +2,12 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseTrickCount } = vi.hoisted(() => ({
-  mockUseTrickCount: vi.fn(),
+const { mockUseItemCount } = vi.hoisted(() => ({
+  mockUseItemCount: vi.fn(),
 }));
 
-vi.mock("@/features/repertoire/hooks/use-trick-count", () => ({
-  useTrickCount: mockUseTrickCount,
+vi.mock("@/features/collect/hooks/use-item-count", () => ({
+  useItemCount: mockUseItemCount,
 }));
 
 vi.mock("next/link", () => ({
@@ -22,9 +22,9 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-import { RepertoireCard } from "./repertoire-card";
+import { CollectionCard } from "./collection-card";
 
-const DESCRIPTION_RE = /dashboard\.repertoireDescription/;
+const DESCRIPTION_RE = /dashboard\.collectionDescription/;
 
 function mockHook({
   count = 0,
@@ -35,10 +35,10 @@ function mockHook({
   isLoading?: boolean;
   error?: Error | null;
 } = {}): void {
-  mockUseTrickCount.mockReturnValue({ count, isLoading, error });
+  mockUseItemCount.mockReturnValue({ count, isLoading, error });
 }
 
-describe("RepertoireCard", () => {
+describe("CollectionCard", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -51,61 +51,66 @@ describe("RepertoireCard", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("renders a link to /repertoire", () => {
+  it("renders a link to /collect", () => {
     mockHook({ count: 5 });
-    render(<RepertoireCard />);
-    expect(screen.getByRole("link")).toHaveAttribute("href", "/repertoire");
+    render(<CollectionCard />);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/collect");
   });
 
   it("sets an accessible label on the link", () => {
     mockHook({ count: 5 });
-    render(<RepertoireCard />);
+    render(<CollectionCard />);
     expect(screen.getByRole("link")).toHaveAttribute(
       "aria-label",
-      "dashboard.repertoireLink"
+      "dashboard.collectionLink"
     );
   });
 
-  it("displays the repertoire title", () => {
+  it("displays the collection title", () => {
     mockHook({ count: 5 });
-    render(<RepertoireCard />);
-    expect(screen.getByText("dashboard.repertoireTitle")).toBeInTheDocument();
+    render(<CollectionCard />);
+    expect(screen.getByText("dashboard.collectionTitle")).toBeInTheDocument();
   });
 
-  it("displays the trick count description when the count resolves", () => {
+  it("displays the item count description when the count resolves", () => {
     mockHook({ count: 0 });
-    render(<RepertoireCard />);
+    render(<CollectionCard />);
     expect(screen.getByText(DESCRIPTION_RE)).toBeInTheDocument();
   });
 
   it("marks the description as busy and hides the count while loading", () => {
     mockHook({ count: 0, isLoading: true });
-    const { container } = render(<RepertoireCard />);
+    const { container } = render(<CollectionCard />);
     expect(screen.queryByText(DESCRIPTION_RE)).not.toBeInTheDocument();
+    // aria-busy is the stable accessibility-tree signal; coupling tests to it
+    // (rather than the shadcn `data-slot="skeleton"` attribute) means a shadcn
+    // primitive bump can't silently break these tests.
     expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
   });
 
   it("falls back to an em-dash on hook error and does NOT render the count", () => {
     mockHook({ count: 0, error: new Error("query failed") });
-    const { container } = render(<RepertoireCard />);
+    const { container } = render(<CollectionCard />);
     expect(screen.queryByText(DESCRIPTION_RE)).not.toBeInTheDocument();
     expect(screen.getByText("—")).toBeInTheDocument();
+    // Em-dash branch must not also render a skeleton — the loading state and
+    // the error state are mutually exclusive.
     expect(container.querySelector('[aria-busy="true"]')).toBeNull();
   });
 
   it("logs an error to the console on hook error", () => {
     const err = new Error("query failed");
     mockHook({ count: 0, error: err });
-    render(<RepertoireCard />);
+    render(<CollectionCard />);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "RepertoireCard: failed to load trick count",
+      "CollectionCard: failed to load item count",
       err
     );
   });
 
   it("does not mark the description as busy when the count resolves", () => {
     mockHook({ count: 5 });
-    const { container } = render(<RepertoireCard />);
+    const { container } = render(<CollectionCard />);
     expect(container.querySelector('[aria-busy="true"]')).toBeNull();
   });
 });

--- a/src/components/collection-card.tsx
+++ b/src/components/collection-card.tsx
@@ -1,22 +1,29 @@
+"use client";
+
 import { ChevronRight, Package } from "lucide-react";
 import Link from "next/link";
-import { getTranslations } from "next-intl/server";
-import type { ReactElement } from "react";
+import { useTranslations } from "next-intl";
+import { type ReactElement, useEffect } from "react";
 import {
   Card,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useItemCount } from "@/features/collect/hooks/use-item-count";
 
-interface CollectionCardProps {
-  itemCount: number;
-}
+function CollectionCard(): ReactElement {
+  const t = useTranslations("dashboard");
+  const { count, isLoading, error } = useItemCount();
 
-export async function CollectionCard({
-  itemCount,
-}: CollectionCardProps): Promise<ReactElement> {
-  const t = await getTranslations("dashboard");
+  // Em-dash on error keeps the card usable as a nav tile; the loading
+  // skeleton would otherwise persist indefinitely on hook failure.
+  useEffect(() => {
+    if (error) {
+      console.error("CollectionCard: failed to load item count", error);
+    }
+  }, [error]);
 
   return (
     <Link
@@ -35,8 +42,8 @@ export async function CollectionCard({
             </div>
             <div className="flex flex-1 flex-col gap-1">
               <CardTitle>{t("collectionTitle")}</CardTitle>
-              <CardDescription>
-                {t("collectionDescription", { count: itemCount })}
+              <CardDescription aria-busy={isLoading ? true : undefined}>
+                {renderDescription({ count, error, isLoading, t })}
               </CardDescription>
             </div>
             <ChevronRight
@@ -49,3 +56,27 @@ export async function CollectionCard({
     </Link>
   );
 }
+
+interface RenderDescriptionArgs {
+  count: number;
+  error: Error | null;
+  isLoading: boolean;
+  t: ReturnType<typeof useTranslations<"dashboard">>;
+}
+
+function renderDescription({
+  count,
+  error,
+  isLoading,
+  t,
+}: RenderDescriptionArgs): ReactElement | string {
+  if (error) {
+    return "—";
+  }
+  if (isLoading) {
+    return <Skeleton className="h-4 w-32" />;
+  }
+  return t("collectionDescription", { count });
+}
+
+export { CollectionCard };

--- a/src/components/repertoire-card.tsx
+++ b/src/components/repertoire-card.tsx
@@ -1,22 +1,29 @@
+"use client";
+
 import { ChevronRight, WandSparkles } from "lucide-react";
 import Link from "next/link";
-import { getTranslations } from "next-intl/server";
-import type { ReactElement } from "react";
+import { useTranslations } from "next-intl";
+import { type ReactElement, useEffect } from "react";
 import {
   Card,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useTrickCount } from "@/features/repertoire/hooks/use-trick-count";
 
-interface RepertoireCardProps {
-  trickCount: number;
-}
+function RepertoireCard(): ReactElement {
+  const t = useTranslations("dashboard");
+  const { count, isLoading, error } = useTrickCount();
 
-export async function RepertoireCard({
-  trickCount,
-}: RepertoireCardProps): Promise<ReactElement> {
-  const t = await getTranslations("dashboard");
+  // Em-dash on error keeps the card usable as a nav tile; the loading
+  // skeleton would otherwise persist indefinitely on hook failure.
+  useEffect(() => {
+    if (error) {
+      console.error("RepertoireCard: failed to load trick count", error);
+    }
+  }, [error]);
 
   return (
     <Link
@@ -32,8 +39,8 @@ export async function RepertoireCard({
             </div>
             <div className="flex flex-1 flex-col gap-1">
               <CardTitle>{t("repertoireTitle")}</CardTitle>
-              <CardDescription>
-                {t("repertoireDescription", { count: trickCount })}
+              <CardDescription aria-busy={isLoading ? true : undefined}>
+                {renderDescription({ count, error, isLoading, t })}
               </CardDescription>
             </div>
             <ChevronRight
@@ -46,3 +53,27 @@ export async function RepertoireCard({
     </Link>
   );
 }
+
+interface RenderDescriptionArgs {
+  count: number;
+  error: Error | null;
+  isLoading: boolean;
+  t: ReturnType<typeof useTranslations<"dashboard">>;
+}
+
+function renderDescription({
+  count,
+  error,
+  isLoading,
+  t,
+}: RenderDescriptionArgs): ReactElement | string {
+  if (error) {
+    return "—";
+  }
+  if (isLoading) {
+    return <Skeleton className="h-4 w-32" />;
+  }
+  return t("repertoireDescription", { count });
+}
+
+export { RepertoireCard };

--- a/src/features/collect/components/item-card.tsx
+++ b/src/features/collect/components/item-card.tsx
@@ -71,31 +71,44 @@ export function ItemCard({
     // so we avoid it by giving each action its own real <button>.
     <Card className="hover:border-ring motion-safe:transition-colors">
       <CardHeader className="relative">
-        <div className="flex items-start justify-between gap-2">
+        {/* min-w-0 here is load-bearing: CardHeader is a CSS grid with implicit
+            auto columns, so this grid item's default min-width: auto would
+            expand to its min-content (the full untruncated title), defeating
+            the inner truncate. min-w-0 lets the grid track shrink, which then
+            lets the flex chain below trigger truncation. */}
+        <div className="flex min-w-0 items-start justify-between gap-2">
           {/* Phrasing-only inside <button> per HTML spec — use <span> with heading styles.
               The name span gets role="heading" aria-level={3} so screen-reader H-key
               navigation still works and the document outline stays intact, matching
-              the semantic <h3> used in trick-card.tsx. */}
-          <button
-            aria-label={`${t("edit")}: ${item.name}`}
-            className="min-w-0 flex-1 cursor-pointer rounded-sm text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
-            onClick={handleEditClick}
-            type="button"
-          >
-            {/* biome-ignore lint/a11y/useSemanticElements: <h3> is phrasing-content-only and invalid inside <button>; the ARIA role preserves H-key nav without breaking HTML. */}
-            <span
-              aria-level={3}
-              className="block truncate font-semibold"
-              role="heading"
+              the semantic <h3> used in trick-card.tsx.
+
+              The button is wrapped in a <div className="min-w-0 flex-1"> so the flex
+              item carrying the shrink/min-width is a <div>, not the button itself.
+              Buttons-as-flex-items don't shrink below their intrinsic content width
+              reliably (UA styling), so the inner <span class="truncate"> never
+              triggered; matching trick-card.tsx restores the truncation chain. */}
+          <div className="min-w-0 flex-1">
+            <button
+              aria-label={`${t("edit")}: ${item.name}`}
+              className="block w-full cursor-pointer rounded-sm text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              onClick={handleEditClick}
+              type="button"
             >
-              {item.name}
-            </span>
-            {item.description ? (
-              <span className="mt-1 line-clamp-2 block font-normal text-muted-foreground text-sm">
-                {item.description}
+              {/* biome-ignore lint/a11y/useSemanticElements: <h3> is phrasing-content-only and invalid inside <button>; the ARIA role preserves H-key nav without breaking HTML. */}
+              <span
+                aria-level={3}
+                className="line-clamp-2 font-semibold"
+                role="heading"
+              >
+                {item.name}
               </span>
-            ) : null}
-          </button>
+              {item.description ? (
+                <span className="mt-1 line-clamp-2 block font-normal text-muted-foreground text-sm">
+                  {item.description}
+                </span>
+              ) : null}
+            </button>
+          </div>
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/features/collect/hooks/use-item-count.test.ts
+++ b/src/features/collect/hooks/use-item-count.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}));
+
+vi.mock("@powersync/react", () => ({
+  useQuery: mockUseQuery,
+  usePowerSync: vi.fn(),
+}));
+
+import { useItemCount } from "./use-item-count";
+
+describe("useItemCount hook", () => {
+  it("returns 0 when no row is returned", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    const { result } = renderHook(() => useItemCount());
+    expect(result.current.count).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns the count from the first row", () => {
+    mockUseQuery.mockReturnValue({
+      data: [{ count: 7 }],
+      isLoading: false,
+      error: null,
+    });
+    const { result } = renderHook(() => useItemCount());
+    expect(result.current.count).toBe(7);
+    expect(typeof result.current.count).toBe("number");
+  });
+
+  it("coerces string counts to numbers (defensive guard against SQLite drivers returning strings)", () => {
+    mockUseQuery.mockReturnValue({
+      // Cast to satisfy the CountRow type; the runtime guard is the point of
+      // this test — ICU plural selectors require a number, not a string.
+      data: [{ count: "7" as unknown as number }],
+      isLoading: false,
+      error: null,
+    });
+    const { result } = renderHook(() => useItemCount());
+    expect(result.current.count).toBe(7);
+    expect(typeof result.current.count).toBe("number");
+  });
+
+  it("forwards isLoading from useQuery", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: true, error: null });
+    const { result } = renderHook(() => useItemCount());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("surfaces useQuery error", () => {
+    const err = new Error("query failed");
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: err });
+    const { result } = renderHook(() => useItemCount());
+    expect(result.current.error).toBe(err);
+  });
+
+  it("returns null error when useQuery error is undefined", () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const { result } = renderHook(() => useItemCount());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("issues a COUNT query against items filtered by deleted_at IS NULL", () => {
+    mockUseQuery.mockClear();
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    renderHook(() => useItemCount());
+
+    const sql = mockUseQuery.mock.calls[0]?.[0] as string;
+    expect(sql).toContain("SELECT COUNT(*)");
+    expect(sql).toContain("FROM items");
+    expect(sql).toContain("deleted_at IS NULL");
+  });
+});

--- a/src/features/collect/hooks/use-item-count.ts
+++ b/src/features/collect/hooks/use-item-count.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useQuery } from "@powersync/react";
+
+interface CountRow {
+  count: number;
+}
+
+interface UseItemCountResult {
+  count: number;
+  error: Error | null;
+  isLoading: boolean;
+}
+
+/**
+ * Returns a reactive count of the user's live (non-soft-deleted) items from
+ * local SQLite. Used by the dashboard CollectionCard so its number stays
+ * consistent with `/collect` (both read from PowerSync — offline-first).
+ */
+export function useItemCount(): UseItemCountResult {
+  const { data, isLoading, error } = useQuery<CountRow>(
+    "SELECT COUNT(*) AS count FROM items WHERE deleted_at IS NULL"
+  );
+
+  // Defensive Number() cast: PowerSync's SQLite driver returns INTEGER columns
+  // as JS numbers in practice, but COUNT(*) is the first such query in this
+  // codebase and ICU plural selectors fall through to `other` if `count` is a
+  // string. A 30-byte cast removes the entire risk class.
+  return {
+    count: Number(data[0]?.count ?? 0),
+    isLoading,
+    error: error ?? null,
+  };
+}

--- a/src/features/repertoire/components/trick-card.tsx
+++ b/src/features/repertoire/components/trick-card.tsx
@@ -98,9 +98,14 @@ export function TrickCard({
       tabIndex={0}
     >
       <CardHeader className="relative">
-        <div className="flex items-start justify-between gap-2">
+        {/* min-w-0 here is load-bearing: CardHeader is a CSS grid with implicit
+            auto columns, so this grid item's default min-width: auto would
+            expand to its min-content (the full untruncated title). min-w-0
+            lets the grid track shrink so the inner truncation/line-clamp
+            chain triggers as designed. */}
+        <div className="flex min-w-0 items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
-            <h3 className="truncate font-semibold">{trick.name}</h3>
+            <h3 className="line-clamp-2 font-semibold">{trick.name}</h3>
             {trick.description ? (
               <p className="mt-1 line-clamp-2 text-muted-foreground text-sm">
                 {trick.description}

--- a/src/features/repertoire/hooks/use-trick-count.test.ts
+++ b/src/features/repertoire/hooks/use-trick-count.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}));
+
+vi.mock("@powersync/react", () => ({
+  useQuery: mockUseQuery,
+  usePowerSync: vi.fn(),
+}));
+
+import { useTrickCount } from "./use-trick-count";
+
+describe("useTrickCount hook", () => {
+  it("returns 0 when no row is returned", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    const { result } = renderHook(() => useTrickCount());
+    expect(result.current.count).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns the count from the first row", () => {
+    mockUseQuery.mockReturnValue({
+      data: [{ count: 12 }],
+      isLoading: false,
+      error: null,
+    });
+    const { result } = renderHook(() => useTrickCount());
+    expect(result.current.count).toBe(12);
+    expect(typeof result.current.count).toBe("number");
+  });
+
+  it("coerces string counts to numbers (defensive guard against SQLite drivers returning strings)", () => {
+    mockUseQuery.mockReturnValue({
+      data: [{ count: "12" as unknown as number }],
+      isLoading: false,
+      error: null,
+    });
+    const { result } = renderHook(() => useTrickCount());
+    expect(result.current.count).toBe(12);
+    expect(typeof result.current.count).toBe("number");
+  });
+
+  it("forwards isLoading from useQuery", () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: true, error: null });
+    const { result } = renderHook(() => useTrickCount());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("surfaces useQuery error", () => {
+    const err = new Error("query failed");
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: err });
+    const { result } = renderHook(() => useTrickCount());
+    expect(result.current.error).toBe(err);
+  });
+
+  it("returns null error when useQuery error is undefined", () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const { result } = renderHook(() => useTrickCount());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("issues a COUNT query against tricks filtered by deleted_at IS NULL", () => {
+    mockUseQuery.mockClear();
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    renderHook(() => useTrickCount());
+
+    const sql = mockUseQuery.mock.calls[0]?.[0] as string;
+    expect(sql).toContain("SELECT COUNT(*)");
+    expect(sql).toContain("FROM tricks");
+    expect(sql).toContain("deleted_at IS NULL");
+  });
+});

--- a/src/features/repertoire/hooks/use-trick-count.ts
+++ b/src/features/repertoire/hooks/use-trick-count.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useQuery } from "@powersync/react";
+
+interface CountRow {
+  count: number;
+}
+
+interface UseTrickCountResult {
+  count: number;
+  error: Error | null;
+  isLoading: boolean;
+}
+
+/**
+ * Returns a reactive count of the user's live (non-soft-deleted) tricks from
+ * local SQLite. Used by the dashboard RepertoireCard so its number stays
+ * consistent with `/repertoire` (both read from PowerSync — offline-first).
+ */
+export function useTrickCount(): UseTrickCountResult {
+  const { data, isLoading, error } = useQuery<CountRow>(
+    "SELECT COUNT(*) AS count FROM tricks WHERE deleted_at IS NULL"
+  );
+
+  // Defensive Number() cast — see use-item-count.ts for rationale (ICU plural
+  // selectors require a number; PowerSync's COUNT return type is not yet
+  // empirically pinned in this codebase).
+  return {
+    count: Number(data[0]?.count ?? 0),
+    isLoading,
+    error: error ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

- **Offline-first counts**: `RepertoireCard` and `CollectionCard` now read counts from local SQLite via new `useTrickCount` / `useItemCount` hooks (PowerSync `useQuery`) instead of server-side Drizzle queries in the dashboard page. Counts are now consistent with `/repertoire` and `/collect`, work offline, and stay reactive as the local DB changes.
- **Error resilience**: hook failure renders an em-dash instead of an indefinite loading skeleton, keeping cards usable as navigation tiles.
- **Card title truncation fix**: outer `div.min-w-0` added to `item-card` and `trick-card` to fix a CSS-grid min-width issue where button-as-flex-item prevented the inner truncation chain from triggering. Titles updated to `line-clamp-2` to match description style.

## Test plan

- [ ] New `use-item-count.ts` + `use-trick-count.ts` hooks covered by dedicated unit tests (count, isLoading, error, string coercion, SQL contents)
- [ ] `CollectionCard` + `RepertoireCard` tests cover loading/error/success states and aria-busy signal
- [ ] Dashboard page tests simplified: card rendering verified, DB-mock tests removed (no longer needed)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test` all pass