### PR TITLE
feat(build): add postbuild secret-scan tripwire (#341)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "predev": "tsx scripts/generate-llms-txt.ts",
     "build": "next build",
     "prebuild": "tsx scripts/generate-llms-txt.ts",
+    "postbuild": "tsx scripts/check-bundle-secrets.ts",
     "start": "next start",
     "lint": "ultracite check",
     "test": "vitest",

--- a/scripts/check-bundle-secrets.test.ts
+++ b/scripts/check-bundle-secrets.test.ts
@@ -1,0 +1,243 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  findSecretMarkers,
+  SERVER_OUTPUT_EXTENSIONS,
+  scanDirectory,
+  VALUE_SHAPE_PATTERNS,
+} from "./check-bundle-secrets";
+
+describe("findSecretMarkers", () => {
+  it("flags a Neon password value", () => {
+    expect(findSecretMarkers("const x = 'npg_abc123XYZ';")).toContain(
+      "neon-password"
+    );
+  });
+
+  it("flags a Postgres URI carrying inline credentials", () => {
+    expect(
+      findSecretMarkers(
+        "postgresql://app_user:p4ssw0rd@db.example.com:5432/app"
+      )
+    ).toContain("postgres-uri-credentials");
+  });
+
+  it("flags a PEM private key block", () => {
+    expect(
+      findSecretMarkers("-----BEGIN RSA PRIVATE KEY-----\nMIIEvQ...")
+    ).toContain("pem-private-key");
+  });
+
+  it("flags the PowerSync admin token env name", () => {
+    expect(findSecretMarkers("process.env.POWERSYNC_ADMIN_TOKEN")).toContain(
+      "powersync-admin-token"
+    );
+  });
+
+  it("flags the database URL env name", () => {
+    expect(findSecretMarkers("const c = process.env.DATABASE_URL;")).toContain(
+      "database-url"
+    );
+  });
+
+  it("flags the internal E2E bucket-health override marker", () => {
+    expect(
+      findSecretMarkers("globalThis.__TEST_FORCE_BUCKET_HEALTH = true;")
+    ).toContain("test-bucket-health-override");
+  });
+
+  it("returns every matching pattern when a string trips more than one", () => {
+    const hits = findSecretMarkers(
+      "postgresql://u:npg_abc123@db.example.com/app"
+    );
+    expect(hits).toContain("neon-password");
+    expect(hits).toContain("postgres-uri-credentials");
+    expect(hits).toHaveLength(2);
+  });
+
+  it("does not match near-misses of each pattern", () => {
+    // `npg` without the underscore the prefix requires.
+    expect(findSecretMarkers("const id = 'npgfoo';")).toEqual([]);
+    // Postgres URI with no inline credentials (no `user:pass@`).
+    expect(findSecretMarkers("postgresql://db.example.com/app")).toEqual([]);
+    // PUBLIC key, not PRIVATE.
+    expect(findSecretMarkers("-----BEGIN PUBLIC KEY-----")).toEqual([]);
+  });
+
+  it("passes clean PowerSync SDK table-name queries", () => {
+    expect(findSecretMarkers('useQuery("SELECT * FROM ps_buckets")')).toEqual(
+      []
+    );
+  });
+
+  it("passes a NEXT_PUBLIC env reference", () => {
+    expect(
+      findSecretMarkers("const u = process.env.NEXT_PUBLIC_POWERSYNC_URL;")
+    ).toEqual([]);
+  });
+});
+
+describe("scanDirectory", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "bundle-secrets-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { force: true, recursive: true });
+  });
+
+  it("reports a planted secret and ignores clean assets", () => {
+    writeFileSync(
+      join(dir, "clean.js"),
+      'useQuery("SELECT * FROM ps_buckets");'
+    );
+    writeFileSync(
+      join(dir, "leak.js"),
+      'const c = "postgresql://u:p4ss@db/app";'
+    );
+
+    const result = scanDirectory(dir);
+
+    expect(result.scannedCount).toBe(2);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]?.file).toContain("leak.js");
+    expect(result.findings[0]?.patterns).toContain("postgres-uri-credentials");
+  });
+
+  it("walks nested chunk directories and counts source maps", () => {
+    mkdirSync(join(dir, "chunks"));
+    writeFileSync(join(dir, "chunks", "a.js"), "export const x = 1;");
+    writeFileSync(join(dir, "chunks", "a.js.map"), '{"version":3}');
+
+    const result = scanDirectory(dir);
+
+    expect(result.scannedCount).toBe(2);
+    expect(result.sourceMapCount).toBe(1);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("ignores non-asset file types", () => {
+    writeFileSync(join(dir, "notes.txt"), "npg_deadbeefcafe");
+
+    const result = scanDirectory(dir);
+
+    expect(result.scannedCount).toBe(0);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("reports a secret planted inside a source map", () => {
+    writeFileSync(
+      join(dir, "app.js.map"),
+      '{"sources":["x"],"sourcesContent":["const c = \'npg_deadbeefcafe\';"]}'
+    );
+
+    const result = scanDirectory(dir);
+
+    expect(result.sourceMapCount).toBe(1);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]?.patterns).toContain("neon-password");
+  });
+
+  it("skips a directory whose name matches an asset extension", () => {
+    // The collectAssetFiles guard must reject non-regular files (a directory
+    // literally named `fake.js`) without throwing on the later read.
+    mkdirSync(join(dir, "fake.js"));
+    writeFileSync(join(dir, "real.js"), "export const x = 1;");
+
+    const result = scanDirectory(dir);
+
+    expect(result.scannedCount).toBe(1);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("returns no findings for an empty directory", () => {
+    expect(scanDirectory(dir).findings).toHaveLength(0);
+  });
+});
+
+describe("scanDirectory — prerendered server output (.html/.rsc)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "bundle-secrets-server-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { force: true, recursive: true });
+  });
+
+  it("flags a secret value rendered into a prerendered page", () => {
+    writeFileSync(
+      join(dir, "landing.html"),
+      "<p>postgresql://u:p4ss@db.example.com/app</p>"
+    );
+
+    const result = scanDirectory(
+      dir,
+      VALUE_SHAPE_PATTERNS,
+      SERVER_OUTPUT_EXTENSIONS
+    );
+
+    expect(result.scannedCount).toBe(1);
+    expect(result.findings[0]?.patterns).toContain("postgres-uri-credentials");
+  });
+
+  it("does not apply env-var NAME patterns to server output", () => {
+    // `DATABASE_URL` legitimately appears in server output; the value-shape
+    // subset must NOT flag it — that exclusion is the point of the subset.
+    writeFileSync(join(dir, "page.rsc"), "process.env.DATABASE_URL");
+
+    const result = scanDirectory(
+      dir,
+      VALUE_SHAPE_PATTERNS,
+      SERVER_OUTPUT_EXTENSIONS
+    );
+
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("ignores server JS — only .html/.rsc/.body are in server scope", () => {
+    writeFileSync(join(dir, "chunk.js"), "const c = 'npg_abc123XYZ';");
+
+    const result = scanDirectory(
+      dir,
+      VALUE_SHAPE_PATTERNS,
+      SERVER_OUTPUT_EXTENSIONS
+    );
+
+    expect(result.scannedCount).toBe(0);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("scans .body response bodies (sitemap/manifest/route handlers)", () => {
+    writeFileSync(
+      join(dir, "sitemap.xml.body"),
+      "<url><loc>postgresql://u:p4ss@db.example.com/app</loc></url>"
+    );
+
+    const result = scanDirectory(
+      dir,
+      VALUE_SHAPE_PATTERNS,
+      SERVER_OUTPUT_EXTENSIONS
+    );
+
+    expect(result.scannedCount).toBe(1);
+    expect(result.findings[0]?.patterns).toContain("postgres-uri-credentials");
+  });
+});
+
+describe("VALUE_SHAPE_PATTERNS composition", () => {
+  it("is exactly the value-shape subset used for server output", () => {
+    // Security-load-bearing invariant: dropping a value pattern here would
+    // silently stop scanning that shape in browser-served prerendered pages.
+    expect(VALUE_SHAPE_PATTERNS.map((p) => p.name)).toEqual([
+      "neon-password",
+      "postgres-uri-credentials",
+      "pem-private-key",
+    ]);
+  });
+});

--- a/scripts/check-bundle-secrets.ts
+++ b/scripts/check-bundle-secrets.ts
@@ -1,0 +1,228 @@
+// Postbuild secret-scan tripwire. RUNS AS THE `postbuild` npm lifecycle hook
+// (package.json), which fires only when the build is invoked via `pnpm build`
+// (pnpm runs pre/post scripts by default). Vercel's `buildCommand` and CI MUST
+// stay `pnpm build` — switching to `next build` directly, or setting
+// `enable-pre-post-scripts=false`, silently disables this scan. (#341)
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+interface SecretPattern {
+  name: string;
+  re: RegExp;
+}
+
+interface SecretFinding {
+  file: string;
+  patterns: string[];
+}
+
+interface ScanResult {
+  findings: SecretFinding[];
+  scannedCount: number;
+  sourceMapCount: number;
+}
+
+// Denylist of known secret-marker SHAPES that must not appear in browser-shipped
+// assets. This is a tripwire, NOT a complete secret detector: a high-entropy or
+// base64 secret with no recognizable prefix would pass. It targets the leak
+// vectors that matter most here — Neon credential values (`npg_`, postgres URIs)
+// and PEM private keys.
+//
+// `DATABASE_URL` / `POWERSYNC_ADMIN_TOKEN` are env-var NAME patterns, not value
+// patterns: those names rarely survive client minification (Next.js dead-code-
+// eliminates server-only `process.env` reads from client bundles), so a match
+// flags a `next.config` `env`/`define` misconfig that inlined the name — a
+// tripwire, not the primary leak path. Validated against a real production build
+// (#341): zero matches on a clean build.
+//
+// Scope: `.next/static/**` (client JS/CSS/maps) is scanned with the FULL
+// denylist. `.next/server/{app,pages}/**/*.{html,rsc,body}` (prerendered pages,
+// RSC flight data, and route-handler response bodies — all served verbatim to
+// browsers) is scanned with the VALUE-shape subset only: env-var NAME patterns
+// (`DATABASE_URL`, `POWERSYNC_ADMIN_TOKEN`) and the override flag legitimately
+// appear in server output and would false-positive there. Server JS
+// (`.next/server/**/*.js`) is NOT scanned for the same reason. See
+// `VALUE_SHAPE_PATTERNS` and the main block below.
+//
+// The JWT-shape pattern `eyJ…\.…\.…` is intentionally NOT included: `@neondatabase/auth`
+// ships client-side JWT handling, so JWT-shaped fixture strings can legitimately appear
+// in vendored chunks. It stays in the manual audit grep (#341 plan, Step 1a) only.
+const SECRET_PATTERNS: readonly SecretPattern[] = [
+  // Neon Postgres password value prefix.
+  { name: "neon-password", re: /npg_[A-Za-z0-9]/ },
+  // Any Postgres connection URI carrying inline credentials.
+  {
+    name: "postgres-uri-credentials",
+    re: /postgres(?:ql)?:\/\/[^"'\s]*:[^"'@\s]+@/,
+  },
+  // PEM private key block.
+  { name: "pem-private-key", re: /-----BEGIN [A-Z ]*PRIVATE KEY-----/ },
+  // Env-var NAME tripwire — flags a build-time inline misconfig, not a live value.
+  { name: "powersync-admin-token", re: /POWERSYNC_ADMIN_TOKEN/ },
+  // Env-var NAME tripwire — flags a build-time inline misconfig, not a live value.
+  { name: "database-url", re: /DATABASE_URL/ },
+  // Known-internal E2E override flag — must tree-shake out of prod (#341 Finding #17).
+  { name: "test-bucket-health-override", re: /__TEST_FORCE_BUCKET_HEALTH/ },
+];
+
+// Value-shape patterns match an actual secret VALUE (not an env-var name or an
+// internal flag), so they are safe to run against server-rendered HTML/RSC where
+// env-var names legitimately appear. Used for the `.next/server/{app,pages}` scan.
+const VALUE_SHAPE_PATTERN_NAMES = new Set([
+  "neon-password",
+  "postgres-uri-credentials",
+  "pem-private-key",
+]);
+const VALUE_SHAPE_PATTERNS: readonly SecretPattern[] = SECRET_PATTERNS.filter(
+  (p) => VALUE_SHAPE_PATTERN_NAMES.has(p.name)
+);
+
+// Client bundles under `.next/static`.
+const SCANNED_EXTENSIONS = /\.(?:js|css|map)$/;
+// Browser-served output under `.next/server/{app,pages}`: prerendered HTML, RSC
+// flight data, and `.body` response bodies (sitemap, manifest, error pages).
+const SERVER_OUTPUT_EXTENSIONS = /\.(?:html|rsc|body)$/;
+
+/**
+ * Returns the names of every secret-marker pattern that matches `content`.
+ * Pure and side-effect-free so the denylist can be unit-tested without a build.
+ */
+export function findSecretMarkers(
+  content: string,
+  patterns: readonly SecretPattern[] = SECRET_PATTERNS
+): string[] {
+  const hits: string[] = [];
+  for (const { name, re } of patterns) {
+    if (re.test(content)) {
+      hits.push(name);
+    }
+  }
+  return hits;
+}
+
+function collectAssetFiles(dir: string, extensions: RegExp): string[] {
+  // `withFileTypes` lets us filter on `Dirent.isFile()` without a follow-up
+  // `statSync` per entry. `isFile()` does NOT follow symlinks, so a broken or
+  // looping symlink whose name matches `extensions` is skipped rather than
+  // throwing — and it drops one syscall per asset.
+  const entries = readdirSync(dir, { recursive: true, withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (!(entry.isFile() && extensions.test(entry.name))) {
+      continue;
+    }
+    files.push(join(entry.parentPath, entry.name));
+  }
+  return files;
+}
+
+/**
+ * Walks `dir` recursively and scans every matching asset for the given secret
+ * patterns. Returns findings plus counts. Free of process state (no exit, no
+ * console) so it is unit-testable against a temp fixture directory.
+ */
+export function scanDirectory(
+  dir: string,
+  patterns: readonly SecretPattern[] = SECRET_PATTERNS,
+  extensions: RegExp = SCANNED_EXTENSIONS
+): ScanResult {
+  const files = collectAssetFiles(dir, extensions);
+  const findings: SecretFinding[] = [];
+  let sourceMapCount = 0;
+  for (const file of files) {
+    if (file.endsWith(".map")) {
+      sourceMapCount++;
+    }
+    const matched = findSecretMarkers(readFileSync(file, "utf8"), patterns);
+    if (matched.length > 0) {
+      findings.push({ file, patterns: matched });
+    }
+  }
+  return { findings, scannedCount: files.length, sourceMapCount };
+}
+
+// Scans `dir` if it exists, else returns an empty result — so an absent
+// `.next/server/{app,pages}` subtree is a no-op rather than a throw.
+function scanIfExists(
+  dir: string,
+  patterns: readonly SecretPattern[],
+  extensions: RegExp
+): ScanResult {
+  return existsSync(dir)
+    ? scanDirectory(dir, patterns, extensions)
+    : { findings: [], scannedCount: 0, sourceMapCount: 0 };
+}
+
+export type { ScanResult, SecretFinding, SecretPattern };
+export { SECRET_PATTERNS, SERVER_OUTPUT_EXTENSIONS, VALUE_SHAPE_PATTERNS };
+
+const isMainModule =
+  process.argv[1]?.endsWith("check-bundle-secrets.ts") ?? false;
+
+if (isMainModule) {
+  const nextDir = resolve(import.meta.dirname, "../.next");
+  const staticDir = join(nextDir, "static");
+  const serverAppDir = join(nextDir, "server", "app");
+  const serverPagesDir = join(nextDir, "server", "pages");
+
+  if (existsSync(nextDir) && !existsSync(staticDir)) {
+    // A build exists but emitted no client assets — a misconfiguration (custom
+    // distDir, relocated output). Fail closed: this is exactly the case the
+    // tripwire must surface loudly rather than silently pass. The lenient skip
+    // below only applies when there is no build at all (`.next` absent).
+    console.error(
+      "[check-bundle-secrets] FAIL — .next exists but .next/static is missing; the build produced no client assets to scan."
+    );
+    process.exitCode = 1;
+  } else if (existsSync(staticDir)) {
+    // Client bundles get the FULL denylist. Prerendered server output (also
+    // browser-served) gets the value-shape subset so server-side env-var NAMES
+    // don't false-positive.
+    const staticResult = scanDirectory(staticDir);
+    const results = [
+      staticResult,
+      scanIfExists(
+        serverAppDir,
+        VALUE_SHAPE_PATTERNS,
+        SERVER_OUTPUT_EXTENSIONS
+      ),
+      scanIfExists(
+        serverPagesDir,
+        VALUE_SHAPE_PATTERNS,
+        SERVER_OUTPUT_EXTENSIONS
+      ),
+    ];
+
+    const findings = results.flatMap((r) => r.findings);
+    const scannedCount = results.reduce((n, r) => n + r.scannedCount, 0);
+
+    // Client source maps in `.next/static` expand the exposure surface (original
+    // source becomes fetchable). Surface their presence; their contents are scanned too.
+    if (staticResult.sourceMapCount > 0) {
+      console.warn(
+        `[check-bundle-secrets] NOTE: ${staticResult.sourceMapCount} client source map(s) present in .next/static — these expand the exposure surface (consider productionBrowserSourceMaps: false). Scanning their contents too.`
+      );
+    }
+
+    if (findings.length > 0) {
+      console.error(
+        "[check-bundle-secrets] FAIL — secret markers found in browser-shipped assets:"
+      );
+      for (const { file, patterns } of findings) {
+        console.error(`  ${file} → ${patterns.join(", ")}`);
+      }
+      // Set `process.exitCode` rather than calling `process.exit(1)`: the latter
+      // can truncate the per-file detail lines above when stderr is a pipe (the
+      // normal case in CI), leaving a failed build with no leak diagnostics.
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `[check-bundle-secrets] OK — scanned ${scannedCount} asset(s) under .next/static + .next/server/{app,pages}, no secret markers.`
+      );
+    }
+  } else {
+    console.log(
+      "[check-bundle-secrets] .next/static not found — skipping (no build present)."
+    );
+  }
+}

--- a/src/app/(app)/dev/sync-status/page.tsx
+++ b/src/app/(app)/dev/sync-status/page.tsx
@@ -16,6 +16,16 @@ export const dynamic = "force-dynamic";
 // which are either public or trivially derivable). If you want to verify
 // nothing sensitive leaks, grep `.next/static/chunks/` after `pnpm build`
 // for the strings you're concerned about.
+//
+// Verified 2026-05-28 (commit 8af1e82): `pnpm build` emits this chunk to
+// `.next/static/chunks/` as expected; a secret-marker grep of `.next/static/`
+// is clean (only non-secret PowerSync SDK table names + display-only JWT decode
+// ship), `__TEST_FORCE_BUCKET_HEALTH` is tree-shaken out, and `force-dynamic`
+// (above) means no prerendered HTML for this route. The
+// `scripts/check-bundle-secrets.ts` postbuild guard scans browser-shipped build
+// output (`.next/static/` + prerendered `.next/server/`) for known
+// secret-marker shapes on every build (a tripwire, not a complete secret
+// detector). (#341)
 export default async function SyncStatusDebugPage(): Promise<ReactElement> {
   // Defense-in-depth: 404 on both axes. `NODE_ENV === "production"` in every
   // Vercel build (prod AND preview), and `VERCEL_ENV` is set on every Vercel


### PR DESCRIPTION
## Summary

- Adds `scripts/check-bundle-secrets.ts` as a `postbuild` npm lifecycle hook (fires automatically via `pnpm build` — Vercel `buildCommand` and CI both invoke it this way)
- Scans all browser-shipped build output for known secret-marker shapes: client bundles (`.next/static/**`) with the full denylist, and prerendered server output (`.next/server/{app,pages}/**/*.{html,rsc,body}`) with a value-shape subset so server-side env-var names don't false-positive
- Fails the build on any match; fail-closes if `.next` exists but `.next/static` is missing (misconfigured distDir); silently passes when no build is present (standalone/test invocation)
- Adds `"postbuild"` script to `package.json`
- Updates the comment in `src/app/(app)/dev/sync-status/page.tsx` to accurately reference the tripwire scope

## What's scanned

| Surface | Extensions | Patterns |
|---|---|---|
| `.next/static/**` | `.js .css .map` | Full denylist (6 patterns) |
| `.next/server/app/**` | `.html .rsc .body` | Value-shapes only (3 patterns) |
| `.next/server/pages/**` | `.html .rsc .body` | Value-shapes only (3 patterns) |

Verified against a real production build: **285 assets scanned clean** (69 static + 215 server/app + 1 server/pages).

## Test plan

- [x] 21 unit tests: all 6 denylist patterns (positive + near-miss), `VALUE_SHAPE_PATTERNS` composition invariant, `.map`/`.body`/`.rsc` extension scoping, directory-vs-file guard, server-output subset correctness (`DATABASE_URL` excluded, `.body` included)
- [x] `pnpm build` passes end-to-end with postbuild scan running (exit 0, 285 assets)
- [x] `pnpm lint`, `pnpm typecheck` pass
- [x] Verified `__TEST_FORCE_BUCKET_HEALTH` is tree-shaken out of production output (the scan would catch it if it weren't)